### PR TITLE
feat: create entity_integration_configs db table migration

### DIFF
--- a/apps/api/prisma/migrations/20230214002909_field_mapping/migration.sql
+++ b/apps/api/prisma/migrations/20230214002909_field_mapping/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "field_mappings" (
+    "id" TEXT NOT NULL,
+    "customer_id" TEXT NOT NULL,
+    "entity_name" TEXT NOT NULL,
+    "integration_type" TEXT NOT NULL,
+    "config" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "field_mappings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "field_mappings_customer_id_entity_name_integration_type_key" ON "field_mappings"("customer_id", "entity_name", "integration_type");

--- a/apps/api/prisma/migrations/20230214010611_entity_integration_config/migration.sql
+++ b/apps/api/prisma/migrations/20230214010611_entity_integration_config/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "field_mappings" (
+CREATE TABLE "entity_integration_configs" (
     "id" TEXT NOT NULL,
     "customer_id" TEXT NOT NULL,
     "entity_name" TEXT NOT NULL,
@@ -8,8 +8,8 @@ CREATE TABLE "field_mappings" (
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
 
-    CONSTRAINT "field_mappings_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "entity_integration_configs_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "field_mappings_customer_id_entity_name_integration_type_key" ON "field_mappings"("customer_id", "entity_name", "integration_type");
+CREATE UNIQUE INDEX "entity_integration_configs_customer_id_entity_name_integrat_key" ON "entity_integration_configs"("customer_id", "entity_name", "integration_type");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -31,6 +31,22 @@ model DeveloperConfig {
   @@map("developer_configs")
 }
 
+model FieldMapping {
+  id              String   @id @default(uuid())
+  customerId      String   @map("customer_id")
+  entityName      String   @map("entity_name")
+  // Purposely using `integrationType` instead of foreign key `integrationId`
+  // so that even if the customer disconnects (deletes) the Salesforce integration
+  // we keep the FieldMappings around (in case they re-connect later).
+  integrationType String   @map("integration_type")
+  config          Json
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
+
+  @@unique([customerId, entityName, integrationType])
+  @@map("field_mappings")
+}
+
 model Sync {
   id               String  @id @default(uuid())
   customerId       String  @map("customer_id")

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -31,7 +31,7 @@ model DeveloperConfig {
   @@map("developer_configs")
 }
 
-model FieldMapping {
+model EntityIntegrationConfig {
   id              String   @id @default(uuid())
   customerId      String   @map("customer_id")
   entityName      String   @map("entity_name")
@@ -44,7 +44,7 @@ model FieldMapping {
   updatedAt       DateTime @updatedAt @map("updated_at")
 
   @@unique([customerId, entityName, integrationType])
-  @@map("field_mappings")
+  @@map("entity_integration_configs")
 }
 
 model Sync {


### PR DESCRIPTION
To support the new concept of `Entity`, we want to store `EntityIntegrationConfig` as a standalone object in the DB. This would consist of both `fieldMapping` and `customProperties`.