### PR TITLE
feat: really janky version of COPY to postgres for syncs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,11 +10,18 @@
     "@supaglue/db": "workspace:*",
     "async-retry": "^1.3.3",
     "csv-parse": "^5.3.5",
-    "jsforce": "^2.0.0-beta.20"
+    "csv-stringify": "^6.3.0",
+    "jsforce": "^2.0.0-beta.20",
+    "pg": "^8.10.0",
+    "pg-copy-streams": "^6.0.5",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@tsconfig/node18": "^1.0.1",
     "@types/async-retry": "^1",
+    "@types/pg": "^8",
+    "@types/pg-copy-streams": "^1.2.2",
+    "@types/uuid": "^9.0.1",
     "typescript": "^4.9.5"
   },
   "scripts": {

--- a/packages/core/remotes/crm/salesforce/index.ts
+++ b/packages/core/remotes/crm/salesforce/index.ts
@@ -195,7 +195,7 @@ class SalesforceClient extends CrmRemoteClientEventEmitter implements CrmRemoteC
     // TODO: Shouldn't be relying on `jsforce` to do this.
     const token = await this.#client.oauth2.refreshToken(this.#refreshToken);
     this.#accessToken = token.access_token;
-    const hadListeners = this.emit('token_refreshed', token.access_token, null);
+    this.emit('token_refreshed', token.access_token, null);
   }
 
   async #fetch(path: string, init: RequestInit): Promise<ReturnType<typeof fetch>> {
@@ -347,6 +347,7 @@ class SalesforceClient extends CrmRemoteClientEventEmitter implements CrmRemoteC
   }
 
   public async listContacts(): Promise<RemoteContact[]> {
+    // TODO: remove limit
     const soql = `
       SELECT ${propertiesToFetch.contact.join(', ')}
       FROM Contact

--- a/packages/core/services/account_service.ts
+++ b/packages/core/services/account_service.ts
@@ -1,4 +1,6 @@
-import type { PrismaClient } from '@supaglue/db';
+import { stringify } from 'csv-stringify';
+import { from as copyFrom } from 'pg-copy-streams';
+import { v4 as uuidv4 } from 'uuid';
 import { NotFoundError, UnauthorizedError } from '../errors';
 import { getPaginationParams, getPaginationResult } from '../lib/pagination';
 import { fromAccountModel } from '../mappers';
@@ -11,20 +13,16 @@ import type {
   ListParams,
   PaginatedResult,
 } from '../types';
-import type { RemoteService } from './remote_service';
+import { CommonModelBaseService } from './common_model_base_service';
 
-export class AccountService {
-  #prisma: PrismaClient;
-  #remoteService: RemoteService;
-
-  constructor(prisma: PrismaClient, remoteService: RemoteService) {
-    this.#prisma = prisma;
-    this.#remoteService = remoteService;
+export class AccountService extends CommonModelBaseService {
+  public constructor(...args: ConstructorParameters<typeof CommonModelBaseService>) {
+    super(...args);
   }
 
   // TODO: implement getParams
   public async getById(id: string, connectionId: string, getParams: GetParams): Promise<Account> {
-    const model = await this.#prisma.crmAccount.findUnique({
+    const model = await this.prisma.crmAccount.findUnique({
       where: { id },
     });
     if (!model) {
@@ -40,7 +38,7 @@ export class AccountService {
   public async list(connectionId: string, listParams: ListParams): Promise<PaginatedResult<Account>> {
     const { page_size, cursor, created_after, created_before, updated_after, updated_before } = listParams;
     const pageSize = page_size ? parseInt(page_size) : undefined;
-    const models = await this.#prisma.crmAccount.findMany({
+    const models = await this.prisma.crmAccount.findMany({
       ...getPaginationParams(pageSize, cursor),
       where: {
         connectionId,
@@ -67,9 +65,9 @@ export class AccountService {
   public async create(customerId: string, connectionId: string, createParams: AccountCreateParams): Promise<Account> {
     // TODO: We may want to have better guarantees that we create the record in both our DB
     // and the external integration.
-    const remoteClient = await this.#remoteService.getCrmRemoteClient(connectionId);
+    const remoteClient = await this.remoteService.getCrmRemoteClient(connectionId);
     const remoteAccount = await remoteClient.createAccount(createParams);
-    const accountModel = await this.#prisma.crmAccount.create({
+    const accountModel = await this.prisma.crmAccount.create({
       data: {
         customerId,
         connectionId,
@@ -82,7 +80,7 @@ export class AccountService {
   public async update(customerId: string, connectionId: string, updateParams: AccountUpdateParams): Promise<Account> {
     // TODO: We may want to have better guarantees that we update the record in both our DB
     // and the external integration.
-    const foundAccountModel = await this.#prisma.crmAccount.findUniqueOrThrow({
+    const foundAccountModel = await this.prisma.crmAccount.findUniqueOrThrow({
       where: {
         id: updateParams.id,
       },
@@ -92,13 +90,13 @@ export class AccountService {
       throw new Error('Account customerId does not match');
     }
 
-    const remoteClient = await this.#remoteService.getCrmRemoteClient(connectionId);
+    const remoteClient = await this.remoteService.getCrmRemoteClient(connectionId);
     const remoteAccount = await remoteClient.updateAccount({
       ...updateParams,
       remoteId: foundAccountModel.remoteId,
     });
 
-    const accountModel = await this.#prisma.crmAccount.update({
+    const accountModel = await this.prisma.crmAccount.update({
       data: remoteAccount,
       where: {
         id: updateParams.id,
@@ -107,20 +105,95 @@ export class AccountService {
     return fromAccountModel(accountModel);
   }
 
-  // TODO: We should do this performantly, which may involve COPY to temp table
-  // and bulk upsert from there.
   public async upsertRemoteAccounts(connectionId: string, upsertParamsList: AccountSyncUpsertParams[]): Promise<void> {
-    for (const upsertParams of upsertParamsList) {
-      await this.#prisma.crmAccount.upsert({
-        where: {
-          connectionId_remoteId: {
-            connectionId,
-            remoteId: upsertParams.remoteId,
-          },
-        },
-        update: upsertParams,
-        create: upsertParams,
+    const client = await this.pgPool.connect();
+
+    // TODO: On the first run, we should be able to directly write into the table and skip the temp table
+
+    try {
+      // TODO: Get schema (api) from config
+      const table = 'api.crm_accounts';
+      const tempTable = 'crm_accounts_temp';
+
+      // Create a temporary table
+      // TODO: In the future, we may want to create a permanent table with background reaper
+      // so that we can resume in the case of failure during the COPY stage.
+      // TODO: Maybe we don't need to include all
+      await client.query(`CREATE TEMP TABLE IF NOT EXISTS ${tempTable} (LIKE ${table} INCLUDING ALL)`);
+
+      // TODO: Define columns and mappers elsewhere
+      // Columns
+      const columnsWithoutId = [
+        'owner',
+        'name',
+        'description',
+        'industry',
+        'website',
+        'number_of_employees',
+        'addresses',
+        'phone_numbers',
+        'last_activity_at',
+        'remote_id',
+        'remote_created_at',
+        'remote_updated_at',
+        'remote_was_deleted',
+        'customer_id',
+        'connection_id',
+        'updated_at', // TODO: We should have default for this column in Postgres
+      ];
+      const columns = ['id', ...columnsWithoutId];
+
+      // Output
+      const stream = client.query(
+        copyFrom(`COPY ${tempTable} (${columns.join(',')}) FROM STDIN WITH (DELIMITER ',', FORMAT CSV)`)
+      );
+
+      // Input
+      const convertedUpsertParamsList = upsertParamsList.map((upsertParams) => ({
+        id: uuidv4(),
+        owner: upsertParams.owner,
+        name: upsertParams.name,
+        description: upsertParams.description,
+        industry: upsertParams.industry,
+        website: upsertParams.website,
+        number_of_employees: upsertParams.numberOfEmployees,
+        addresses: upsertParams.addresses,
+        phone_numbers: upsertParams.phoneNumbers,
+        last_activity_at: upsertParams.lastActivityAt?.toISOString(),
+        remote_id: upsertParams.remoteId,
+        remote_created_at: upsertParams.remoteCreatedAt?.toISOString(),
+        remote_updated_at: upsertParams.remoteUpdatedAt?.toISOString(),
+        remote_was_deleted: upsertParams.remoteWasDeleted,
+        customer_id: upsertParams.customerId,
+        connection_id: upsertParams.connectionId,
+        updated_at: new Date().toISOString(),
+      }));
+
+      await new Promise((resolve, reject) => {
+        const csvInput = stringify(
+          convertedUpsertParamsList.map((upsertParams) => ({ ...upsertParams, id: uuidv4() })),
+          {
+            columns,
+            cast: {
+              boolean: (value: boolean) => value.toString(),
+            },
+          }
+        );
+        csvInput.on('error', reject);
+        stream.on('error', reject);
+        stream.on('finish', resolve);
+        csvInput.pipe(stream);
       });
+
+      // Copy from temp table
+      const columnsToUpdate = columnsWithoutId.join(',');
+      const excludedDolumnsToUpdate = columnsWithoutId.map((column) => `EXCLUDED.${column}`).join(',');
+      await client.query(`INSERT INTO ${table}
+SELECT * FROM ${tempTable}
+ON CONFLICT (connection_id, remote_id)
+DO UPDATE SET (${columnsToUpdate}) = (${excludedDolumnsToUpdate})`);
+    } finally {
+      client.release();
     }
   }
 }

--- a/packages/core/services/common_model_base_service.ts
+++ b/packages/core/services/common_model_base_service.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from '@supaglue/db';
+import { Pool } from 'pg';
+import { RemoteService } from './remote_service';
+
+export abstract class CommonModelBaseService {
+  // TODO: Use just pg for common models?
+  protected readonly pgPool: Pool;
+  protected readonly prisma: PrismaClient;
+  protected readonly remoteService: RemoteService;
+
+  // setting constructor as public so that we can use `ConstructorParameters` in child classes
+  public constructor(pgPool: Pool, prisma: PrismaClient, remoteService: RemoteService) {
+    this.pgPool = pgPool;
+    this.prisma = prisma;
+    this.remoteService = remoteService;
+  }
+}

--- a/packages/core/services/lead_service.ts
+++ b/packages/core/services/lead_service.ts
@@ -1,4 +1,6 @@
-import type { PrismaClient } from '@supaglue/db';
+import { stringify } from 'csv-stringify';
+import { from as copyFrom } from 'pg-copy-streams';
+import { v4 as uuidv4 } from 'uuid';
 import { NotFoundError, UnauthorizedError } from '../errors';
 import { POSTGRES_UPDATE_BATCH_SIZE } from '../lib/constants';
 import { getExpandedAssociations } from '../lib/expand';
@@ -13,22 +15,18 @@ import type {
   ListParams,
   PaginatedResult,
 } from '../types';
-import type { RemoteService } from './remote_service';
+import { CommonModelBaseService } from './common_model_base_service';
 
-export class LeadService {
-  #prisma: PrismaClient;
-  #remoteService: RemoteService;
-
-  constructor(prisma: PrismaClient, remoteService: RemoteService) {
-    this.#prisma = prisma;
-    this.#remoteService = remoteService;
+export class LeadService extends CommonModelBaseService {
+  public constructor(...args: ConstructorParameters<typeof CommonModelBaseService>) {
+    super(...args);
   }
 
   // TODO: implement getParams
   public async getById(id: string, connectionId: string, getParams: GetParams): Promise<Lead> {
     const { expand } = getParams;
     const expandedAssociations = getExpandedAssociations(expand);
-    const model = await this.#prisma.crmLead.findUnique({
+    const model = await this.prisma.crmLead.findUnique({
       where: { id },
       include: {
         convertedAccount: expandedAssociations.includes('converted_account'),
@@ -49,7 +47,7 @@ export class LeadService {
     const { page_size, cursor, created_after, created_before, updated_after, updated_before, expand } = listParams;
     const expandedAssociations = getExpandedAssociations(expand);
     const pageSize = page_size ? parseInt(page_size) : undefined;
-    const models = await this.#prisma.crmLead.findMany({
+    const models = await this.prisma.crmLead.findMany({
       ...getPaginationParams(pageSize, cursor),
       where: {
         connectionId,
@@ -80,9 +78,9 @@ export class LeadService {
   public async create(customerId: string, connectionId: string, createParams: LeadCreateParams): Promise<Lead> {
     // TODO: We may want to have better guarantees that we update the record in both our DB
     // and the external integration.
-    const remoteClient = await this.#remoteService.getCrmRemoteClient(connectionId);
+    const remoteClient = await this.remoteService.getCrmRemoteClient(connectionId);
     const remoteLead = await remoteClient.createLead(createParams);
-    const leadModel = await this.#prisma.crmLead.create({
+    const leadModel = await this.prisma.crmLead.create({
       data: {
         customerId,
         connectionId,
@@ -95,7 +93,7 @@ export class LeadService {
   public async update(customerId: string, connectionId: string, updateParams: LeadUpdateParams): Promise<Lead> {
     // TODO: We may want to have better guarantees that we update the record in both our DB
     // and the external integration.
-    const foundLeadModel = await this.#prisma.crmLead.findUniqueOrThrow({
+    const foundLeadModel = await this.prisma.crmLead.findUniqueOrThrow({
       where: {
         id: updateParams.id,
       },
@@ -105,13 +103,13 @@ export class LeadService {
       throw new Error('Lead customerId does not match');
     }
 
-    const remoteClient = await this.#remoteService.getCrmRemoteClient(connectionId);
+    const remoteClient = await this.remoteService.getCrmRemoteClient(connectionId);
     const remoteLead = await remoteClient.updateLead({
       ...updateParams,
       remoteId: foundLeadModel.remoteId,
     });
 
-    const leadModel = await this.#prisma.crmLead.update({
+    const leadModel = await this.prisma.crmLead.update({
       data: remoteLead,
       where: {
         id: updateParams.id,
@@ -120,20 +118,100 @@ export class LeadService {
     return fromLeadModel(leadModel);
   }
 
-  // TODO: We should do this performantly, which may involve COPY to temp table
-  // and bulk upsert from there.
   public async upsertRemoteLeads(connectionId: string, upsertParamsList: LeadSyncUpsertParams[]): Promise<void> {
-    for (const upsertParams of upsertParamsList) {
-      await this.#prisma.crmLead.upsert({
-        where: {
-          connectionId_remoteId: {
-            connectionId,
-            remoteId: upsertParams.remoteId,
-          },
-        },
-        update: upsertParams,
-        create: upsertParams,
+    const client = await this.pgPool.connect();
+
+    // TODO: On the first run, we should be able to directly write into the table and skip the temp table
+
+    try {
+      // TODO: Get schema (api) from config
+      const table = 'api.crm_leads';
+      const tempTable = 'crm_leads_temp';
+
+      // Create a temporary table
+      // TODO: In the future, we may want to create a permanent table with background reaper
+      // so that we can resume in the case of failure during the COPY stage.
+      // TODO: Maybe we don't need to include all
+      await client.query(`CREATE TEMP TABLE IF NOT EXISTS ${tempTable} (LIKE ${table} INCLUDING ALL)`);
+
+      // TODO: Define columns and mappers elsewhere
+      // Columns
+      const columnsWithoutId = [
+        'remote_id',
+        'customer_id',
+        'connection_id',
+        'remote_was_deleted',
+        'owner',
+        'lead_source',
+        'title',
+        'company',
+        'first_name',
+        'last_name',
+        'addresses',
+        'phone_numbers',
+        'email_addresses',
+        'remote_created_at',
+        'remote_updated_at',
+        'converted_date',
+        '_converted_remote_account_id',
+        '_converted_remote_contact_id',
+        'updated_at', // TODO: We should have default for this column in Postgres
+      ];
+      const columns = ['id', ...columnsWithoutId];
+
+      // Output
+      const stream = client.query(
+        copyFrom(`COPY ${tempTable} (${columns.join(',')}) FROM STDIN WITH (DELIMITER ',', FORMAT CSV)`)
+      );
+
+      // Input
+      const convertedUpsertParamsList = upsertParamsList.map((upsertParams) => ({
+        id: uuidv4(),
+        remote_id: upsertParams.remoteId,
+        customer_id: upsertParams.customerId,
+        connection_id: upsertParams.connectionId,
+        remote_was_deleted: upsertParams.remoteWasDeleted,
+        owner: upsertParams.owner,
+        lead_source: upsertParams.leadSource,
+        title: upsertParams.title,
+        company: upsertParams.company,
+        first_name: upsertParams.firstName,
+        last_name: upsertParams.lastName,
+        addresses: upsertParams.addresses,
+        email_addresses: upsertParams.emailAddresses,
+        remote_created_at: upsertParams.remoteCreatedAt?.toISOString(),
+        remote_updated_at: upsertParams.remoteUpdatedAt?.toISOString(),
+        converted_date: upsertParams.convertedDate?.toISOString(),
+        _converted_remote_account_id: upsertParams.convertedRemoteAccountId,
+        _converted_remote_contact_id: upsertParams.convertedRemoteContactId,
+        updated_at: new Date().toISOString(),
+      }));
+
+      await new Promise((resolve, reject) => {
+        const csvInput = stringify(
+          convertedUpsertParamsList.map((upsertParams) => ({ ...upsertParams, id: uuidv4() })),
+          {
+            columns,
+            cast: {
+              boolean: (value: boolean) => value.toString(),
+            },
+          }
+        );
+        csvInput.on('error', reject);
+        stream.on('error', reject);
+        stream.on('finish', resolve);
+        csvInput.pipe(stream);
       });
+
+      // Copy from temp table
+      const columnsToUpdate = columnsWithoutId.join(',');
+      const excludedDolumnsToUpdate = columnsWithoutId.map((column) => `EXCLUDED.${column}`).join(',');
+      await client.query(`INSERT INTO ${table}
+SELECT * FROM ${tempTable}
+ON CONFLICT (connection_id, remote_id)
+DO UPDATE SET (${columnsToUpdate}) = (${excludedDolumnsToUpdate})`);
+    } finally {
+      client.release();
     }
   }
 
@@ -142,7 +220,7 @@ export class LeadService {
     limit: number,
     cursor?: string
   ): Promise<string | undefined> {
-    const leadsWithDanglingAccounts = await this.#prisma.crmLead.findMany({
+    const leadsWithDanglingAccounts = await this.prisma.crmLead.findMany({
       where: {
         connectionId,
         convertedAccountId: null,
@@ -164,7 +242,7 @@ export class LeadService {
     const danglingRemoteAccountIds = leadsWithDanglingAccounts.map(
       ({ convertedRemoteAccountId }) => convertedRemoteAccountId
     ) as string[];
-    const crmAccounts = await this.#prisma.crmAccount.findMany({
+    const crmAccounts = await this.prisma.crmAccount.findMany({
       where: {
         connectionId,
         remoteId: {
@@ -174,7 +252,7 @@ export class LeadService {
     });
     await Promise.all(
       crmAccounts.map(({ remoteId, id }) => {
-        return this.#prisma.crmLead.updateMany({
+        return this.prisma.crmLead.updateMany({
           where: {
             connectionId,
             convertedRemoteAccountId: remoteId,
@@ -200,7 +278,7 @@ export class LeadService {
     limit: number,
     cursor?: string
   ): Promise<string | undefined> {
-    const leadsWithDanglingContacts = await this.#prisma.crmLead.findMany({
+    const leadsWithDanglingContacts = await this.prisma.crmLead.findMany({
       where: {
         connectionId,
         convertedContactId: null,
@@ -222,7 +300,7 @@ export class LeadService {
     const danglingRemoteContactIds = leadsWithDanglingContacts.map(
       ({ convertedRemoteContactId }) => convertedRemoteContactId
     ) as string[];
-    const crmContacts = await this.#prisma.crmContact.findMany({
+    const crmContacts = await this.prisma.crmContact.findMany({
       where: {
         connectionId,
         remoteId: {
@@ -232,7 +310,7 @@ export class LeadService {
     });
     await Promise.all(
       crmContacts.map(({ remoteId, id }) => {
-        return this.#prisma.crmLead.updateMany({
+        return this.prisma.crmLead.updateMany({
           where: {
             connectionId,
             convertedRemoteContactId: remoteId,

--- a/packages/core/services/opportunity_service.ts
+++ b/packages/core/services/opportunity_service.ts
@@ -1,4 +1,6 @@
-import type { PrismaClient } from '@supaglue/db';
+import { stringify } from 'csv-stringify';
+import { from as copyFrom } from 'pg-copy-streams';
+import { v4 as uuidv4 } from 'uuid';
 import { NotFoundError, UnauthorizedError } from '../errors';
 import { POSTGRES_UPDATE_BATCH_SIZE } from '../lib/constants';
 import { getExpandedAssociations } from '../lib/expand';
@@ -13,22 +15,18 @@ import type {
   OpportunityUpdateParams,
   PaginatedResult,
 } from '../types';
-import type { RemoteService } from './remote_service';
+import { CommonModelBaseService } from './common_model_base_service';
 
-export class OpportunityService {
-  #prisma: PrismaClient;
-  #remoteService: RemoteService;
-
-  constructor(prisma: PrismaClient, remoteService: RemoteService) {
-    this.#prisma = prisma;
-    this.#remoteService = remoteService;
+export class OpportunityService extends CommonModelBaseService {
+  public constructor(...args: ConstructorParameters<typeof CommonModelBaseService>) {
+    super(...args);
   }
 
   // TODO: implement getParams
   public async getById(id: string, connectionId: string, getParams: GetParams): Promise<Opportunity> {
     const { expand } = getParams;
     const expandedAssociations = getExpandedAssociations(expand);
-    const model = await this.#prisma.crmOpportunity.findUnique({
+    const model = await this.prisma.crmOpportunity.findUnique({
       where: { id },
       include: {
         account: expandedAssociations.includes('account'),
@@ -48,7 +46,7 @@ export class OpportunityService {
     const { page_size, cursor, created_after, created_before, updated_after, updated_before, expand } = listParams;
     const expandedAssociations = getExpandedAssociations(expand);
     const pageSize = page_size ? parseInt(page_size) : undefined;
-    const models = await this.#prisma.crmOpportunity.findMany({
+    const models = await this.prisma.crmOpportunity.findMany({
       ...getPaginationParams(pageSize, cursor),
       where: {
         connectionId,
@@ -76,7 +74,7 @@ export class OpportunityService {
   }
 
   private async getAssociatedAccountRemoteId(accountId: string): Promise<string> {
-    const crmAccount = await this.#prisma.crmAccount.findUnique({
+    const crmAccount = await this.prisma.crmAccount.findUnique({
       where: {
         id: accountId,
       },
@@ -98,9 +96,9 @@ export class OpportunityService {
     if (createParams.accountId) {
       remoteCreateParams.accountId = await this.getAssociatedAccountRemoteId(createParams.accountId);
     }
-    const remoteClient = await this.#remoteService.getCrmRemoteClient(connectionId);
+    const remoteClient = await this.remoteService.getCrmRemoteClient(connectionId);
     const remoteOpportunity = await remoteClient.createOpportunity(remoteCreateParams);
-    const opportunityModel = await this.#prisma.crmOpportunity.create({
+    const opportunityModel = await this.prisma.crmOpportunity.create({
       data: {
         customerId,
         connectionId,
@@ -118,7 +116,7 @@ export class OpportunityService {
   ): Promise<Opportunity> {
     // TODO: We may want to have better guarantees that we update the record in both our DB
     // and the external integration.
-    const foundOpportunityModel = await this.#prisma.crmOpportunity.findUniqueOrThrow({
+    const foundOpportunityModel = await this.prisma.crmOpportunity.findUniqueOrThrow({
       where: {
         id: updateParams.id,
       },
@@ -133,13 +131,13 @@ export class OpportunityService {
       remoteUpdateParams.accountId = await this.getAssociatedAccountRemoteId(updateParams.accountId);
     }
 
-    const remoteClient = await this.#remoteService.getCrmRemoteClient(connectionId);
+    const remoteClient = await this.remoteService.getCrmRemoteClient(connectionId);
     const remoteOpportunity = await remoteClient.updateOpportunity({
       ...remoteUpdateParams,
       remoteId: foundOpportunityModel.remoteId,
     });
 
-    const opportunityModel = await this.#prisma.crmOpportunity.update({
+    const opportunityModel = await this.prisma.crmOpportunity.update({
       data: { ...remoteOpportunity, accountId: updateParams.accountId },
       where: {
         id: updateParams.id,
@@ -148,23 +146,98 @@ export class OpportunityService {
     return fromOpportunityModel(opportunityModel);
   }
 
-  // TODO: We should do this performantly, which may involve COPY to temp table
-  // and bulk upsert from there.
   public async upsertRemoteOpportunities(
     connectionId: string,
     upsertParamsList: OpportunitySyncUpsertParams[]
   ): Promise<void> {
-    for (const upsertParams of upsertParamsList) {
-      await this.#prisma.crmOpportunity.upsert({
-        where: {
-          connectionId_remoteId: {
-            connectionId,
-            remoteId: upsertParams.remoteId,
-          },
-        },
-        update: upsertParams,
-        create: upsertParams,
+    const client = await this.pgPool.connect();
+
+    // TODO: On the first run, we should be able to directly write into the table and skip the temp table
+
+    try {
+      // TODO: Get schema (api) from config
+      const table = 'api.crm_opportunities';
+      const tempTable = 'crm_opportunities_temp';
+
+      // Create a temporary table
+      // TODO: In the future, we may want to create a permanent table with background reaper
+      // so that we can resume in the case of failure during the COPY stage.
+      // TODO: Maybe we don't need to include all
+      await client.query(`CREATE TEMP TABLE IF NOT EXISTS ${tempTable} (LIKE ${table} INCLUDING ALL)`);
+
+      // TODO: Define columns and mappers elsewhere
+      // Columns
+      const columnsWithoutId = [
+        'remote_id',
+        'customer_id',
+        'connection_id',
+        'remote_was_deleted',
+        'owner',
+        'name',
+        'description',
+        'amount',
+        'stage',
+        'status',
+        'last_activity_at',
+        'close_date',
+        'remote_created_at',
+        'remote_updated_at',
+        '_remote_account_id',
+        'updated_at', // TODO: We should have default for this column in Postgres
+      ];
+      const columns = ['id', ...columnsWithoutId];
+
+      // Output
+      const stream = client.query(
+        copyFrom(`COPY ${tempTable} (${columns.join(',')}) FROM STDIN WITH (DELIMITER ',', FORMAT CSV)`)
+      );
+
+      // Input
+      const convertedUpsertParamsList = upsertParamsList.map((upsertParams) => ({
+        id: uuidv4(),
+        remote_id: upsertParams.remoteId,
+        customer_id: upsertParams.customerId,
+        connection_id: upsertParams.connectionId,
+        remote_was_deleted: upsertParams.remoteWasDeleted,
+        owner: upsertParams.owner,
+        name: upsertParams.name,
+        description: upsertParams.description,
+        amount: upsertParams.amount,
+        stage: upsertParams.stage,
+        status: upsertParams.status,
+        last_activity_at: upsertParams.lastActivityAt?.toISOString(),
+        close_date: upsertParams.closeDate?.toISOString(),
+        remote_created_at: upsertParams.remoteCreatedAt?.toISOString(),
+        remote_updated_at: upsertParams.remoteUpdatedAt?.toISOString(),
+        _remote_account_id: upsertParams.remoteAccountId,
+        updated_at: new Date().toISOString(),
+      }));
+
+      await new Promise((resolve, reject) => {
+        const csvInput = stringify(
+          convertedUpsertParamsList.map((upsertParams) => ({ ...upsertParams, id: uuidv4() })),
+          {
+            columns,
+            cast: {
+              boolean: (value: boolean) => value.toString(),
+            },
+          }
+        );
+        csvInput.on('error', reject);
+        stream.on('error', reject);
+        stream.on('finish', resolve);
+        csvInput.pipe(stream);
       });
+
+      // Copy from temp table
+      const columnsToUpdate = columnsWithoutId.join(',');
+      const excludedDolumnsToUpdate = columnsWithoutId.map((column) => `EXCLUDED.${column}`).join(',');
+      await client.query(`INSERT INTO ${table}
+SELECT * FROM ${tempTable}
+ON CONFLICT (connection_id, remote_id)
+DO UPDATE SET (${columnsToUpdate}) = (${excludedDolumnsToUpdate})`);
+    } finally {
+      client.release();
     }
   }
 
@@ -173,7 +246,7 @@ export class OpportunityService {
     limit: number,
     cursor?: string
   ): Promise<string | undefined> {
-    const opportunitiesWithDanglingAccounts = await this.#prisma.crmOpportunity.findMany({
+    const opportunitiesWithDanglingAccounts = await this.prisma.crmOpportunity.findMany({
       where: {
         connectionId,
         accountId: null,
@@ -195,7 +268,7 @@ export class OpportunityService {
     const danglingRemoteAccountIds = opportunitiesWithDanglingAccounts.map(
       ({ remoteAccountId }) => remoteAccountId
     ) as string[];
-    const crmAccounts = await this.#prisma.crmAccount.findMany({
+    const crmAccounts = await this.prisma.crmAccount.findMany({
       where: {
         connectionId,
         remoteId: {
@@ -205,7 +278,7 @@ export class OpportunityService {
     });
     await Promise.all(
       crmAccounts.map(({ remoteId, id }) => {
-        return this.#prisma.crmOpportunity.updateMany({
+        return this.prisma.crmOpportunity.updateMany({
           where: {
             connectionId,
             remoteAccountId: remoteId,

--- a/packages/db/prisma/migrations/20230307235714_camelcase/migration.sql
+++ b/packages/db/prisma/migrations/20230307235714_camelcase/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `firstName` on the `crm_leads` table. All the data in the column will be lost.
+  - You are about to drop the column `lastName` on the `crm_leads` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "crm_leads" DROP COLUMN "firstName",
+DROP COLUMN "lastName",
+ADD COLUMN     "first_name" VARCHAR(255),
+ADD COLUMN     "last_name" VARCHAR(255);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -118,8 +118,8 @@ model CrmLead {
   leadSource               String?     @map("lead_source") @db.VarChar(255)
   title                    String?     @db.VarChar(255)
   company                  String?     @db.VarChar(255)
-  firstName                String?     @db.VarChar(255)
-  lastName                 String?     @db.VarChar(255)
+  firstName                String?     @db.VarChar(255) @map("first_name")
+  lastName                 String?     @db.VarChar(255) @map("last_name")
   addresses                Json?
   phoneNumbers             Json?       @map("phone_numbers")
   emailAddresses           Json?       @map("email_addresses")

--- a/yarn.lock
+++ b/yarn.lock
@@ -3305,10 +3305,17 @@ __metadata:
     "@supaglue/db": "workspace:*"
     "@tsconfig/node18": ^1.0.1
     "@types/async-retry": ^1
+    "@types/pg": ^8
+    "@types/pg-copy-streams": ^1.2.2
+    "@types/uuid": ^9.0.1
     async-retry: ^1.3.3
     csv-parse: ^5.3.5
+    csv-stringify: ^6.3.0
     jsforce: ^2.0.0-beta.20
+    pg: ^8.10.0
+    pg-copy-streams: ^6.0.5
     typescript: ^4.9.5
+    uuid: ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -4062,6 +4069,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/pg-copy-streams@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@types/pg-copy-streams@npm:1.2.2"
+  dependencies:
+    "@types/node": "*"
+    "@types/pg": "*"
+  checksum: 601a9295d122a1a7307b4730c5811e71003653d58aa7d1423a0311c09f763f8f2183a5fc82e5fb53375b2d1679c43805f5fe316e88dcae2eaf9ec7c1e0676e5f
+  languageName: node
+  linkType: hard
+
+"@types/pg@npm:*, @types/pg@npm:^8":
+  version: 8.6.6
+  resolution: "@types/pg@npm:8.6.6"
+  dependencies:
+    "@types/node": "*"
+    pg-protocol: "*"
+    pg-types: ^2.2.0
+  checksum: ac145553a8ad2f357feacad1bceaf5d6ce904eb9d66233b84c469a2b4fa3738d4ebdf29b7ea45387be2d07f915fd873a229f90a2f766d7c377afa7c41fbcf8d1
+  languageName: node
+  linkType: hard
+
 "@types/prettier@npm:^2":
   version: 2.7.2
   resolution: "@types/prettier@npm:2.7.2"
@@ -4225,6 +4253,13 @@ __metadata:
   version: 9.0.0
   resolution: "@types/uuid@npm:9.0.0"
   checksum: 59ae56d9547c8758588659da2a2b4c97cce79c2aae1798c892bb29452ef08e87859dea2ec3a66bfa88d0d2153147520be2b1893be920f9f0bc9c53a3207ea6aa
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "@types/uuid@npm:9.0.1"
+  checksum: c472b8a77cbeded4bc529220b8611afa39bd64677f507838f8083d8aac8033b1f88cb9ddaa2f8589e0dcd2317291d0f6e1379f82d5ceebd6f74f3b4825288e00
   languageName: node
   linkType: hard
 
@@ -5385,6 +5420,13 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  languageName: node
+  linkType: hard
+
+"buffer-writer@npm:2.0.0":
+  version: 2.0.0
+  resolution: "buffer-writer@npm:2.0.0"
+  checksum: 11736b48bb75106c52ca8ec9f025e7c1b3b25ce31875f469d7210eabd5c576c329e34f6b805d4a8d605ff3f0db1e16342328802c4c963e9c826b0e43a4e631c2
   languageName: node
   linkType: hard
 
@@ -6584,6 +6626,13 @@ __metadata:
   version: 5.6.5
   resolution: "csv-stringify@npm:5.6.5"
   checksum: f93e1444857416081de3d86765b62e4c4f7c110974ad6bbcb0031d7db39b6624847ac9ee5705726e7011346f32f3696f27299b74b23a6c2b083adff0dd2755fe
+  languageName: node
+  linkType: hard
+
+"csv-stringify@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "csv-stringify@npm:6.3.0"
+  checksum: d2503ad298b6f432bae5932af365fb1a5f8f51b31a170d8e1c0735cb89193cb665976754612800c3302570bf7086749d60a30d97d820cc3a7c9b7cd4a49fd311
   languageName: node
   linkType: hard
 
@@ -11290,6 +11339,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"packet-reader@npm:1.0.0":
+  version: 1.0.0
+  resolution: "packet-reader@npm:1.0.0"
+  checksum: 0b7516f0cbf3e322aad591bed29ba544220088c53943145c0d9121a6f59182ad811f7fd6785a8979a34356aca69d97653689029964c5998dc02645633d88ffd7
+  languageName: node
+  linkType: hard
+
 "param-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "param-case@npm:3.0.4"
@@ -11489,6 +11545,87 @@ __metadata:
   version: 1.5.5
   resolution: "perfect-scrollbar@npm:1.5.5"
   checksum: 7a8d3097e91df1dd112f28ee9539c1a36ae7a836d986798af2e0d1e32c3ef21380215b3c06bc12434d89547d7f763637ac19b877549049b6c2166da85956c9dc
+  languageName: node
+  linkType: hard
+
+"pg-connection-string@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "pg-connection-string@npm:2.5.0"
+  checksum: a6f3a068f7c9416a5b33a326811caf0dfaaee045c225b7c628b4c9b4e9a2b25bdd12a21e4c48940e1000ea223a4e608ca122d2ff3dd08c8b1db0fc9f5705133a
+  languageName: node
+  linkType: hard
+
+"pg-copy-streams@npm:^6.0.5":
+  version: 6.0.5
+  resolution: "pg-copy-streams@npm:6.0.5"
+  dependencies:
+    obuf: ^1.1.2
+  checksum: 45074d8b366a0f572af628cbf5831b834653856f7945b1e11541bc1b81609b464d636d344b6f60b2c6b836328e9b2faa48e1add5f9adc3c6ca4591ebbea96e5d
+  languageName: node
+  linkType: hard
+
+"pg-int8@npm:1.0.1":
+  version: 1.0.1
+  resolution: "pg-int8@npm:1.0.1"
+  checksum: a1e3a05a69005ddb73e5f324b6b4e689868a447c5fa280b44cd4d04e6916a344ac289e0b8d2695d66e8e89a7fba023affb9e0e94778770ada5df43f003d664c9
+  languageName: node
+  linkType: hard
+
+"pg-pool@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "pg-pool@npm:3.6.0"
+  peerDependencies:
+    pg: ">=8.0"
+  checksum: f3fe050fbfe27406369340c4c26efcbe21a388ace085a876453de0ea496a315c38b2dc739ac97d4767a359e911da2ec4810467f72601eeec8ad540e58b27987c
+  languageName: node
+  linkType: hard
+
+"pg-protocol@npm:*, pg-protocol@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "pg-protocol@npm:1.6.0"
+  checksum: e12662d2de2011e0c3a03f6a09f435beb1025acdc860f181f18a600a5495dc38a69d753bbde1ace279c8c442536af9c1a7c11e1d0fe3fad3aa1348b28d9d2683
+  languageName: node
+  linkType: hard
+
+"pg-types@npm:^2.1.0, pg-types@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "pg-types@npm:2.2.0"
+  dependencies:
+    pg-int8: 1.0.1
+    postgres-array: ~2.0.0
+    postgres-bytea: ~1.0.0
+    postgres-date: ~1.0.4
+    postgres-interval: ^1.1.0
+  checksum: bf4ec3f594743442857fb3a8dfe5d2478a04c98f96a0a47365014557cbc0b4b0cee01462c79adca863b93befbf88f876299b75b72c665b5fb84a2c94fbd10316
+  languageName: node
+  linkType: hard
+
+"pg@npm:^8.10.0":
+  version: 8.10.0
+  resolution: "pg@npm:8.10.0"
+  dependencies:
+    buffer-writer: 2.0.0
+    packet-reader: 1.0.0
+    pg-connection-string: ^2.5.0
+    pg-pool: ^3.6.0
+    pg-protocol: ^1.6.0
+    pg-types: ^2.1.0
+    pgpass: 1.x
+  peerDependencies:
+    pg-native: ">=3.0.1"
+  peerDependenciesMeta:
+    pg-native:
+      optional: true
+  checksum: c6be78f2e823f2ae3c618c8e54a6622592dd71b556fb665d7eaedcbcc2fa5d210a8bcf519401e72526a65b9d797f19b772f48f29b9d9f31e98dd526fd27d61e0
+  languageName: node
+  linkType: hard
+
+"pgpass@npm:1.x":
+  version: 1.0.5
+  resolution: "pgpass@npm:1.0.5"
+  dependencies:
+    split2: ^4.1.0
+  checksum: 947ac096c031eebdf08d989de2e9f6f156b8133d6858c7c2c06c041e1e71dda6f5f3bad3c0ec1e96a09497bbc6ef89e762eefe703b5ef9cb2804392ec52ec400
   languageName: node
   linkType: hard
 
@@ -12146,6 +12283,36 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: e39ac60ccd1542d4f9d93d894048aac0d686b3bb38e927d8386005718e6793dbbb46930f0a523fe382f1bbd843c6d980aaea791252bf5e176180e5a4336d9679
+  languageName: node
+  linkType: hard
+
+"postgres-array@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "postgres-array@npm:2.0.0"
+  checksum: 0e1e659888147c5de579d229a2d95c0d83ebdbffc2b9396d890a123557708c3b758a0a97ed305ce7f58edfa961fa9f0bbcd1ea9f08b6e5df73322e683883c464
+  languageName: node
+  linkType: hard
+
+"postgres-bytea@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "postgres-bytea@npm:1.0.0"
+  checksum: d844ae4ca7a941b70e45cac1261a73ee8ed39d72d3d74ab1d645248185a1b7f0ac91a3c63d6159441020f4e1f7fe64689ac56536a307b31cef361e5187335090
+  languageName: node
+  linkType: hard
+
+"postgres-date@npm:~1.0.4":
+  version: 1.0.7
+  resolution: "postgres-date@npm:1.0.7"
+  checksum: 5745001d47e51cd767e46bcb1710649cd705d91a24d42fa661c454b6dcbb7353c066a5047983c90a626cd3bbfea9e626cc6fa84a35ec57e5bbb28b49f78e13ed
+  languageName: node
+  linkType: hard
+
+"postgres-interval@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "postgres-interval@npm:1.2.0"
+  dependencies:
+    xtend: ^4.0.0
+  checksum: 746b71f93805ae33b03528e429dc624706d1f9b20ee81bf743263efb6a0cd79ae02a642a8a480dbc0f09547b4315ab7df6ce5ec0be77ed700bac42730f5c76b2
   languageName: node
   linkType: hard
 
@@ -14085,7 +14252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"split2@npm:^4.0.0":
+"split2@npm:^4.0.0, split2@npm:^4.1.0":
   version: 4.1.0
   resolution: "split2@npm:4.1.0"
   checksum: ec581597cb74c13cdfb5e2047543dd40cb1e8e9803c7b1e0c29ede05f2b4f049b2d6e7f2788a225d544549375719658b8f38e9366364dec35dc7a12edfda5ee5


### PR DESCRIPTION
there is still a lot more to do here. for example:
- we manually list out columns right now. maybe we can get them from prisma somehow, or we should ditch prisma for common model
- we should stream data into COPY from SF instead of doing things serially (pipelining)
- on initial load, we can avoid doing the temp table COPY and just write directly to the common model table
- don't manually write `api` schema. rely on config instead