### PR TITLE
feat: Support custom properties in inbound syncs to Postgres

### DIFF
--- a/apps/sample-app/pages/index.tsx
+++ b/apps/sample-app/pages/index.tsx
@@ -60,13 +60,22 @@ function ContactsTable({
     keepPreviousData: true,
   });
   const userCount = count || initialTotalUsers;
-  const cols = [
+  let cols = [
     { name: 'First Name' },
     { name: 'Last Name' },
     { name: 'Title' },
     { name: 'Email' },
     { name: 'Salesforce ID' },
   ];
+
+  // Display custom properties in the table
+  // Right now there's no way to consume custom properties outside of the integration config page,
+  // so just look at the first record returned to see if there are any custom properties on it
+  let extraFields: string[] = [];
+  if (users.length && users[0].extraAttributes) {
+    extraFields = Object.keys(users[0].extraAttributes);
+    cols = [...cols, ...extraFields.map((attr) => ({ name: attr }))];
+  }
 
   return (
     <Table
@@ -89,6 +98,9 @@ function ContactsTable({
           <TableCell>{user.title}</TableCell>
           <TableCell>{user.email}</TableCell>
           <TableCell>{user.salesforceId}</TableCell>
+          {extraFields.map((field: string, idx) => (
+            <TableCell key={idx}>{(user.extraAttributes as Record<string, any>)[field]}</TableCell>
+          ))}
         </tr>
       ))}
     />

--- a/apps/sample-app/prisma/schema.prisma
+++ b/apps/sample-app/prisma/schema.prisma
@@ -74,16 +74,16 @@ model SalesforceCreds {
 }
 
 model SalesforceContact {
-  id                Int      @id @default(autoincrement())
-  email             String   @db.VarChar(255)
-  customerId        String   @map("customer_id") @db.VarChar(255)
-  salesforceId      String?  @map("salesforce_id") @db.VarChar(255)
-  title             String?  @db.VarChar(255)
-  firstName         String?  @map("first_name") @db.VarChar(255)
-  lastName          String?  @map("last_name") @db.VarChar(255)
-  extraAttributes   Json?    @map("extra_attributes")
-  createdAt         DateTime @default(now()) @map("created_at")
-  updatedAt         DateTime @updatedAt @map("updated_at")
+  id              Int      @id @default(autoincrement())
+  email           String   @db.VarChar(255)
+  customerId      String   @map("customer_id") @db.VarChar(255)
+  salesforceId    String?  @map("salesforce_id") @db.VarChar(255)
+  title           String?  @db.VarChar(255)
+  firstName       String?  @map("first_name") @db.VarChar(255)
+  lastName        String?  @map("last_name") @db.VarChar(255)
+  extraAttributes Json?    @map("extra_attributes")
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
 
   @@unique([customerId, salesforceId])
   @@map("salesforce_contacts")


### PR DESCRIPTION
Write to custom properties when syncing objects from Salesforce to Postgres.

Does not include:
- [ ] Reading from custom properties when doing outbound syncs from postgres > salesforce
- [ ] Supporting custom properties for webhook destinations