### PR TITLE
chore: clean up common types for SDK

### DIFF
--- a/apps/sample-app/supaglue-config/inbound/contact.ts
+++ b/apps/sample-app/supaglue-config/inbound/contact.ts
@@ -30,7 +30,7 @@ const contactSchema = sdk.schema({
 const contactSyncConfig = sdk.syncConfigs.inbound({
   name: 'Contacts',
   source: sdk.customer.sources.salesforce({
-    objectConfig: sdk.customer.specifiedSalesforceObjectConfig('Contact'),
+    objectConfig: sdk.customer.common.salesforce.specifiedObjectConfig('Contact'),
   }),
   cronExpression: '*/15 * * * *',
   destination: sdk.internal.destinations.postgres({

--- a/apps/sample-app/supaglue-config/inbound/lead.ts
+++ b/apps/sample-app/supaglue-config/inbound/lead.ts
@@ -32,7 +32,7 @@ const leadMapping = sdk.defaultFieldMapping([
 const leadSyncConfig = sdk.syncConfigs.inbound({
   name: 'Leads',
   source: sdk.customer.sources.salesforce({
-    objectConfig: sdk.customer.specifiedSalesforceObjectConfig('Lead'),
+    objectConfig: sdk.customer.common.salesforce.specifiedObjectConfig('Lead'),
   }),
   cronExpression: '*/15 * * * *',
   destination: sdk.internal.destinations.postgres({

--- a/apps/sample-app/supaglue-config/inbound/opportunity.ts
+++ b/apps/sample-app/supaglue-config/inbound/opportunity.ts
@@ -34,7 +34,7 @@ const opportunityMapping = sdk.defaultFieldMapping([
 const opportunitySyncConfig = sdk.syncConfigs.inbound({
   name: 'Opportunities',
   source: sdk.customer.sources.salesforce({
-    objectConfig: sdk.customer.specifiedSalesforceObjectConfig('Opportunity'),
+    objectConfig: sdk.customer.common.salesforce.specifiedObjectConfig('Opportunity'),
   }),
   cronExpression: '*/15 * * * *',
   destination: sdk.internal.destinations.webhook({

--- a/apps/sample-app/supaglue-config/outbound/contact.ts
+++ b/apps/sample-app/supaglue-config/outbound/contact.ts
@@ -30,7 +30,7 @@ const contactSchema = sdk.schema({
 const contactSyncConfig = sdk.syncConfigs.outbound({
   name: 'ContactsOutbound',
   destination: sdk.customer.destinations.salesforce({
-    objectConfig: sdk.customer.specifiedSalesforceObjectConfig('Contact'),
+    objectConfig: sdk.customer.common.salesforce.specifiedObjectConfig('Contact'),
     upsertKey: 'salesforce_id',
   }),
   cronExpression: '*/15 * * * *',

--- a/apps/sample-app/supaglue-config/postgres_credentials.ts
+++ b/apps/sample-app/supaglue-config/postgres_credentials.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv';
 
 dotenv.config({ path: `${__dirname}/../.env` });
 
-const credentials = sdk.internal.postgresCredentials({
+const credentials = sdk.internal.common.postgres.credentials({
   host: 'postgres',
   port: 5432,
   database: 'sample_app',

--- a/apps/sample-app/supaglue-config/salesforce_credentials.ts
+++ b/apps/sample-app/supaglue-config/salesforce_credentials.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv';
 
 dotenv.config({ path: `${__dirname}/../.env` });
 
-const credentials = sdk.customer.salesforceCredentials({
+const credentials = sdk.customer.common.salesforce.credentials({
   loginUrl: process.env.SALESFORCE_URL ?? '',
   clientId: process.env.SALESFORCE_KEY ?? '',
   clientSecret: process.env.SALESFORCE_SECRET ?? '',

--- a/packages/sdk/src/customer/base/salesforce.ts
+++ b/packages/sdk/src/customer/base/salesforce.ts
@@ -1,4 +1,4 @@
-import { SalesforceObjectConfig } from '../common';
+import { SalesforceObjectConfig } from '../common/salesforce';
 import { BaseCustomerIntegration } from './base';
 
 export type SalesforceCustomerIntegration = BaseCustomerIntegration & {

--- a/packages/sdk/src/customer/common/index.ts
+++ b/packages/sdk/src/customer/common/index.ts
@@ -1,1 +1,1 @@
-export * from './salesforce';
+export * as salesforce from './salesforce';

--- a/packages/sdk/src/customer/common/salesforce.ts
+++ b/packages/sdk/src/customer/common/salesforce.ts
@@ -12,14 +12,14 @@ type SelectableSalesforceObjectConfig = {
 
 export type SalesforceObjectConfig = SpecifiedSalesforceObjectConfig | SelectableSalesforceObjectConfig;
 
-export function specifiedSalesforceObjectConfig(object: SalesforceObject): SpecifiedSalesforceObjectConfig {
+export function specifiedObjectConfig(object: SalesforceObject): SpecifiedSalesforceObjectConfig {
   return {
     type: 'specified',
     object,
   };
 }
 
-export function selectableSalesforceObjectConfig(objectChoices: SalesforceObject[]): SelectableSalesforceObjectConfig {
+export function selectableObjectConfig(objectChoices: SalesforceObject[]): SelectableSalesforceObjectConfig {
   return {
     type: 'selectable',
     objectChoices,
@@ -32,6 +32,6 @@ export type SalesforceCredentials = {
   clientSecret: string;
 };
 
-export function salesforceCredentials(params: SalesforceCredentials) {
+export function credentials(params: SalesforceCredentials) {
   return params;
 }

--- a/packages/sdk/src/customer/index.ts
+++ b/packages/sdk/src/customer/index.ts
@@ -1,3 +1,3 @@
-export * from './common';
+export * as common from './common';
 export * as destinations from './destinations';
 export * as sources from './sources';

--- a/packages/sdk/src/developer_config.ts
+++ b/packages/sdk/src/developer_config.ts
@@ -1,4 +1,4 @@
-import { SalesforceCredentials } from './customer';
+import { SalesforceCredentials } from './customer/common/salesforce';
 import { SyncConfig } from './sync_config';
 
 export type DeveloperConfigParams = {

--- a/packages/sdk/src/internal/base/postgres.ts
+++ b/packages/sdk/src/internal/base/postgres.ts
@@ -1,4 +1,4 @@
-import { PostgresCredentials } from '../common';
+import { PostgresCredentials } from '../common/postgres';
 import { BaseInternalIntegration } from './base';
 
 export type PostgresInternalIntegration = BaseInternalIntegration & {

--- a/packages/sdk/src/internal/common/index.ts
+++ b/packages/sdk/src/internal/common/index.ts
@@ -1,1 +1,1 @@
-export * from './postgres';
+export * as postgres from './postgres';

--- a/packages/sdk/src/internal/common/postgres.ts
+++ b/packages/sdk/src/internal/common/postgres.ts
@@ -6,6 +6,6 @@ export type PostgresCredentials = {
   password: string;
 };
 
-export function postgresCredentials(params: PostgresCredentials): PostgresCredentials {
+export function credentials(params: PostgresCredentials): PostgresCredentials {
   return params;
 }

--- a/packages/sdk/src/internal/index.ts
+++ b/packages/sdk/src/internal/index.ts
@@ -1,3 +1,3 @@
-export * from './common';
+export * as common from './common';
 export * as destinations from './destinations';
 export * as sources from './sources';


### PR DESCRIPTION
As per conversation with @tomkit offline, cleaning up the common types namespacing a bit.

The namespacing/scoping is becoming kind of long, but we can revisit that later.