### PR TITLE
fix: change background color of enabled Switch from gray to indigo

### DIFF
--- a/packages/nextjs/src/components/Switch/styles.ts
+++ b/packages/nextjs/src/components/Switch/styles.ts
@@ -26,7 +26,7 @@ const switchRoot = css({
 const switchRootOn = css([
   switchRoot,
   {
-    backgroundColor: slate.slate9,
+    backgroundColor: indigo.indigo9,
   },
 ]);
 


### PR DESCRIPTION
Since if the enabled Switch is gray, it could be mistaken for disabled.

Before:
<img width="372" alt="Screen Shot 2023-02-03 at 10 29 24 AM" src="https://user-images.githubusercontent.com/2220186/216680146-59067d4e-f300-4bf3-af57-bec9f91f299f.png">

After:
<img width="380" alt="Screen Shot 2023-02-03 at 10 28 49 AM" src="https://user-images.githubusercontent.com/2220186/216680154-118c52fe-c00c-4740-ba9a-4e40d64f4ead.png">
