### PR TITLE
fix: sample app tabs

### DIFF
--- a/apps/sample-app/components/PageTabs.tsx
+++ b/apps/sample-app/components/PageTabs.tsx
@@ -18,14 +18,14 @@ export const PageTabs: FC<PageTabsProps> = ({ tabs, disabled, className }: PageT
   const tabName = useActiveTab(tabs[0].name);
   const router = useRouter();
 
-  const [activeTab, setActiveTab] = useState<string>(tabName);
+  const [activeTabName, setActiveTabName] = useState<string>(tabName);
 
   useEffect(() => {
-    setActiveTab(tabName);
+    setActiveTabName(tabName);
   }, [tabName]);
 
   const onSelectTab = (tab: string) => {
-    setActiveTab(tab);
+    setActiveTabName(tab);
     void router.push({ hash: tab });
   };
 
@@ -36,10 +36,10 @@ export const PageTabs: FC<PageTabsProps> = ({ tabs, disabled, className }: PageT
           <PageTab
             key={tab.name}
             tab={tab}
-            href={`#${tab}`}
+            href={`#${tab.name}`}
             disabled={disabled}
-            isActiveTab={tab.name === activeTab}
-            setActiveTab={onSelectTab}
+            isActiveTab={tab.name === activeTabName}
+            setActiveTabName={onSelectTab}
           />
         ))}
       </nav>
@@ -52,10 +52,16 @@ interface PageTabProps {
   href: string;
   disabled?: boolean;
   isActiveTab: boolean;
-  setActiveTab: (activeTab: string) => void;
+  setActiveTabName: (activeTabName: string) => void;
 }
 
-export const PageTab: FC<PageTabProps> = ({ tab, href, disabled = false, isActiveTab, setActiveTab }: PageTabProps) => {
+export const PageTab: FC<PageTabProps> = ({
+  tab,
+  href,
+  disabled = false,
+  isActiveTab,
+  setActiveTabName,
+}: PageTabProps) => {
   if (disabled) {
     return (
       <div className="tabs" aria-current={isActiveTab ? 'page' : undefined}>
@@ -66,7 +72,7 @@ export const PageTab: FC<PageTabProps> = ({ tab, href, disabled = false, isActiv
   return (
     <a
       href={href}
-      onClick={() => setActiveTab(tab.name)}
+      onClick={() => setActiveTabName(tab.name)}
       className={classNames('tab tab-bordered px-6', {
         'tab-active': isActiveTab,
       })}

--- a/apps/sample-app/hooks.ts
+++ b/apps/sample-app/hooks.ts
@@ -9,6 +9,13 @@ export const useCustomerIdFromSession = () => {
   return session?.data?.user?.name ?? ANONYMOUS_CUSTOMER_ID;
 };
 
+export const pageTabs = [
+  { name: 'Contacts', label: 'Contacts' },
+  { name: 'Leads', label: 'Leads' },
+  { name: 'Accounts', label: 'Accounts' },
+  { name: 'Opportunities', label: 'Opportunities' },
+];
+
 export const useActiveTab = (defaultTab: string) => {
   const [activeTabName, setActiveTabName] = useState(defaultTab);
   const { asPath } = useRouter();

--- a/apps/sample-app/hooks.ts
+++ b/apps/sample-app/hooks.ts
@@ -10,16 +10,16 @@ export const useCustomerIdFromSession = () => {
 };
 
 export const useActiveTab = (defaultTab: string) => {
-  const [activeTab, setActiveTab] = useState(defaultTab);
+  const [activeTabName, setActiveTabName] = useState(defaultTab);
   const { asPath } = useRouter();
   useEffect(() => {
     const hash = asPath.split('#')[1] ?? '';
     const newActiveTab = hash && decodeURIComponent(hash);
 
     if (newActiveTab) {
-      setActiveTab(newActiveTab);
+      setActiveTabName(newActiveTab);
     }
   }, [asPath]);
 
-  return activeTab;
+  return activeTabName;
 };

--- a/apps/sample-app/pages/index.tsx
+++ b/apps/sample-app/pages/index.tsx
@@ -4,11 +4,11 @@ import Head from 'next/head';
 import { useState } from 'react';
 import useSWR from 'swr';
 import { DrawerMenuButton } from '../components/DrawerMenuButton';
-import { PageTabs, Tab } from '../components/PageTabs';
+import { PageTabs } from '../components/PageTabs';
 import { Pagination } from '../components/Pagination';
 import { Table } from '../components/Table';
 import { TableCell } from '../components/Table/TableCell';
-import { useActiveTab } from '../hooks';
+import { pageTabs, useActiveTab } from '../hooks';
 import prisma, { SalesforceAccount, SalesforceContact, SalesforceLead, SalesforceOpportunity } from '../lib/prismadb';
 import authOptions from './api/auth/[...nextauth]';
 
@@ -256,13 +256,6 @@ function LeadsTable({
     />
   );
 }
-
-const pageTabs: Tab[] = [
-  { name: 'Contacts', label: 'Contacts' },
-  { name: 'Leads', label: 'Leads' },
-  { name: 'Accounts', label: 'Accounts' },
-  { name: 'Opportunities', label: 'Opportunities' },
-];
 
 export default function Users({ contacts, count }: PageProps) {
   const activeTabName = useActiveTab(pageTabs[0].name);

--- a/apps/sample-app/pages/index.tsx
+++ b/apps/sample-app/pages/index.tsx
@@ -258,14 +258,14 @@ function LeadsTable({
 }
 
 const pageTabs: Tab[] = [
-  { name: 'Contacts', label: 'App Contacts' },
-  { name: 'Leads', label: 'App Leads' },
-  { name: 'Accounts', label: 'App Accounts' },
-  { name: 'Opportunities', label: 'App Opportunities' },
+  { name: 'Contacts', label: 'Contacts' },
+  { name: 'Leads', label: 'Leads' },
+  { name: 'Accounts', label: 'Accounts' },
+  { name: 'Opportunities', label: 'Opportunities' },
 ];
 
 export default function Users({ contacts, count }: PageProps) {
-  const activeTab = useActiveTab(pageTabs[0].name);
+  const activeTabName = useActiveTab(pageTabs[0].name);
   return (
     <>
       <Head>
@@ -280,10 +280,10 @@ export default function Users({ contacts, count }: PageProps) {
         </header>
 
         <PageTabs className="mb-4" tabs={pageTabs} disabled={false} />
-        {activeTab === 'Contacts' && <ContactsTable initialUsers={contacts} initialTotalUsers={count} />}
-        {activeTab === 'Leads' && <LeadsTable initialUsers={[]} initialTotalUsers={0} />}
-        {activeTab === 'Accounts' && <AccountsTable initialUsers={[]} initialTotalUsers={0} />}
-        {activeTab === 'Opportunities' && <OpportunitiesTable initialUsers={[]} initialTotalUsers={0} />}
+        {activeTabName === 'Contacts' && <ContactsTable initialUsers={contacts} initialTotalUsers={count} />}
+        {activeTabName === 'Leads' && <LeadsTable initialUsers={[]} initialTotalUsers={0} />}
+        {activeTabName === 'Accounts' && <AccountsTable initialUsers={[]} initialTotalUsers={0} />}
+        {activeTabName === 'Opportunities' && <OpportunitiesTable initialUsers={[]} initialTotalUsers={0} />}
       </main>
     </>
   );

--- a/apps/sample-app/pages/integrations/[type].tsx
+++ b/apps/sample-app/pages/integrations/[type].tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { DrawerMenuButton } from '../../components/DrawerMenuButton';
 import { PageTabs } from '../../components/PageTabs';
-import { useActiveTab } from '../../hooks';
+import { pageTabs, useActiveTab } from '../../hooks';
 
 export default function Integration() {
   const router = useRouter();
@@ -55,13 +55,6 @@ const IntegrationPage = ({ type }: { type: string }) => {
     </>
   );
 };
-
-const pageTabs = [
-  { name: 'Contacts', label: 'Contacts' },
-  { name: 'Leads', label: 'Leads' },
-  { name: 'Accounts', label: 'Accounts' },
-  { name: 'Opportunities', label: 'Opportunities' },
-];
 
 const SyncConfiguration = () => {
   const syncConfigName = useActiveTab(pageTabs[0].name);


### PR DESCRIPTION
* Fix url hash to be tab name and not an object
* Remove `App` prefix which is redundant (it's already in the `App Objects` page
* Share `pageTabs` array across 2 different pages so they don't diverge
* Rename variables to make code more readable