### PR TITLE
fix(api): make docker images smaller

### DIFF
--- a/.yarnrc.build.yml
+++ b/.yarnrc.build.yml
@@ -1,0 +1,15 @@
+nmHoistingLimits: workspaces
+
+nodeLinker: node-modules
+
+npmPublishAccess: public
+
+plugins:
+  - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
+    spec: '@yarnpkg/plugin-typescript'
+  - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
+    spec: '@yarnpkg/plugin-workspace-tools'
+  - path: .yarn/plugins/@yarnpkg/plugin-version.cjs
+    spec: '@yarnpkg/plugin-version'
+
+yarnPath: .yarn/releases/yarn-3.3.1.cjs

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 # First install dependencies (as they change less often)
 COPY .gitignore .gitignore
-COPY .yarnrc.yml .yarnrc.yml
+COPY .yarnrc.build.yml .yarnrc.yml
 COPY .yarn .yarn
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/yarn.lock ./yarn.lock

--- a/apps/sample-app/Dockerfile
+++ b/apps/sample-app/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 # First install the dependencies (as they change less often)
 COPY .gitignore .gitignore
-COPY .yarnrc.yml .yarnrc.yml
+COPY .yarnrc.build.yml .yarnrc.yml
 COPY .yarn .yarn
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/yarn.lock ./yarn.lock

--- a/turbo.json
+++ b/turbo.json
@@ -35,5 +35,12 @@
       "cache": false
     }
   },
-  "globalDependencies": ["**/.env", "**/.env.*local", "tsconfig.json", ".eslintrc.json", ".yarnrc.yml"]
+  "globalDependencies": [
+    "**/.env",
+    "**/.env.*local",
+    "tsconfig.json",
+    ".eslintrc.json",
+    ".yarnrc.yml",
+    ".yarnrc.build.yml"
+  ]
 }


### PR DESCRIPTION
Don't install `@swc/core` for all architectures as part of the image build process