### PR TITLE
feat: add SalesforceDisconnectButton component

### DIFF
--- a/apps/api/routes/integration.ts
+++ b/apps/api/routes/integration.ts
@@ -1,9 +1,10 @@
 import { Request, Response, Router } from 'express';
+import jsforce from 'jsforce';
 import { getDependencyContainer } from '../dependency_container';
 import { IntegrationCreateParams, SafeIntegration } from '../integrations/entities';
 import { errorMiddleware as posthogErrorMiddleware, middleware as posthogMiddleware } from '../lib/posthog';
 
-const { integrationService } = getDependencyContainer();
+const { integrationService, developerConfigService } = getDependencyContainer();
 
 const router: Router = Router({ mergeParams: true });
 
@@ -40,6 +41,31 @@ router.post(
     return res.status(200).send(integration);
   },
   posthogErrorMiddleware('Create Integration')
+);
+
+router.delete(
+  '/:integrationId',
+  posthogMiddleware('Delete Integration'),
+  async (req: Request<{ integrationId: string }>, res: Response<Record<string, never>>) => {
+    const integration = await integrationService.getById(req.params.integrationId, /* unsafe */ true);
+    const { refreshToken } = integration.credentials;
+    const developerConfig = await developerConfigService.getDeveloperConfig();
+
+    // Log out of Salesforce first
+    const oauth2 = new jsforce.OAuth2({
+      ...developerConfig.getSalesforceCredentials(),
+      redirectUri: `${process.env.SUPAGLUE_API_SERVER_URL}/oauth/callback`,
+    });
+    const connection = new jsforce.Connection({ oauth2, loginUrl: oauth2.loginUrl, refreshToken });
+    // TODO: Handle case when user is already logged-out
+    await connection.logoutByOAuth2(true);
+
+    // Then delete the integration and all associated syncs
+    await integrationService.delete(req.params.integrationId);
+
+    return res.status(204);
+  },
+  posthogErrorMiddleware('Delete Integration')
 );
 
 export default router;

--- a/apps/api/routes/oauth.ts
+++ b/apps/api/routes/oauth.ts
@@ -19,7 +19,8 @@ router.get('/salesforce', async (req: Request<never, any, never, { state: string
     state,
   });
 
-  res.redirect(redirectUrl);
+  // Always prompt the user to enter their username and password when connecting
+  res.redirect(`${redirectUrl}&prompt=login`);
 });
 
 router.get('/callback', async (req: Request<never, any, never, { code: string; state: string }>, res: Response) => {

--- a/packages/nextjs/src/components/Button/styles.ts
+++ b/packages/nextjs/src/components/Button/styles.ts
@@ -1,27 +1,44 @@
 import { css } from '@emotion/react';
-import { indigo, slate } from '@radix-ui/colors';
+import { indigo, red, slate } from '@radix-ui/colors';
 
-export default {
-  button: css({
-    alignItems: 'center',
-    borderRadius: '0.5rem',
-    color: 'white',
-    display: 'flex',
-    fontSize: '0.875rem',
-    fontWeight: '500',
-    lineHeight: '1.25rem',
-    justifyContent: 'center',
-    padding: '0.5rem 0.75rem',
-    width: 'fit-content',
-    backgroundColor: indigo.indigo9,
-    ':hover': {
-      backgroundColor: indigo.indigo10,
-    },
-    ':focus-visible': {
-      boxShadow: indigo.indigo12,
-    },
-    ':disabled': {
-      backgroundColor: slate.slate8,
-    },
-  }),
+const disabledStyles = {
+  backgroundColor: slate.slate8,
+  color: slate.slate1,
+  cursor: 'auto',
 };
+
+const button = css({
+  alignItems: 'center',
+  borderRadius: '0.5rem',
+  color: 'white',
+  display: 'flex',
+  fontSize: '0.875rem',
+  fontWeight: '500',
+  lineHeight: '1.25rem',
+  justifyContent: 'center',
+  padding: '0.5rem 0.75rem',
+  width: 'fit-content',
+  backgroundColor: indigo.indigo9,
+  ':hover': {
+    backgroundColor: indigo.indigo10,
+  },
+  ':focus-visible': {
+    boxShadow: indigo.indigo12,
+  },
+  ':disabled': disabledStyles,
+  ':disabled:hover': disabledStyles,
+});
+
+const destructiveButton = css(button, {
+  backgroundColor: red.red9,
+  ':hover': {
+    backgroundColor: red.red10,
+  },
+});
+
+const styles = {
+  button,
+  destructiveButton,
+};
+
+export default styles;

--- a/packages/nextjs/src/components/FieldMapping/styles.ts
+++ b/packages/nextjs/src/components/FieldMapping/styles.ts
@@ -47,7 +47,7 @@ const fieldDropdown = css({
   width: '50%',
 });
 
-export default {
+const styles = {
   emptyContentReason,
   form,
   formHeaderRow,
@@ -56,3 +56,5 @@ export default {
   fieldName,
   fieldDropdown,
 };
+
+export default styles;

--- a/packages/nextjs/src/components/IntegrationCard/IntegrationCard.tsx
+++ b/packages/nextjs/src/components/IntegrationCard/IntegrationCard.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import classNames from 'classnames';
-import { useDeveloperConfig } from '../../hooks/api';
-import { SupaglueProviderInternal } from '../../providers';
+import { SalesforceConnectButton, SalesforceDisconnectButton } from '..';
+import { useDeveloperConfig, useSalesforceIntegration } from '../../hooks/api';
+import { SupaglueProviderInternal, useSupaglueContext } from '../../providers';
 import { SupaglueAppearance } from '../../types';
-import { SalesforceConnectButton } from '../SalesforceConnectButton';
 import styles from './styles';
 
 export type IntegrationCardProps = {
@@ -22,9 +22,16 @@ export type IntegrationCardProps = {
 };
 
 const IntegrationCardInternal = ({ name, description, configurationUrl, appearance }: IntegrationCardProps) => {
+  const { customerId } = useSupaglueContext();
   const { data: developerConfig } = useDeveloperConfig();
+  const { data: integration, error } = useSalesforceIntegration(customerId);
+  const integrationConnected = integration && error?.response?.status !== 404;
 
-  return developerConfig ? (
+  if (!developerConfig) {
+    return <span>No developer config found</span>;
+  }
+
+  return (
     <li>
       <div css={styles.card} className={classNames(appearance?.elements?.card, 'sg-integrationCard')}>
         <span css={styles.name} className={classNames(appearance?.elements?.name, 'sg-integrationCard-name')}>
@@ -36,11 +43,12 @@ const IntegrationCardInternal = ({ name, description, configurationUrl, appearan
         >
           {description}
         </span>
-        <SalesforceConnectButton configurationUrl={configurationUrl} appearance={appearance} />
+        <div css={styles.buttonWrapper}>
+          {integrationConnected ? <SalesforceDisconnectButton integration={integration} /> : null}
+          <SalesforceConnectButton configurationUrl={configurationUrl} appearance={appearance} />
+        </div>
       </div>
     </li>
-  ) : (
-    <span>No developer config found</span>
   );
 };
 

--- a/packages/nextjs/src/components/IntegrationCard/styles.ts
+++ b/packages/nextjs/src/components/IntegrationCard/styles.ts
@@ -23,8 +23,17 @@ const description = css({
   textAlign: 'center',
 });
 
-export default {
+const buttonWrapper = css({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: '1rem',
+});
+
+const styles = {
   card,
   name,
+  buttonWrapper,
   description,
 };
+
+export default styles;

--- a/packages/nextjs/src/components/SalesforceConnectButton/SalesforceConnectButton.tsx
+++ b/packages/nextjs/src/components/SalesforceConnectButton/SalesforceConnectButton.tsx
@@ -43,7 +43,7 @@ const SalesforceConnectButtonInternal = (props: SalesforceConnectButtonProps) =>
 
   return (
     <Button
-      css={[styles.button, { width: '8rem' }]}
+      css={styles.button}
       className={classNames('sg-salesforceConnectButton', props.appearance?.elements?.button)}
       onClick={onClick}
     >

--- a/packages/nextjs/src/components/SalesforceDisconnectButton/SalesforceDisconnectButton.tsx
+++ b/packages/nextjs/src/components/SalesforceDisconnectButton/SalesforceDisconnectButton.tsx
@@ -1,0 +1,68 @@
+/** @jsxImportSource @emotion/react */
+import axios from 'axios';
+import classNames from 'classnames';
+import { HTMLAttributes, useState } from 'react';
+import useSWRMutation from 'swr/mutation';
+import { SupaglueProviderInternal, useSupaglueContext } from '../../providers';
+import { SupaglueAppearance } from '../../types';
+import { Button } from '../Button';
+import styles from '../Button/styles';
+
+async function deleteIntegration(url: string) {
+  try {
+    return await axios({ url, method: 'DELETE' });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Error deleting integration:', err);
+  }
+}
+
+export type SalesforceDisconnectButtonProps = {
+  appearance?: SupaglueAppearance & {
+    elements?: {
+      button?: string;
+    };
+  };
+  integration: { id: string };
+} & HTMLAttributes<HTMLButtonElement>;
+
+const SalesforceDisconnectButtonInternal = (props: SalesforceDisconnectButtonProps) => {
+  const { children, integration } = props;
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const { apiUrl } = useSupaglueContext();
+
+  const { trigger: callDeleteIntegration } = useSWRMutation(
+    `${apiUrl}/integrations/${integration.id}/`,
+    deleteIntegration
+  );
+
+  const onClick = async () => {
+    setIsDisconnecting(true);
+
+    // TODO: Optimistic update, since deleting Temporal schedules can take a while
+    await callDeleteIntegration();
+
+    setIsDisconnecting(false);
+  };
+
+  if (children) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Button
+      css={[styles.destructiveButton]}
+      className={classNames('sg-salesforceDisconnectButton', props.appearance?.elements?.button)}
+      disabled={isDisconnecting}
+      onClick={onClick}
+    >
+      Disconnect
+    </Button>
+  );
+};
+
+export const SalesforceDisconnectButton = (props: SalesforceDisconnectButtonProps) => (
+  <SupaglueProviderInternal>
+    <SalesforceDisconnectButtonInternal {...props} />
+  </SupaglueProviderInternal>
+);

--- a/packages/nextjs/src/components/SalesforceDisconnectButton/index.ts
+++ b/packages/nextjs/src/components/SalesforceDisconnectButton/index.ts
@@ -1,0 +1,1 @@
+export * from './SalesforceDisconnectButton';

--- a/packages/nextjs/src/components/Select/styles.ts
+++ b/packages/nextjs/src/components/Select/styles.ts
@@ -19,6 +19,11 @@ const selectTrigger = css(buttonStyles.button, {
   },
   ':disabled': {
     backgroundColor: slate.slate3,
+    color: slate.slate11,
+  },
+  ':disabled:hover': {
+    backgroundColor: slate.slate3,
+    color: slate.slate11,
   },
   ':disabled svg': {
     opacity: 0,
@@ -60,10 +65,12 @@ const selectLoading = css({
   fontSize: '14px',
 });
 
-export default {
+const styles = {
   selectTrigger,
   selectContent,
   selectItem,
   selectViewport,
   selectLoading,
 };
+
+export default styles;

--- a/packages/nextjs/src/components/index.ts
+++ b/packages/nextjs/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from './FieldMapping';
 export * from './IntegrationCard';
 export * from './SalesforceConnectButton';
+export * from './SalesforceDisconnectButton';
 export * from './Select';
 export * from './Switch';
 export * from './TriggerSyncButton';


### PR DESCRIPTION
Adds a button to disconnect a Salesforce account and delete the end user's integration.

<img width="313" alt="Screenshot 2023-02-06 at 12 04 33 PM" src="https://user-images.githubusercontent.com/2220186/217075020-9606516a-22b0-479f-a577-d9ef4716489c.png">

TO DO (later):
- Right now, clicking "Disconnect" both logs the user out and deletes the SFDC integration. In the future, we might allow users to keep the integration but disconnect in order to switch the Salesforce account they use to authenticate
- Currently the `DELETE /integrations/:id` endpoint takes a _long_ time and gives no feedback to the user - we should add a button loading state and consider offloading the Temporal schedule deletions to an async task
- ~See if there's an alternative to appending `prompt=login` to the SFDC authz url.~ (Currently, without it, a user gets automatically logged in after clicking "Disconnect" and then "Connect" again. @lucasmarshall do you know why this might be? Something to do with Salesforce session policies maybe?)