### PR TITLE
feat: add customPropertiesEnabled setting to sync configs

### DIFF
--- a/apps/api/temporal/sdk/internal_integrations/postgres.ts
+++ b/apps/api/temporal/sdk/internal_integrations/postgres.ts
@@ -74,7 +74,12 @@ export class DestinationPostgresInternalIntegration extends PostgresInternalInte
     const normalizedFields = destination.schema.fields.map((field) => field.name);
     const customFields = Object.keys(fieldMapping).filter((field) => !normalizedFields.includes(field));
 
-    const hasCustomFields = !!customPropertiesColumn && customFields.length;
+    const customFieldsEnabled = !!syncConfig.customPropertiesEnabled;
+    if (customFieldsEnabled && !customPropertiesColumn) {
+      throw new Error('Unable to sync custom properties without a customPropertiesColumn specified');
+    }
+    const hasCustomFields = customFieldsEnabled && customFields.length;
+
     const dbFields = hasCustomFields ? [...normalizedFields, customPropertiesColumn] : normalizedFields;
 
     const dbFieldsWithoutPrimaryKey = dbFields.filter((field) => field !== upsertKey);

--- a/apps/sample-app/supaglue-config/inbound/contact.ts
+++ b/apps/sample-app/supaglue-config/inbound/contact.ts
@@ -48,6 +48,7 @@ const contactSyncConfig = sdk.syncConfigs.inbound({
   }),
   strategy: 'full_refresh',
   defaultFieldMapping: contactMapping,
+  customPropertiesEnabled: true,
 });
 
 export default contactSyncConfig;

--- a/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
+++ b/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
@@ -99,8 +99,8 @@ const FieldCollection = ({ appearance, syncConfig, sync }: FieldCollectionProps)
 
   // Use the customer-defined field mapping if it exists; default to the values supplied by the developer
   const initialFieldMapping: CustomerFieldMapping = {};
-  (syncConfig.defaultFieldMapping || []).map(({ name, field }) => {
-    initialFieldMapping[name] = field;
+  ((syncConfig.destination as PostgresDestination).schema.fields || []).map(({ name }) => {
+    initialFieldMapping[name] = syncConfig.defaultFieldMapping?.find((field) => field.name === name)?.field || '';
   });
 
   if (sync.fieldMapping) {

--- a/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
+++ b/packages/nextjs/src/elements/FieldMapping/FieldMapping.tsx
@@ -29,10 +29,18 @@ const getSchema = (syncConfig: SyncConfig): Schema => {
 };
 
 const customPropertiesEnabled = (syncConfig: SyncConfig): boolean => {
-  if (syncConfig.type === 'outbound') {
-    return !!syncConfig.source.config.customPropertiesColumn;
+  if (syncConfig.type === 'inbound' && syncConfig.destination.type === 'postgres') {
+    return Boolean(
+      (syncConfig.destination as PostgresDestination).config.customPropertiesColumn &&
+        syncConfig.customPropertiesEnabled
+    );
   }
-  return syncConfig.destination.type === 'postgres' && !!syncConfig.destination.config.customPropertiesColumn;
+
+  if (syncConfig.type === 'outbound' && syncConfig.source.type === 'postgres') {
+    return false;
+  }
+
+  return Boolean(syncConfig.customPropertiesEnabled);
 };
 
 type MappedField = {

--- a/packages/types/src/sync_config.ts
+++ b/packages/types/src/sync_config.ts
@@ -288,6 +288,10 @@ export type BasePeriodicSyncConfig = {
   strategy: 'full_refresh';
 
   defaultFieldMapping?: FieldMapping[];
+
+  // Determines whether the customer can create custom properties for this sync
+  // For Postgres integrations, a `customPropertiesColumn` must also be specified
+  customPropertiesEnabled?: boolean;
 };
 
 export type BaseRealtimeSyncConfig = Omit<BasePeriodicSyncConfig, 'cronExpression' | 'strategy'>;


### PR DESCRIPTION
Adds a separate config property to the `SyncConfig` that governs whether or not a customer is able to add custom fields to a field mapping. Note that for postgres integrations, a `customPropertiesColumn` is also required.

Also fixes an issue where `destination.schema.fields` is out of sync with the `defaultFieldMapping`, so that fields specified in the latter but not the former do not appear in the customer's field mapping.