### PR TITLE
feat: update custom property UX

### DIFF
--- a/packages/nextjs/src/elements/FieldMapping/styles.ts
+++ b/packages/nextjs/src/elements/FieldMapping/styles.ts
@@ -50,6 +50,10 @@ const fieldWrapper = _applyTheme((theme: SgTheme) =>
     justifyContent: 'space-between',
     position: 'relative',
     ...theme.elementOverrides?.fieldWrapper,
+    '> span:first-of-type': {
+      position: 'absolute',
+      right: '55%',
+    },
   })
 );
 
@@ -76,6 +80,7 @@ const newCustomPropertyInput = _applyTheme((theme: SgTheme) =>
     },
     backgroundColor: theme.colors.inputBackground,
     color: theme.colors.inputText,
+    width: '40%',
     ...theme.elementOverrides?.newCustomPropertyInput,
   })
 );
@@ -90,10 +95,21 @@ const customPropertySubmitInput = _applyTheme((theme: SgTheme) =>
 const addCustomPropertyButton = _applyTheme((theme: SgTheme) =>
   css({
     backgroundColor: theme.colors.background,
-    border: 'none',
-    color: theme.colors.text,
-    marginTop: '1rem',
-    textAlign: 'start',
+    border: `1px solid ${indigo.indigo11}`,
+    borderRadius: '0.5rem',
+    color: indigo.indigo11,
+    fontWeight: '500',
+    marginLeft: 'auto',
+    marginTop: '0.75rem',
+    padding: '0.375rem 0.75rem',
+    width: 'fit-content',
+    ':hover': {
+      backgroundColor: indigo.indigo2,
+    },
+    ':disabled': {
+      ...theme.common.disabled,
+      border: 'none',
+    },
     ...theme.elementOverrides?.addCustomPropertyButton,
   })
 );

--- a/packages/nextjs/src/elements/FieldMapping/styles.ts
+++ b/packages/nextjs/src/elements/FieldMapping/styles.ts
@@ -94,7 +94,7 @@ const customPropertySubmitInput = _applyTheme((theme: SgTheme) =>
 
 const addCustomPropertyButton = _applyTheme((theme: SgTheme) =>
   css({
-    backgroundColor: theme.colors.background,
+    backgroundColor: 'white',
     border: `1px solid ${indigo.indigo11}`,
     borderRadius: '0.5rem',
     color: indigo.indigo11,


### PR DESCRIPTION
No functional change, this just updates the custom property UX such that we show a (disabled) salesforce field dropdown alongside the text input where you can add the name of your new custom property.

In order to allow selecting a salesforce field before naming a custom property, we'll need to refactor the FieldMapping component and allow custom properties to be updated as well as created and deleted. This raises some product questions about how we should model custom properties, whether they need IDs, etc., and whether supaglue config is the correct place for that metadata or whether it should actually live in the developer's application.