### PR TITLE
feat!: inbound sync types

### DIFF
--- a/apps/api/developer_config/services/developer_config_service.ts
+++ b/apps/api/developer_config/services/developer_config_service.ts
@@ -77,6 +77,7 @@ export class DeveloperConfigService {
             // TODO: Make this idempotent in case developer config needs to be updated again
             this.#syncService.createSync(
               {
+                type: 'inbound',
                 syncConfigName,
                 customerId,
                 enabled: false,

--- a/apps/api/integrations/services/integration_service.ts
+++ b/apps/api/integrations/services/integration_service.ts
@@ -79,6 +79,7 @@ export class IntegrationService {
         developerConfig.getSyncConfigs().map((syncConfig) =>
           this.#syncService.createSync(
             {
+              type: 'inbound',
               customerId,
               syncConfigName: syncConfig.name,
               enabled: false,

--- a/apps/api/prisma/migrations/20230207213130_sync_type/migration.sql
+++ b/apps/api/prisma/migrations/20230207213130_sync_type/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `type` to the `syncs` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "syncs" ADD COLUMN     "type" TEXT NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -34,6 +34,7 @@ model DeveloperConfig {
 model Sync {
   id                                String    @id @default(uuid())
   customerId                        String    @map("customer_id")
+  type                              String
   enabled                           Boolean
   syncConfigName                    String    @map("sync_config_name")
   fieldMapping                      Json?     @map("field_mapping")

--- a/apps/api/syncs/entities/sync.ts
+++ b/apps/api/syncs/entities/sync.ts
@@ -1,16 +1,32 @@
-export type Sync = {
-  id: string;
-  customerId: string;
+type BaseSyncUpdateParams = {
+  // TODO: Consider moving `enabled` elsewhere when/if we allow syncs to be triggered.
   enabled: boolean;
   syncConfigName: string;
   fieldMapping?: Record<string, string>;
+
+  // TODO: We need to define another level of abstraction later if we want to do
+  // triggered syncs and not just syncs periodically run on a schedule.
   salesforceAPIUsageLimitPercentage?: number; // e.g. 0.8
 };
 
-export type SyncCreateParams = Omit<Sync, 'id'>;
-
-export type SyncUpdateParams = {
-  enabled?: boolean;
-  fieldMapping?: Record<string, string>;
-  salesforceAPIUsageLimitPercentage?: number; // e.g. 0.8
+type BaseSyncCreateParams = BaseSyncUpdateParams & {
+  customerId: string;
 };
+
+type BaseSync = BaseSyncCreateParams & {
+  id: string;
+};
+
+type InboundSyncCore = { type: 'inbound' };
+export type InboundSyncUpdateParams = BaseSyncUpdateParams & InboundSyncCore;
+export type InboundSyncCreateParams = BaseSyncCreateParams & InboundSyncCore;
+export type InboundSync = BaseSync & InboundSyncCore;
+
+type OutboundSyncCore = { type: 'outbound' };
+export type OutboundSyncUpdateParams = BaseSyncUpdateParams & OutboundSyncCore;
+export type OutboundSyncCreateParams = BaseSyncCreateParams & OutboundSyncCore;
+export type OutboundSync = BaseSync & OutboundSyncCore;
+
+export type SyncUpdateParams = InboundSyncUpdateParams | OutboundSyncUpdateParams;
+export type SyncCreateParams = InboundSyncCreateParams | OutboundSyncCreateParams;
+export type Sync = InboundSync | OutboundSync;


### PR DESCRIPTION
This change involves adding a non-nullable column `type` to `syncs` table. If you already have `syncs`, you may want to truncate your `syncs` table before applying this migration. Alternatively, reset your environment with `docker compose down -v`.