### PR TITLE
feat: enable customers to create custom properties in the sync config

### DIFF
--- a/apps/api/routes/field.ts
+++ b/apps/api/routes/field.ts
@@ -8,6 +8,11 @@ const { integrationService, developerConfigService } = getDependencyContainer();
 
 const router: Router = Router({ mergeParams: true });
 
+type SObjectField = {
+  name: string;
+  label: string;
+};
+
 router.get(
   '/',
   posthogMiddleware('Get Fields'),
@@ -42,8 +47,7 @@ router.get(
     const result = await connection.sobject(salesforceObject).describe$();
 
     const fields = result.fields.map((field) => ({ label: field.label, name: field.name }));
-
-    fields.sort();
+    fields.sort((a: SObjectField, b: SObjectField) => a.label.localeCompare(b.label));
 
     return res.status(200).send(fields);
   },

--- a/apps/api/routes/sync.ts
+++ b/apps/api/routes/sync.ts
@@ -2,7 +2,7 @@ import { Request, Response, Router } from 'express';
 import { getDependencyContainer } from '../dependency_container';
 import { BadRequestError, NotFoundError } from '../errors';
 import { errorMiddleware as posthogErrorMiddleware, middleware as posthogMiddleware } from '../lib/posthog';
-import { Sync, SyncCreateParams, SyncRun, SyncRunStatus } from '../syncs/entities';
+import { Sync, SyncCreateParams, SyncRun, SyncRunStatus, SyncUpdateParams } from '../syncs/entities';
 
 const { syncService, developerConfigService } = getDependencyContainer();
 
@@ -58,7 +58,7 @@ router.post(
 router.put(
   '/:syncId',
   posthogMiddleware('Update Sync'),
-  async (req: Request<{ syncId: string }, any, SyncCreateParams>, res: Response<Sync>) => {
+  async (req: Request<{ syncId: string }, any, SyncUpdateParams>, res: Response<Sync>) => {
     // TODO: Validate that `req.params.syncId` is equal to `req.body.id`.
     const developerConfig = await developerConfigService.getDeveloperConfig();
     const sync = await syncService.updateSync(req.params.syncId, req.body, developerConfig);

--- a/apps/api/syncs/entities/sync.ts
+++ b/apps/api/syncs/entities/sync.ts
@@ -194,8 +194,8 @@ type BaseSyncUpdateParams = {
   enabled: boolean;
   syncConfigName: string;
   fieldMapping?: Record<string, string>;
-  // Customer-defined fields that are not included in the developer's destination schema
-  customProperties?: Record<string, string>[];
+  // TODO: cast json column values to correct types when reading from db
+  customProperties?: Record<string, string>[]; // Customer-, rather than developer-defined
 };
 
 type BaseSyncCreateParams = BaseSyncUpdateParams & {

--- a/apps/api/syncs/entities/sync.ts
+++ b/apps/api/syncs/entities/sync.ts
@@ -194,6 +194,8 @@ type BaseSyncUpdateParams = {
   enabled: boolean;
   syncConfigName: string;
   fieldMapping?: Record<string, string>;
+  // Customer-defined fields that are not included in the developer's destination schema
+  customProperties?: Record<string, string>[];
 };
 
 type BaseSyncCreateParams = BaseSyncUpdateParams & {

--- a/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
+++ b/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
@@ -10,7 +10,6 @@ import {
   DeveloperConfig,
   Field,
   PostgresDestination,
-  SObjectField,
   SyncConfig,
   SyncUpdateParams,
 } from '../../lib/types';
@@ -91,13 +90,13 @@ type FieldCollectionProps = {
 };
 
 const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps) => {
-  const initialFieldMapping = syncConfig.destination.schema.fields.reduce<CustomerFieldMapping>((mapping, { name }) => {
-    mapping[name] =
-      sync.fieldMapping?.[name] ||
-      syncConfig.defaultFieldMapping?.find((mapping) => mapping.name === name)?.field ||
-      '';
-    return mapping;
-  }, {});
+  // Use the customer-defined field mapping if it exists, or else the default one supplied by the developer
+  const initialFieldMapping =
+    sync.fieldMapping ??
+    syncConfig.destination.schema.fields.reduce<CustomerFieldMapping>((mapping, { name }) => {
+      mapping[name] = syncConfig.defaultFieldMapping?.find((entry) => entry.name === name)?.field || '';
+      return mapping;
+    }, {});
   const [fieldMapping, setFieldMapping] = useState<CustomerFieldMapping>(initialFieldMapping);
 
   const [isCreatingCustomProperty, setIsCreatingCustomProperty] = useState(false);
@@ -212,7 +211,7 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
             onValueChange={async (value: string) => {
               await onUpdateMappedField({ name, value });
             }}
-            options={fields ? fields.sort((a: SObjectField, b: SObjectField) => a.label.localeCompare(b.label)) : []}
+            options={fields ?? []}
             value={fieldMapping[name]}
             isLoading={isLoadingFields}
           />

--- a/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
+++ b/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
@@ -1,27 +1,30 @@
 /** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
 import classNames from 'classnames';
 import { ReactNode, useState } from 'react';
 import useSWR from 'swr';
 import useSWRMutation from 'swr/mutation';
 import { updateSync, useSalesforceIntegration } from '../../hooks/api';
-import { DeveloperConfig, PostgresDestination, SyncConfig } from '../../lib/types';
+import {
+  CustomerFieldMapping,
+  DeveloperConfig,
+  Field,
+  PostgresDestination,
+  SObjectField,
+  SyncConfig,
+  SyncUpdateParams,
+} from '../../lib/types';
 import { Select, SelectElements } from '../../primitives';
+import { XIcon } from '../../primitives/icons';
 import { SupaglueProviderInternal } from '../../providers';
 import { useSupaglueContext } from '../../providers/SupaglueProvider';
 import { SupaglueAppearance } from '../../types';
 import styles from './styles';
 
-type Field = {
+type MappedField = {
   name: string;
   value: string;
 };
-
-type SalesforceField = {
-  name: string;
-  label: string;
-};
-
-type FieldMapping = Record<string, string>;
 
 const EmptyContent = ({ className, children }: { className?: string; children: ReactNode }) => {
   return (
@@ -74,29 +77,30 @@ const FieldMappingInternal = ({ appearance, syncConfigName }: FieldMappingProps)
 };
 
 type FieldCollectionProps = {
-  appearance?: SupaglueAppearance & {
-    elements?: FieldMappingElements;
-  };
+  appearance?: FieldMappingAppearance;
   syncConfig: SyncConfig;
   sync: {
     id: string;
     customerId: string;
     enabled: boolean;
-    fieldMapping?: FieldMapping;
+    fieldMapping?: CustomerFieldMapping;
     name: string;
     syncConfigName: string;
+    customProperties?: Field[];
   };
 };
 
 const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps) => {
-  const initialFieldMapping = syncConfig.destination.schema.fields.reduce<FieldMapping>((mapping, { name }) => {
+  const initialFieldMapping = syncConfig.destination.schema.fields.reduce<CustomerFieldMapping>((mapping, { name }) => {
     mapping[name] =
       sync.fieldMapping?.[name] ||
       syncConfig.defaultFieldMapping?.find((mapping) => mapping.name === name)?.field ||
       '';
     return mapping;
   }, {});
-  const [fieldMapping, setFieldMapping] = useState<FieldMapping>(initialFieldMapping);
+  const [fieldMapping, setFieldMapping] = useState<CustomerFieldMapping>(initialFieldMapping);
+
+  const [isCreatingCustomProperty, setIsCreatingCustomProperty] = useState(false);
 
   const { apiUrl, customerId } = useSupaglueContext();
 
@@ -107,31 +111,75 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
   const { mutate } = useSWR({
     path: `/syncs?customerId=${customerId}&syncConfigName=${syncConfig.name}`,
   });
-  const { trigger: triggerUpdateSync } = useSWRMutation(`${apiUrl}/syncs/${sync.id}`, updateSync);
+  const { trigger: callUpdateSync } = useSWRMutation(`${apiUrl}/syncs/${sync.id}`, updateSync);
 
   const { upsertKey } = (syncConfig.destination as PostgresDestination).config;
 
-  const onUpdateField = async (field: Field) => {
-    const updatedFieldMapping = {
-      ...fieldMapping,
-      [field.name]: field.value,
-    };
-
-    const result = await triggerUpdateSync({
-      id: sync.id,
-      fieldMapping: updatedFieldMapping,
-    });
+  const onUpdateSync = async (params: SyncUpdateParams, onSuccess?: () => void) => {
+    const result = await callUpdateSync(params);
 
     if (result?.data) {
       // Update the cache and state
       mutate({ ...result.data });
-      setFieldMapping(updatedFieldMapping);
+      if (onSuccess) {
+        onSuccess();
+      }
     }
+  };
+
+  const onUpdateMappedField = async (field: MappedField) => {
+    const updatedFieldMapping: CustomerFieldMapping = {
+      ...fieldMapping,
+      [field.name]: field.value,
+    };
+
+    await onUpdateSync(
+      {
+        id: sync.id,
+        fieldMapping: updatedFieldMapping,
+      },
+      () => setFieldMapping(updatedFieldMapping)
+    );
+  };
+
+  const applicationFields = [...syncConfig.destination.schema.fields, ...(sync.customProperties || [])];
+  const customPropertyNames = new Set((sync.customProperties || []).map((field) => field.name));
+
+  const onCreateCustomProperty = async (name: string) => {
+    name = name.trim();
+
+    // Prevent duplicate field names
+    if (name === '' || applicationFields.map((field) => field.name).includes(name)) {
+      // TODO: Show error
+      return;
+    }
+
+    await onUpdateSync(
+      {
+        id: sync.id,
+        customProperties: [...(sync.customProperties || []), { name, label: name }],
+      },
+      () => setIsCreatingCustomProperty(false)
+    );
+  };
+
+  const onRemoveCustomProperty = async (name: string) => {
+    const updatedFieldMapping: CustomerFieldMapping = { ...fieldMapping };
+    delete fieldMapping[name];
+
+    await onUpdateSync(
+      {
+        id: sync.id,
+        customProperties: (sync.customProperties || []).filter((field) => field.name !== name),
+        fieldMapping: updatedFieldMapping,
+      },
+      () => setFieldMapping(updatedFieldMapping)
+    );
   };
 
   return (
     // TODO: write form primitives
-    <form css={styles.form} className={classNames('sg-form', appearance?.elements?.form)}>
+    <div css={styles.form} className={classNames('sg-form', appearance?.elements?.form)}>
       <div css={styles.formHeaderRow} className={classNames('sg-formHeaderRow', appearance?.elements?.formHeaderRow)}>
         <div
           css={styles.formColumnHeader}
@@ -147,7 +195,7 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
         </div>
       </div>
 
-      {syncConfig.destination.schema.fields.map(({ label, name }, idx) => (
+      {applicationFields.map(({ label, name }, idx) => (
         <div
           key={idx}
           css={styles.fieldWrapper}
@@ -162,21 +210,96 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
             disabled={!!upsertKey && name === upsertKey}
             label="Salesforce field name"
             onValueChange={async (value: string) => {
-              await onUpdateField({ name, value });
+              await onUpdateMappedField({ name, value });
             }}
-            options={
-              fields ? fields.sort((a: SalesforceField, b: SalesforceField) => a.label.localeCompare(b.label)) : []
-            }
+            options={fields ? fields.sort((a: SObjectField, b: SObjectField) => a.label.localeCompare(b.label)) : []}
             value={fieldMapping[name]}
             isLoading={isLoadingFields}
           />
+
+          {customPropertyNames.has(name) && (
+            <XIcon
+              onClick={() => onRemoveCustomProperty(name)}
+              css={css({ position: 'absolute', right: '-1.75rem' })}
+            />
+          )}
         </div>
       ))}
-    </form>
+
+      {isCreatingCustomProperty && (
+        <NewCustomPropertyForm
+          appearance={appearance}
+          onCancel={() => setIsCreatingCustomProperty(false)}
+          onCreateCustomProperty={onCreateCustomProperty}
+        />
+      )}
+
+      <AddCustomPropertyButton
+        appearance={appearance}
+        disabled={isCreatingCustomProperty}
+        onClick={() => setIsCreatingCustomProperty(true)}
+      />
+    </div>
   );
 };
 
+const NewCustomPropertyForm = ({
+  appearance,
+  onCancel,
+  onCreateCustomProperty,
+}: {
+  appearance?: FieldMappingAppearance;
+  onCancel: () => void;
+  onCreateCustomProperty: (name: string) => void;
+}) => (
+  <form
+    onSubmit={(e) => {
+      e.preventDefault();
+      // @ts-expect-error: Figure out how to type this
+      onCreateCustomProperty(e.target[0].value);
+    }}
+    css={styles.fieldWrapper}
+    className={classNames(appearance?.elements?.fieldWrapper, 'sg-fieldWrapper')}
+  >
+    <input
+      css={styles.newCustomPropertyInput}
+      className={classNames(appearance?.elements?.newCustomPropertyInput, 'sg-newCustomPropertyInput')}
+      onBlur={(e) => onCreateCustomProperty(e.target.value)}
+      defaultValue=""
+      type="text"
+    />
+    <input css={styles.customPropertySubmitInput} type="submit" />
+    <XIcon
+      className={classNames(appearance?.elements?.deleteCustomPropertyButton, 'sg-deleteCustomPropertyButton')}
+      onClick={onCancel}
+      css={css({
+        marginRight: 'auto',
+      })}
+    />
+  </form>
+);
+
+const AddCustomPropertyButton = ({
+  appearance,
+  ...props
+}: {
+  appearance?: FieldMappingAppearance;
+  disabled?: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    className={classNames(appearance?.elements?.addCustomPropertyButton, 'sg-addCustomPropertyButton')}
+    css={styles.addCustomPropertyButton}
+    {...props}
+    type={undefined}
+  >
+    + Add custom property
+  </button>
+);
+
 export type FieldMappingElements = SelectElements & {
+  addCustomPropertyButton?: string;
+  deleteCustomPropertyButton?: string;
   fieldDropdownOption?: string;
   fieldMapperRow?: string;
   fieldName?: string;
@@ -184,12 +307,15 @@ export type FieldMappingElements = SelectElements & {
   form?: string;
   formColumnHeader?: string;
   formHeaderRow?: string;
+  newCustomPropertyInput?: string;
+};
+
+type FieldMappingAppearance = SupaglueAppearance & {
+  elements?: FieldMappingElements;
 };
 
 export type FieldMappingProps = {
-  appearance?: SupaglueAppearance & {
-    elements?: FieldMappingElements;
-  };
+  appearance?: FieldMappingAppearance;
   syncConfigName: string;
 };
 

--- a/packages/nextjs/src/elements/FieldMapping/styles.ts
+++ b/packages/nextjs/src/elements/FieldMapping/styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { indigo, slate } from '@radix-ui/colors';
 import { _applyTheme } from '../../style/internal';
 import { SgTheme } from '../../style/types/theme';
 
@@ -48,6 +49,7 @@ const fieldWrapper = _applyTheme((theme: SgTheme) =>
     flexDirection: 'row',
     gap: '1rem',
     justifyContent: 'space-between',
+    position: 'relative',
     ...theme.elementOverrides?.fieldWrapper,
   })
 );
@@ -60,13 +62,42 @@ const fieldName = _applyTheme((theme: SgTheme) =>
   })
 );
 
+const newCustomPropertyInput = css({
+  border: `1px solid ${slate.slate9}`,
+  borderRadius: '0.5rem',
+  height: '2.25rem',
+  lineHeight: 1,
+  padding: '0.25rem 0.5rem',
+  ':focus': {
+    boxShadow: 'none',
+  },
+  ':focus-visible': {
+    boxShadow: `0 0 0 2px ${indigo.indigo12}`,
+  },
+});
+
+const customPropertySubmitInput = css({
+  display: 'none',
+});
+
+const addCustomPropertyButton = css({
+  backgroundColor: 'white',
+  border: 'none',
+  color: slate.slate11,
+  marginTop: '1rem',
+  textAlign: 'start',
+});
+
 const styles = {
+  addCustomPropertyButton,
+  customPropertySubmitInput,
   emptyContentReason,
   form,
   formHeaderRow,
   formColumnHeader,
   fieldWrapper,
   fieldName,
+  newCustomPropertyInput,
 };
 
 export default styles;

--- a/packages/nextjs/src/lib/types.ts
+++ b/packages/nextjs/src/lib/types.ts
@@ -7,9 +7,21 @@ const SALESFORCE_OBJECT_TYPES = ['Contact', 'Lead', 'Account', 'Opportunity'] as
 
 export type SalesforceObjectType = (typeof SALESFORCE_OBJECT_TYPES)[number];
 
+export type SObjectField = {
+  name: string;
+  label: string;
+};
+
 export type FieldMapping = {
   name: string;
   field: string;
+};
+
+export type CustomerFieldMapping = Record<string, string>;
+export type SyncUpdateParams = {
+  id: string;
+  fieldMapping?: CustomerFieldMapping;
+  customProperties?: Field[];
 };
 
 export type SyncConfig = {
@@ -20,6 +32,7 @@ export type SyncConfig = {
   // TODO: support incremental
   strategy: 'full_refresh';
   defaultFieldMapping?: FieldMapping[];
+  customProperties?: Field[];
 };
 
 type BaseDestination = {
@@ -52,7 +65,7 @@ export type WebhookDestination = BaseDestination & {
 
 export type Destination = PostgresDestination | WebhookDestination;
 
-type Field = {
+export type Field = {
   name: string; // Raw field name.
   label?: string; // Human-readable label to be displayed to customers.
   description?: string;

--- a/packages/nextjs/src/primitives/icons/index.ts
+++ b/packages/nextjs/src/primitives/icons/index.ts
@@ -1,0 +1,1 @@
+export * from './xIcon';

--- a/packages/nextjs/src/primitives/icons/xIcon.tsx
+++ b/packages/nextjs/src/primitives/icons/xIcon.tsx
@@ -1,0 +1,15 @@
+import { SerializedStyles } from '@emotion/react';
+import { slate } from '@radix-ui/colors';
+
+export const XIcon = (props: { className?: string; css?: SerializedStyles; onClick: () => void }) => (
+  <button css={{ color: slate.slate9 }} {...props} type={undefined}>
+    <svg height="15" width="15" viewBox="0 0 15 15" fill="none">
+      <path
+        d="M12.8536 2.85355C13.0488 2.65829 13.0488 2.34171 12.8536 2.14645C12.6583 1.95118 12.3417 1.95118 12.1464 2.14645L7.5 6.79289L2.85355 2.14645C2.65829 1.95118 2.34171 1.95118 2.14645 2.14645C1.95118 2.34171 1.95118 2.65829 2.14645 2.85355L6.79289 7.5L2.14645 12.1464C1.95118 12.3417 1.95118 12.6583 2.14645 12.8536C2.34171 13.0488 2.65829 13.0488 2.85355 12.8536L7.5 8.20711L12.1464 12.8536C12.3417 13.0488 12.6583 13.0488 12.8536 12.8536C13.0488 12.6583 13.0488 12.3417 12.8536 12.1464L8.20711 7.5L12.8536 2.85355Z"
+        fill="currentColor"
+        fillRule="evenodd"
+        clipRule="evenodd"
+      ></path>
+    </svg>
+  </button>
+);


### PR DESCRIPTION
Depends on #104

Adds a simple button to allow customers to create custom properties for the purposes of their SFDC integration. Note that these are application-side custom properties, not Salesforce custom fields.

For now, this is a fairly naive implementation that assumes that customer-defined properties aren't consumed by the application outside of the Salesforce syncs.

**Caveats**
1. Custom properties cannot be renamed
2. Custom properties cannot be reused across syncs, even for the same sObjects (same as field mappings). We're planning to refactor how syncs are modeled to enable field mappings, custom properties, etc. to be shared across syncs.

TO DO (follow-up):
- [ ] Actually write ingested Salesforce data to the custom properties
- [ ] Validate custom field when creating and display errors
- [ ] Fix annoying UI issue where the new custom property input lingers after the field mapping has been updated
- [ ] Only allow creating custom properties if enabled for that customer by the developer
- [ ] Update SG default theme to include form/input styles (FYI @asdfryan - I held off on this until you're back from OOO)