### PR TITLE
chore: move toast to TriggerSyncButton component

### DIFF
--- a/apps/sample-app/pages/integrations/[type].tsx
+++ b/apps/sample-app/pages/integrations/[type].tsx
@@ -77,7 +77,7 @@ const SyncConfiguration = () => {
       <PageTabs className="" tabs={pageTabs} disabled={false} />
       <>
         <div className="flex flex-col gap-4">
-          <div className="relative pt-3 px-3">
+          <div className="pt-3 px-3">
             <TriggerSyncButton syncConfigName={syncConfigName} />
           </div>
 

--- a/apps/sample-app/pages/integrations/[type].tsx
+++ b/apps/sample-app/pages/integrations/[type].tsx
@@ -2,7 +2,7 @@ import { FieldMapping, TriggerSyncButton, useSupaglueContext } from '@supaglue/n
 import { useDeveloperConfig, useSalesforceIntegration } from '@supaglue/nextjs/src/hooks/api';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { PageTabs } from '../../components/PageTabs';
 import { useActiveTab } from '../../hooks';
 // TUTORIAL: Uncomment this
@@ -61,30 +61,6 @@ const pageTabs = ['Contacts', 'Leads', 'Accounts', 'Opportunities'];
 const SyncConfiguration = () => {
   const syncConfigName = useActiveTab(pageTabs[0]);
 
-  const [timeoutId, setTimeoutId] = useState<number | undefined>();
-  const [toastMessage, setToastMessage] = useState<string | undefined>();
-
-  const showToast = (message: string) => {
-    if (timeoutId) {
-      window.clearTimeout(timeoutId);
-    }
-    setToastMessage(message);
-    setTimeoutId(
-      window.setTimeout(() => {
-        setTimeoutId(undefined);
-      }, 2000)
-    );
-  };
-
-  useEffect(() => {
-    return () => {
-      if (timeoutId) {
-        window.clearTimeout(timeoutId);
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const getSwitch = (syncConfigName: string) => {
     // TUTORIAL: uncomment this
@@ -102,16 +78,7 @@ const SyncConfiguration = () => {
       <>
         <div className="flex flex-col gap-4">
           <div className="relative pt-3 px-3">
-            <TriggerSyncButton
-              syncConfigName={syncConfigName}
-              onSuccess={() => showToast('Successfully started sync!')}
-              onError={() => showToast('Error encountered.')}
-            />
-            {timeoutId && (
-              <span className="absolute z-10 top-0 left-36 mt-5 block rounded bg-gray-600 py-1 px-2 text-xs text-white">
-                {toastMessage}
-              </span>
-            )}
+            <TriggerSyncButton syncConfigName={syncConfigName} />
           </div>
 
           <div>{getSwitch(syncConfigName)}</div>

--- a/packages/nextjs/src/components/TriggerSyncButton/styles.ts
+++ b/packages/nextjs/src/components/TriggerSyncButton/styles.ts
@@ -1,0 +1,25 @@
+import { css } from '@emotion/react';
+import { slate } from '@radix-ui/colors';
+import { _applyTheme } from '../../style/internal';
+import { SgTheme } from '../../style/types/theme';
+
+const toast = _applyTheme((theme: SgTheme) =>
+  css({
+    position: 'absolute',
+    zIndex: 10,
+    color: 'white',
+    backgroundColor: slate.slate11,
+    padding: '0.25rem 0.5rem',
+    display: 'block',
+    left: '9rem',
+    top: '0.375rem',
+    borderRadius: '0.25rem',
+    fontSize: '0.75rem',
+    lineHeight: '1rem',
+    ...theme.elementOverrides?.toast,
+  })
+);
+
+export default {
+  toast,
+};


### PR DESCRIPTION
Right now the toast logic is written inside the sample app.

This is step 1 of moving the entire config setting into nextjs package.

We should consider making the toast a primitive, but it's tricky because it depends on its parent container. We should probably have a `NotificationProvider` that manages all of these, but punting for now.