### PR TITLE
fix(nextjs): fix xicon styling

### DIFF
--- a/packages/nextjs/src/primitives/icons/styles.ts
+++ b/packages/nextjs/src/primitives/icons/styles.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+import { slate } from '@radix-ui/colors';
+import { ThemedStyles, _applyTheme } from '../../style/internal';
+import { SgTheme } from '../../style/types/theme';
+
+const xIcon = _applyTheme((theme: SgTheme) =>
+  css({
+    color: slate.slate9,
+    ...theme.elementOverrides?.xIcon,
+  })
+);
+
+const styles: ThemedStyles = {
+  xIcon,
+};
+
+export default styles;

--- a/packages/nextjs/src/primitives/icons/xIcon.tsx
+++ b/packages/nextjs/src/primitives/icons/xIcon.tsx
@@ -1,8 +1,9 @@
+/** @jsxImportSource @emotion/react */
 import { SerializedStyles } from '@emotion/react';
-import { slate } from '@radix-ui/colors';
+import styles from './styles';
 
 export const XIcon = (props: { className?: string; css?: SerializedStyles; onClick: () => void }) => (
-  <button css={{ color: slate.slate9 }} {...props} type={undefined}>
+  <button css={styles.xIcon} {...props} type={undefined}>
     <svg height="15" width="15" viewBox="0 0 15 15" fill="none">
       <path
         d="M12.8536 2.85355C13.0488 2.65829 13.0488 2.34171 12.8536 2.14645C12.6583 1.95118 12.3417 1.95118 12.1464 2.14645L7.5 6.79289L2.85355 2.14645C2.65829 1.95118 2.34171 1.95118 2.14645 2.14645C1.95118 2.34171 1.95118 2.65829 2.14645 2.85355L6.79289 7.5L2.14645 12.1464C1.95118 12.3417 1.95118 12.6583 2.14645 12.8536C2.34171 13.0488 2.65829 13.0488 2.85355 12.8536L7.5 8.20711L12.1464 12.8536C12.3417 13.0488 12.6583 13.0488 12.8536 12.8536C13.0488 12.6583 13.0488 12.3417 12.8536 12.1464L8.20711 7.5L12.8536 2.85355Z"


### PR DESCRIPTION
The real problem was that JSX was not properly interpreting the css. I also refactored the component styles to take into account theming (which is currently not necessary right now, but is convenient if in the future we choose to do so)