### PR TITLE
feat: improve custom properties UX

### DIFF
--- a/packages/nextjs/src/elements/FieldMapping/styles.ts
+++ b/packages/nextjs/src/elements/FieldMapping/styles.ts
@@ -80,7 +80,7 @@ const newCustomPropertyInput = _applyTheme((theme: SgTheme) =>
     },
     backgroundColor: theme.colors.inputBackground,
     color: theme.colors.inputText,
-    width: '40%',
+    width: '90%',
     ...theme.elementOverrides?.newCustomPropertyInput,
   })
 );


### PR DESCRIPTION
Refactors the `FieldMapping` component in order to improve UX for adding and removing custom properties:
- Allow selecting a Salesforce field before naming the custom property
- Prevent glitchy-seeming UI when creating a new custom property (where the text input stays in the DOM even after the field mapping has been re-rendered with the new field)