### PR TITLE
fix: fix custom fields bugs (2 out of 3)

### DIFF
--- a/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
+++ b/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
@@ -164,7 +164,7 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
 
   const onRemoveCustomProperty = async (name: string) => {
     const updatedFieldMapping: CustomerFieldMapping = { ...fieldMapping };
-    delete fieldMapping[name];
+    delete updatedFieldMapping[name];
 
     await onUpdateSync(
       sync.id,
@@ -219,7 +219,7 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
 
           {customPropertyNames.has(name) && (
             <XIcon
-              onClick={() => onRemoveCustomProperty(name)}
+              onClick={async () => await onRemoveCustomProperty(name)}
               css={css({ position: 'absolute', right: '-1.75rem' })}
             />
           )}
@@ -227,11 +227,7 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
       ))}
 
       {isCreatingCustomProperty && (
-        <NewCustomPropertyForm
-          appearance={appearance}
-          onCancel={() => setIsCreatingCustomProperty(false)}
-          onCreateCustomProperty={onCreateCustomProperty}
-        />
+        <NewCustomPropertyForm appearance={appearance} onCreateCustomProperty={onCreateCustomProperty} />
       )}
 
       {/* TODO: Add flag to enable/disable custom properties
@@ -249,11 +245,9 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
 
 const NewCustomPropertyForm = ({
   appearance,
-  onCancel,
   onCreateCustomProperty,
 }: {
   appearance?: FieldMappingAppearance;
-  onCancel: () => void;
   onCreateCustomProperty: (name: string) => void;
 }) => (
   <form
@@ -273,13 +267,6 @@ const NewCustomPropertyForm = ({
       type="text"
     />
     <input css={styles.customPropertySubmitInput} type="submit" />
-    <XIcon
-      className={classNames(appearance?.elements?.deleteCustomPropertyButton, 'sg-deleteCustomPropertyButton')}
-      onClick={onCancel}
-      css={css({
-        marginRight: 'auto',
-      })}
-    />
   </form>
 );
 


### PR DESCRIPTION
1. Fixes a bug where removing a custom field doesn't actually remove it from the field mapping due to a typo (good catch @asdfryan)
2. Removes the X icon to delete a new custom property before it's been created. Because we save the new custom property on blur, we end up creating the new property even if the user actually clicked on the X.