### PR TITLE
fix: add route to properties on posthog api events

### DIFF
--- a/apps/api/lib/posthog.ts
+++ b/apps/api/lib/posthog.ts
@@ -56,6 +56,7 @@ function onResFinished(req: Request, res: Response, err?: any) {
     event: 'API Call',
     properties: {
       method: req.method,
+      route: `${req.baseUrl}${req.route.path}`,
       params: req.params,
       providerName: getProviderNameFromRequest(req),
       query: req.query,


### PR DESCRIPTION
This is so we can aggregate events by route, like `/crm/v1/opportunities/:opportunity_id` and `/oauth/connect`.