### PR TITLE
fix: vertically align toast with TriggerSyncButton

### DIFF
--- a/packages/nextjs/src/elements/TriggerSyncButton/styles.ts
+++ b/packages/nextjs/src/elements/TriggerSyncButton/styles.ts
@@ -12,14 +12,17 @@ const toast = _applyTheme((theme: SgTheme) =>
     padding: '0.25rem 0.5rem',
     display: 'block',
     left: '9rem',
-    top: '0.375rem',
+    top: 0,
     borderRadius: '0.25rem',
     fontSize: '0.75rem',
     lineHeight: '1rem',
+    width: '100%',
     ...theme.elementOverrides?.toast,
   })
 );
 
-export default {
+const styles = {
   toast,
 };
+
+export default styles;


### PR DESCRIPTION
Before:
<img width="618" alt="Screenshot 2023-02-10 at 3 12 39 PM" src="https://user-images.githubusercontent.com/2220186/218229711-b8b63303-9796-4236-8c88-92662407466a.png">

After:
<img width="419" alt="Screenshot 2023-02-10 at 3 14 11 PM" src="https://user-images.githubusercontent.com/2220186/218229726-48f12a6d-0382-4802-8620-9bc43436a8ee.png">

