### PR TITLE
feat: support custom properties in outbound syncs from Postgres

### DIFF
--- a/apps/cli/src/commands/syncs_commands/resume.ts
+++ b/apps/cli/src/commands/syncs_commands/resume.ts
@@ -1,7 +1,7 @@
 /*
  * Resume a customer's sync:
  *
- *  $ supaglue syncs logs --customer-id 1 --sync-config-name Contacts
+ *  $ supaglue syncs resume --customer-id 1 --sync-config-name Contacts
  *
  */
 

--- a/apps/sample-app/supaglue-config/outbound/contact.ts
+++ b/apps/sample-app/supaglue-config/outbound/contact.ts
@@ -31,6 +31,7 @@ const contactSyncConfig = sdk.syncConfigs.outbound({
       credentials,
       table: 'salesforce_contacts',
       customerIdColumn: 'customer_id',
+      customPropertiesColumn: 'extra_attributes',
     },
     retryPolicy: sdk.retryPolicy({
       retries: 2,
@@ -38,6 +39,7 @@ const contactSyncConfig = sdk.syncConfigs.outbound({
   }),
   strategy: 'full_refresh',
   defaultFieldMapping: contactMapping,
+  customPropertiesEnabled: true,
 });
 
 export default contactSyncConfig;


### PR DESCRIPTION
Enables custom properties to be synced from Postgres > Salesforce.

Also:
- For now, adds a hardcoded `pollingTimeout` of 10 seconds when waiting for the results of a bulk upload (in the future, this should be in a config file).
- Logs the result of a bulk upload job, including any records that errored
- Updates the sample app's outbound contact syncs to enable custom properties