### PR TITLE
chore: add customPropertiesColumn to Postgres destination config

### DIFF
--- a/apps/api/developer_config/entities/developer_config.ts
+++ b/apps/api/developer_config/entities/developer_config.ts
@@ -34,6 +34,7 @@ export type PostgresInternalIntegration = BaseInternalIntegration & {
     };
     table: string;
     customerIdColumn: string;
+    customPropertiesColumn?: string; // NOTE: This must be a jsonb column on the same table
   };
 };
 

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -32,21 +32,21 @@ model DeveloperConfig {
 }
 
 model Sync {
-  id                String    @id @default(uuid())
-  customerId        String    @map("customer_id")
-  type              String
-  enabled           Boolean
-  syncConfigName    String    @map("sync_config_name")
-  fieldMapping      Json?     @map("field_mapping")
-  customProperties  Json?     @map("custom_properties")
+  id               String  @id @default(uuid())
+  customerId       String  @map("customer_id")
+  type             String
+  enabled          Boolean
+  syncConfigName   String  @map("sync_config_name")
+  fieldMapping     Json?   @map("field_mapping")
+  customProperties Json?   @map("custom_properties")
 
   // TODO: We might want to consider storing source/destination/etc.
   // fields in a single JSONB column down the road instead for simplicity,
   // since we're unlikely to index by these anyway. Also, these properties
   // might diverge a lot for type=inbound vs type=outbound down the line.
-  source         Json?     @map("source")
-  destination    Json?     @map("destination")
-  SyncRun        SyncRun[]
+  source      Json?     @map("source")
+  destination Json?     @map("destination")
+  SyncRun     SyncRun[]
 
   @@unique([customerId, syncConfigName])
   @@map("syncs")

--- a/apps/sample-app/prisma/migrations/20230209203536_add_extra_attrbiutes_column_to_salesforce_contacts/migration.sql
+++ b/apps/sample-app/prisma/migrations/20230209203536_add_extra_attrbiutes_column_to_salesforce_contacts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "salesforce_contacts" ADD COLUMN     "extra_attributes" JSONB;

--- a/apps/sample-app/prisma/schema.prisma
+++ b/apps/sample-app/prisma/schema.prisma
@@ -74,15 +74,16 @@ model SalesforceCreds {
 }
 
 model SalesforceContact {
-  id           Int      @id @default(autoincrement())
-  email        String   @db.VarChar(255)
-  customerId   String   @map("customer_id") @db.VarChar(255)
-  salesforceId String?  @map("salesforce_id") @db.VarChar(255)
-  title        String?  @db.VarChar(255)
-  firstName    String?  @map("first_name") @db.VarChar(255)
-  lastName     String?  @map("last_name") @db.VarChar(255)
-  createdAt    DateTime @default(now()) @map("created_at")
-  updatedAt    DateTime @updatedAt @map("updated_at")
+  id                Int      @id @default(autoincrement())
+  email             String   @db.VarChar(255)
+  customerId        String   @map("customer_id") @db.VarChar(255)
+  salesforceId      String?  @map("salesforce_id") @db.VarChar(255)
+  title             String?  @db.VarChar(255)
+  firstName         String?  @map("first_name") @db.VarChar(255)
+  lastName          String?  @map("last_name") @db.VarChar(255)
+  extraAttributes   Json?    @map("extra_attributes")
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
 
   @@unique([customerId, salesforceId])
   @@map("salesforce_contacts")

--- a/apps/sample-app/supaglue-config/inbound/contact.ts
+++ b/apps/sample-app/supaglue-config/inbound/contact.ts
@@ -40,6 +40,7 @@ const contactSyncConfig = sdk.syncConfigs.inbound({
       table: 'salesforce_contacts',
       upsertKey: 'salesforce_id',
       customerIdColumn: 'customer_id',
+      customPropertiesColumn: 'extra_attributes',
     },
     retryPolicy: sdk.retryPolicy({
       retries: 2,

--- a/packages/sdk/src/internal/base/postgres.ts
+++ b/packages/sdk/src/internal/base/postgres.ts
@@ -7,5 +7,6 @@ export type PostgresInternalIntegration = BaseInternalIntegration & {
     credentials: PostgresCredentials;
     table: string;
     customerIdColumn: string;
+    customPropertiesColumn?: string;
   };
 };


### PR DESCRIPTION
Add a new config property to indicate where customer-defined properties should be written to in a Postgres destination. For now, this must be a `jsonb` column on the same table that we're writing Salesforce objects to.

Includes a migration to add a custom properties column to the `salesforce_contacts` table in the sample app.