### PR TITLE
docs: salesforce object config comment

### DIFF
--- a/apps/api/developer_config/entities/developer_config.ts
+++ b/apps/api/developer_config/entities/developer_config.ts
@@ -242,11 +242,14 @@ type SalesforceObject =
   | 'WorkTypeGroup'
   | 'WorkTypeGroupMember';
 
+// Developer specifies the Salesforce sObject
 type SpecifiedSalesforceObjectConfig = {
   type: 'specified';
   object: SalesforceObject;
 };
 
+// Developer expects the customer to choose from a list of
+// Salesforce sObject choices.
 type SelectableSalesforceObjectConfig = {
   type: 'selectable';
   objectChoices: SalesforceObject[];


### PR DESCRIPTION
Just a comment in code to explain difference between developer specifying an SF object vs expecting customer to choose one.