### PR TITLE
feat: support multiple oauth2 connections per integration

### DIFF
--- a/packages/core/types/connection.ts
+++ b/packages/core/types/connection.ts
@@ -14,6 +14,7 @@ type BaseConnectionCreateParams = {
   customerId: string;
   integrationId: string;
   credentials: ConnectionCredentials;
+  name?: string;
 };
 
 type BaseConnection = BaseConnectionCreateParams & {

--- a/packages/db/prisma/migrations/20230306194940_add_name_to_connections_table_remove_unique_index/migration.sql
+++ b/packages/db/prisma/migrations/20230306194940_add_name_to_connections_table_remove_unique_index/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "connections_customer_id_integration_id_key";
+
+-- AlterTable
+ALTER TABLE "connections" ADD COLUMN     "name" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -40,6 +40,7 @@ model Connection {
   category        String
   // Salesforce, Hubspot, etc.
   providerName    String        @map("provider_name")
+  name            String?
   status          String // available | added | authorized | callable
   credentials     Json // {type, access_token, refresh_token, expires_at, raw}
   customer        Customer      @relation(fields: [customerId], references: [id], onDelete: Cascade)
@@ -48,7 +49,6 @@ model Connection {
   updatedAt       DateTime      @updatedAt @map("updated_at")
   syncHistoryList SyncHistory[]
 
-  @@unique([customerId, integrationId])
   @@map("connections")
 }
 


### PR DESCRIPTION
Removes unique index on (customerId, integrationId) so that multiple connections can be added for the same customer + integration.
Adds an optional `name` column (maybe should be `username`?) to the `connections` table in order to disambiguate when there are multiple connections available.

The idea is to fetch the username associated with the access token and persist that as the default "name" for a connection.

