### PR TITLE
fix: fix switch on color

### DIFF
--- a/packages/nextjs/src/components/Switch/styles.ts
+++ b/packages/nextjs/src/components/Switch/styles.ts
@@ -26,7 +26,7 @@ const switchRoot = css({
 const switchRootOn = css([
   switchRoot,
   {
-    backgroundColor: slate.slate9,
+    backgroundColor: indigo.indigo9,
   },
 ]);
 


### PR DESCRIPTION
I accidentally used `slate9` instead of `indigo9` when I refactored the CSS.

![Screenshot 2023-02-03 at 11 22 29 AM](https://user-images.githubusercontent.com/1498449/216689548-e3f948e4-4cb3-44c5-9032-7ae1ff75e476.png)
