### PR TITLE
fix: only show the '+ Add custom property' button if postgres schema supports it

### DIFF
--- a/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
+++ b/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
@@ -141,6 +141,12 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
     );
   };
 
+  // TODO: Add flag to enable/disable custom properties
+  // For now, just check to see if there's a column configured for custom properties
+  const destinationConfig = syncConfig.destination.config;
+  const customPropertiesEnabled =
+    'customPropertiesColumn' in destinationConfig && !!destinationConfig.customPropertiesColumn;
+
   const applicationFields = [...syncConfig.destination.schema.fields, ...(sync.customProperties || [])];
   const customPropertyNames = new Set((sync.customProperties || []).map((field) => field.name));
 
@@ -233,11 +239,13 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
         />
       )}
 
-      <AddCustomPropertyButton
-        appearance={appearance}
-        disabled={isCreatingCustomProperty}
-        onClick={() => setIsCreatingCustomProperty(true)}
-      />
+      {customPropertiesEnabled && (
+        <AddCustomPropertyButton
+          appearance={appearance}
+          disabled={isCreatingCustomProperty}
+          onClick={() => setIsCreatingCustomProperty(true)}
+        />
+      )}
     </div>
   );
 };

--- a/packages/nextjs/src/lib/types.ts
+++ b/packages/nextjs/src/lib/types.ts
@@ -32,7 +32,6 @@ export type SyncConfig = {
   // TODO: support incremental
   strategy: 'full_refresh';
   defaultFieldMapping?: FieldMapping[];
-  customProperties?: Field[];
 };
 
 type BaseDestination = {
@@ -51,6 +50,7 @@ export type PostgresDestination = BaseDestination & {
     };
     table: string;
     upsertKey: string;
+    customPropertiesColumn?: string;
   };
 };
 


### PR DESCRIPTION
Custom properties are only enabled for inbound contacts syncs right now, so hide the button for all other syncs.