### PR TITLE
fix: broken openapi specs/validation middleware

### DIFF
--- a/apps/api/routes/mgmt/v1/customer/index.ts
+++ b/apps/api/routes/mgmt/v1/customer/index.ts
@@ -1,7 +1,6 @@
 import { getDependencyContainer } from '@/dependency_container';
 import { camelcaseKeys } from '@/lib/camelcase';
 import { snakecaseKeys } from '@/lib/snakecase';
-import { openapiMiddleware } from '@/middleware/openapi';
 import {
   CreateCustomerPathParams,
   CreateCustomerRequest,
@@ -23,7 +22,6 @@ const { customerService } = getDependencyContainer();
 
 export default function init(app: Router): void {
   const customerRouter = Router();
-  customerRouter.use(openapiMiddleware('customer'));
 
   customerRouter.get(
     '/',

--- a/apps/api/routes/mgmt/v1/index.ts
+++ b/apps/api/routes/mgmt/v1/index.ts
@@ -1,9 +1,12 @@
+import { openapiMiddleware } from '@/middleware/openapi';
 import { Router } from 'express';
 import customer from './customer';
 import integration from './integration';
 
 export default function init(app: Router): void {
   const v1Router = Router();
+
+  v1Router.use(openapiMiddleware('mgmt'));
 
   customer(v1Router);
   integration(v1Router);

--- a/openapi/crm/components/schemas/objects/account.yaml
+++ b/openapi/crm/components/schemas/objects/account.yaml
@@ -46,46 +46,47 @@ properties:
     type: string
     nullable: true
     example: https://supaglue.com/
-example:
-  - addresses:
-      - address_type: Shipping
-        city: San Francisco
-        country: US
-        postal_code: '94107'
-        state: CA
-        street_1: 525 Brannan
-        street_2: ~
-    description: Integration API
-    id: e888cedf-e9d0-42c5-9485-2d72984faef2
-    industry: APIs
-    last_activity_at: '2022-02-10T00:00:00Z'
-    name: Sample Customer
-    number_of_employees: 224
-    owner: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
-    phone_numbers:
-      - phone_number: '+14151234567'
-        phone_number_type: Mobile
-    created_at: '2022-02-27T00:00:00Z'
-    updated_at: '2022-02-27T00:00:00Z'
-    website: https://supaglue.com/
-  - addresses:
-      - address_type: Shipping
-        city: San Francisco
-        country: US
-        postal_code: '94107'
-        state: CA
-        street_1: 525 Brannan
-        street_2: ~
-    description: Integration API
-    id: 3bde961a-90da-4daa-ab2e-cc4498c460f9
-    industry: APIs
-    last_activity_at: '2022-02-27T00:00:00Z'
-    name: Sample Customer
-    number_of_employees: 1000
-    owner: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
-    phone_numbers:
-      - phone_number: '+14151234567'
-        phone_number_type: Mobile
-    created_at: '2022-02-27T00:00:00Z'
-    updated_at: '2022-02-27T00:00:00Z'
-    website: https://supaglue.com/
+# Multiple examples are only supported in OpenAPI 3.1.0, and this is the wrong format
+# example:
+#   - addresses:
+#       - address_type: Shipping
+#         city: San Francisco
+#         country: US
+#         postal_code: '94107'
+#         state: CA
+#         street_1: 525 Brannan
+#         street_2: ~
+#     description: Integration API
+#     id: e888cedf-e9d0-42c5-9485-2d72984faef2
+#     industry: APIs
+#     last_activity_at: '2022-02-10T00:00:00Z'
+#     name: Sample Customer
+#     number_of_employees: 224
+#     owner: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+#     phone_numbers:
+#       - phone_number: '+14151234567'
+#         phone_number_type: Mobile
+#     created_at: '2022-02-27T00:00:00Z'
+#     updated_at: '2022-02-27T00:00:00Z'
+#     website: https://supaglue.com/
+#   - addresses:
+#       - address_type: Shipping
+#         city: San Francisco
+#         country: US
+#         postal_code: '94107'
+#         state: CA
+#         street_1: 525 Brannan
+#         street_2: ~
+#     description: Integration API
+#     id: 3bde961a-90da-4daa-ab2e-cc4498c460f9
+#     industry: APIs
+#     last_activity_at: '2022-02-27T00:00:00Z'
+#     name: Sample Customer
+#     number_of_employees: 1000
+#     owner: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+#     phone_numbers:
+#       - phone_number: '+14151234567'
+#         phone_number_type: Mobile
+#     created_at: '2022-02-27T00:00:00Z'
+#     updated_at: '2022-02-27T00:00:00Z'
+#     website: https://supaglue.com/

--- a/openapi/crm/openapi.bundle.json
+++ b/openapi/crm/openapi.bundle.json
@@ -123,7 +123,7 @@
                             }
                           ],
                           "description": "Integration API",
-                          "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
+                          "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6b",
                           "industry": "APIs",
                           "last_activity_at": "2023-02-27T00:00:00Z",
                           "name": "Sample Customer",
@@ -253,7 +253,7 @@
                         }
                       ],
                       "description": "Integration API",
-                      "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
+                      "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6c",
                       "industry": "API's",
                       "last_activity_at": "2022-02-10T00:00:00Z",
                       "name": "Supaglue",
@@ -1520,67 +1520,7 @@
             "nullable": true,
             "example": "https://supaglue.com/"
           }
-        },
-        "example": [
-          {
-            "addresses": [
-              {
-                "address_type": "Shipping",
-                "city": "San Francisco",
-                "country": "US",
-                "postal_code": "94107",
-                "state": "CA",
-                "street_1": "525 Brannan",
-                "street_2": null
-              }
-            ],
-            "description": "Integration API",
-            "id": "e888cedf-e9d0-42c5-9485-2d72984faef2",
-            "industry": "APIs",
-            "last_activity_at": "2022-02-10T00:00:00Z",
-            "name": "Sample Customer",
-            "number_of_employees": 224,
-            "owner": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
-            "phone_numbers": [
-              {
-                "phone_number": "+14151234567",
-                "phone_number_type": "Mobile"
-              }
-            ],
-            "created_at": "2022-02-27T00:00:00Z",
-            "updated_at": "2022-02-27T00:00:00Z",
-            "website": "https://supaglue.com/"
-          },
-          {
-            "addresses": [
-              {
-                "address_type": "Shipping",
-                "city": "San Francisco",
-                "country": "US",
-                "postal_code": "94107",
-                "state": "CA",
-                "street_1": "525 Brannan",
-                "street_2": null
-              }
-            ],
-            "description": "Integration API",
-            "id": "3bde961a-90da-4daa-ab2e-cc4498c460f9",
-            "industry": "APIs",
-            "last_activity_at": "2022-02-27T00:00:00Z",
-            "name": "Sample Customer",
-            "number_of_employees": 1000,
-            "owner": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
-            "phone_numbers": [
-              {
-                "phone_number": "+14151234567",
-                "phone_number_type": "Mobile"
-              }
-            ],
-            "created_at": "2022-02-27T00:00:00Z",
-            "updated_at": "2022-02-27T00:00:00Z",
-            "website": "https://supaglue.com/"
-          }
-        ]
+        }
       },
       "create_update_account": {
         "type": "object",

--- a/openapi/crm/paths/accounts.yaml
+++ b/openapi/crm/paths/accounts.yaml
@@ -63,7 +63,7 @@ get:
                         street_1: 525 Brannan
                         street_2: ~
                     description: Integration API
-                    id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
+                    id: 9572d08b-f19f-48cc-a992-1eb7031d3f6b
                     industry: APIs
                     last_activity_at: '2023-02-27T00:00:00Z'
                     name: Sample Customer

--- a/openapi/crm/paths/accounts@{account_id}.yaml
+++ b/openapi/crm/paths/accounts@{account_id}.yaml
@@ -31,7 +31,7 @@ get:
                     street_1: 525 Brannan
                     street_2: ~
                 description: Integration API
-                id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
+                id: 9572d08b-f19f-48cc-a992-1eb7031d3f6c
                 industry: API's
                 last_activity_at: '2022-02-10T00:00:00Z'
                 name: Supaglue

--- a/openapi/mgmt/components/schemas/objects/connection.yaml
+++ b/openapi/mgmt/components/schemas/objects/connection.yaml
@@ -31,16 +31,17 @@ required:
   - credentials
   - provider_name
   - category
-example:
-  - id: e888cedf-e9d0-42c5-9485-2d72984faef2
-    customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69 
-    status: available
-    integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
-    provider_name: salesforce
-    category: crm
-    credentials:
-    - type: oauth2
-      access_token: 00DDn000004L1rN!AQwAQFcdcvZCaMN83FUDEI5BHyjWILUCMH91UOX7xPVAgn2DjT9LrYTX8RT9vSQ281kBUtQBNsjBKC6R4lIlQTLLvCTuYxtJ
-      refresh_token: 5Aep861J.7rrvmXwLwV8Hw86X7cQtxqOq1cNOt9LLourdPAeVgOQHl7idtvQp_e70Q_r20DpwpB4Mo.45QlO29e
-      instance_url: https://myapp-dev-ed.develop.my.salesforce.com
-      expires_at: 2023-03-09T21:55:54Z
+# ajv has issues with interpreting the id here as a schema id
+# example:
+#   id: e888cedf-e9d0-42c5-9485-2d72984faef3
+#   customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69 
+#   status: available
+#   integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
+#   provider_name: salesforce
+#   category: crm
+#   credentials:
+#   - type: oauth2
+#     access_token: 00DDn000004L1rN!AQwAQFcdcvZCaMN83FUDEI5BHyjWILUCMH91UOX7xPVAgn2DjT9LrYTX8RT9vSQ281kBUtQBNsjBKC6R4lIlQTLLvCTuYxtJ
+#     refresh_token: 5Aep861J.7rrvmXwLwV8Hw86X7cQtxqOq1cNOt9LLourdPAeVgOQHl7idtvQp_e70Q_r20DpwpB4Mo.45QlO29e
+#     instance_url: https://myapp-dev-ed.develop.my.salesforce.com
+#     expires_at: 2023-03-09T21:55:54Z

--- a/openapi/mgmt/components/schemas/objects/customer.yaml
+++ b/openapi/mgmt/components/schemas/objects/customer.yaml
@@ -13,6 +13,7 @@ properties:
 required:
   - id
   - application_id
-example:
-  - id: e888cedf-e9d0-42c5-9485-2d72984faef2
-  - application_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69 
+# ajv has issues with interpreting the id here as a schema id
+# example:
+#   id: e888cedf-e9d0-42c5-9485-2d72984faefc
+#   application_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69 

--- a/openapi/mgmt/components/schemas/objects/integration.yaml
+++ b/openapi/mgmt/components/schemas/objects/integration.yaml
@@ -23,23 +23,24 @@ required:
   - auth_type
   - provider_name
   - config
-example:
-  - id: e888cedf-e9d0-42c5-9485-2d72984faef2
-    category: crm
-    auth_type: oauth2
-    provider_name: hubspot
-    config:
-    - remote_provider_app_id: my_app_id
-      oauth:
-      - oauth_scopes:
-        - crm.objects.contacts.read
-        - crm.objects.companies.read
-        - crm.objects.deals.read
-        - crm.objects.contacts.write
-        - crm.objects.companies.write
-        - crm.objects.deals.write
-        credentials:
-        - oauth_client_id: 7393b5a4-5e20-4648-87af-b7b297793fd1
-          oauth_client_secret: 941b846a-5a8c-48b8-b0e1-41b6d4bc4f1a
-    - sync:
-      - period_ms: 60000
+# ajv has issues with interpreting the id here as a schema id
+# example:
+#   id: e888cedf-e9d0-42c5-9485-2d72984faef5
+#   category: crm
+#   auth_type: oauth2
+#   provider_name: hubspot
+#   config:
+#   - remote_provider_app_id: my_app_id
+#     oauth:
+#     - oauth_scopes:
+#       - crm.objects.contacts.read
+#       - crm.objects.companies.read
+#       - crm.objects.deals.read
+#       - crm.objects.contacts.write
+#       - crm.objects.companies.write
+#       - crm.objects.deals.write
+#       credentials:
+#       - oauth_client_id: 7393b5a4-5e20-4648-87af-b7b297793fd1
+#         oauth_client_secret: 941b846a-5a8c-48b8-b0e1-41b6d4bc4f1a
+#   - sync:
+#     - period_ms: 60000

--- a/openapi/mgmt/openapi.bundle.json
+++ b/openapi/mgmt/openapi.bundle.json
@@ -48,7 +48,7 @@
                         "application_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69"
                       },
                       {
-                        "id": "e888cedf-e9d0-42c5-9485-2d72984faef2",
+                        "id": "e888cedf-e9d0-42c5-9485-2d72984faef6",
                         "application_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69"
                       }
                     ]
@@ -135,7 +135,7 @@
                 "examples": {
                   "Example": {
                     "value": {
-                      "id": "0258cbc6-6020-430a-848e-aafacbadf4ae",
+                      "id": "0258cbc6-6020-430a-848e-aafacbadf4af",
                       "application_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69"
                     }
                   }
@@ -180,7 +180,7 @@
                   "Example": {
                     "value": [
                       {
-                        "id": "e888cedf-e9d0-42c5-9485-2d72984faef2",
+                        "id": "e888cedf-e9d0-42c5-9485-2d72984faef8",
                         "category": "crm",
                         "auth_type": "oauth2",
                         "provider_name": "hubspot",
@@ -308,7 +308,7 @@
                 "examples": {
                   "Example": {
                     "value": {
-                      "id": "e888cedf-e9d0-42c5-9485-2d72984faef2",
+                      "id": "e888cedf-e9d0-42c5-9485-2d72984faef9",
                       "category": "crm",
                       "auth_type": "oauth2",
                       "provider_name": "hubspot",
@@ -378,7 +378,7 @@
                 "examples": {
                   "Example": {
                     "value": {
-                      "id": "e888cedf-e9d0-42c5-9485-2d72984faef2",
+                      "id": "e888cedf-e9d0-42c5-9485-2d72984faef0",
                       "category": "crm",
                       "auth_type": "oauth2",
                       "provider_name": "hubspot",
@@ -437,7 +437,7 @@
                 "examples": {
                   "Example": {
                     "value": {
-                      "id": "e888cedf-e9d0-42c5-9485-2d72984faef2",
+                      "id": "e888cedf-e9d0-42c5-9485-2d72984faefa",
                       "category": "crm",
                       "auth_type": "oauth2",
                       "provider_name": "hubspot",
@@ -514,7 +514,7 @@
                   "Example": {
                     "value": [
                       {
-                        "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
+                        "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6b",
                         "customer_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
                         "status": "available",
                         "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
@@ -531,7 +531,7 @@
                         ]
                       },
                       {
-                        "id": "e888cedf-e9d0-42c5-9485-2d72984faef2",
+                        "id": "e888cedf-e9d0-42c5-9485-2d72984faef7",
                         "customer_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
                         "status": "available",
                         "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
@@ -585,7 +585,7 @@
                 "examples": {
                   "Example": {
                     "value": {
-                      "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
+                      "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6c",
                       "customer_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
                       "status": "available",
                       "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
@@ -625,7 +625,7 @@
                 "examples": {
                   "Example": {
                     "value": {
-                      "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
+                      "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6d",
                       "customer_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
                       "status": "available",
                       "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
@@ -694,14 +694,6 @@
         "required": [
           "id",
           "application_id"
-        ],
-        "example": [
-          {
-            "id": "e888cedf-e9d0-42c5-9485-2d72984faef2"
-          },
-          {
-            "application_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69"
-          }
         ]
       },
       "integration": {
@@ -738,44 +730,6 @@
           "auth_type",
           "provider_name",
           "config"
-        ],
-        "example": [
-          {
-            "id": "e888cedf-e9d0-42c5-9485-2d72984faef2",
-            "category": "crm",
-            "auth_type": "oauth2",
-            "provider_name": "hubspot",
-            "config": [
-              {
-                "remote_provider_app_id": "my_app_id",
-                "oauth": [
-                  {
-                    "oauth_scopes": [
-                      "crm.objects.contacts.read",
-                      "crm.objects.companies.read",
-                      "crm.objects.deals.read",
-                      "crm.objects.contacts.write",
-                      "crm.objects.companies.write",
-                      "crm.objects.deals.write"
-                    ],
-                    "credentials": [
-                      {
-                        "oauth_client_id": "7393b5a4-5e20-4648-87af-b7b297793fd1",
-                        "oauth_client_secret": "941b846a-5a8c-48b8-b0e1-41b6d4bc4f1a"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "sync": [
-                  {
-                    "period_ms": 60000
-                  }
-                ]
-              }
-            ]
-          }
         ]
       },
       "connection": {
@@ -821,25 +775,6 @@
           "credentials",
           "provider_name",
           "category"
-        ],
-        "example": [
-          {
-            "id": "e888cedf-e9d0-42c5-9485-2d72984faef2",
-            "customer_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
-            "status": "available",
-            "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
-            "provider_name": "salesforce",
-            "category": "crm",
-            "credentials": [
-              {
-                "type": "oauth2",
-                "access_token": "00DDn000004L1rN!AQwAQFcdcvZCaMN83FUDEI5BHyjWILUCMH91UOX7xPVAgn2DjT9LrYTX8RT9vSQ281kBUtQBNsjBKC6R4lIlQTLLvCTuYxtJ",
-                "refresh_token": "5Aep861J.7rrvmXwLwV8Hw86X7cQtxqOq1cNOt9LLourdPAeVgOQHl7idtvQp_e70Q_r20DpwpB4Mo.45QlO29e",
-                "instance_url": "https://myapp-dev-ed.develop.my.salesforce.com",
-                "expires_at": "2023-03-09T21:55:54.000Z"
-              }
-            ]
-          }
         ]
       },
       "connection_credentials": {

--- a/openapi/mgmt/paths/customers.yaml
+++ b/openapi/mgmt/paths/customers.yaml
@@ -19,7 +19,7 @@ get:
               value:
                 - id: 7393b5a4-5e20-4648-87af-b7b297793fd1
                   application_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
-                - id: e888cedf-e9d0-42c5-9485-2d72984faef2
+                - id: e888cedf-e9d0-42c5-9485-2d72984faef6
                   application_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
 post:
   operationId: createCustomer

--- a/openapi/mgmt/paths/customers@{customer_id}.yaml
+++ b/openapi/mgmt/paths/customers@{customer_id}.yaml
@@ -30,7 +30,7 @@ delete:
           examples:
             Example:
               value:
-                id: 0258cbc6-6020-430a-848e-aafacbadf4ae
+                id: 0258cbc6-6020-430a-848e-aafacbadf4af
                 application_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
 parameters:
   - name: customer_id

--- a/openapi/mgmt/paths/customers@{customer_id}connections.yaml
+++ b/openapi/mgmt/paths/customers@{customer_id}connections.yaml
@@ -17,7 +17,7 @@ get:
           examples:
             Example:
               value:
-                - id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
+                - id: 9572d08b-f19f-48cc-a992-1eb7031d3f6b
                   customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69 
                   status: available
                   integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
@@ -29,7 +29,7 @@ get:
                     refresh_token: 5Aep861J.7rrvmXwLwV8Hw86X7cQtxqOq1cNOt9LLourdPAeVgOQHl7idtvQp_e70Q_r20DpwpB4Mo.45QlO29e
                     instance_url: https://myapp-dev-ed.develop.my.salesforce.com
                     expires_at: 2023-03-09T21:55:54Z
-                - id: e888cedf-e9d0-42c5-9485-2d72984faef2
+                - id: e888cedf-e9d0-42c5-9485-2d72984faef7
                   customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69 
                   status: available
                   integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a

--- a/openapi/mgmt/paths/customers@{customer_id}connections@{connection_id}.yaml
+++ b/openapi/mgmt/paths/customers@{customer_id}connections@{connection_id}.yaml
@@ -13,7 +13,7 @@ get:
           examples:
             Example:
               value:
-                id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
+                id: 9572d08b-f19f-48cc-a992-1eb7031d3f6c
                 customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69 
                 status: available
                 integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
@@ -40,7 +40,7 @@ delete:
           examples:
             Example:
               value:
-                id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
+                id: 9572d08b-f19f-48cc-a992-1eb7031d3f6d
                 customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69 
                 status: available
                 integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a

--- a/openapi/mgmt/paths/integrations.yaml
+++ b/openapi/mgmt/paths/integrations.yaml
@@ -17,7 +17,7 @@ get:
           examples:
             Example:
               value:
-                - id: e888cedf-e9d0-42c5-9485-2d72984faef2
+                - id: e888cedf-e9d0-42c5-9485-2d72984faef8
                   category: crm
                   auth_type: oauth2
                   provider_name: hubspot

--- a/openapi/mgmt/paths/integrations@{integration_id}.yaml
+++ b/openapi/mgmt/paths/integrations@{integration_id}.yaml
@@ -13,7 +13,7 @@ get:
           examples:
             Example:
               value:
-                id: e888cedf-e9d0-42c5-9485-2d72984faef2
+                id: e888cedf-e9d0-42c5-9485-2d72984faef9
                 category: crm
                 auth_type: oauth2
                 provider_name: hubspot
@@ -54,7 +54,7 @@ put:
           examples:
             Example:
               value:
-                id: e888cedf-e9d0-42c5-9485-2d72984faef2
+                id: e888cedf-e9d0-42c5-9485-2d72984faef0
                 category: crm
                 auth_type: oauth2
                 provider_name: hubspot
@@ -88,7 +88,7 @@ delete:
           examples:
             Example:
               value:
-                id: e888cedf-e9d0-42c5-9485-2d72984faef2
+                id: e888cedf-e9d0-42c5-9485-2d72984faefa
                 category: crm
                 auth_type: oauth2
                 provider_name: hubspot


### PR DESCRIPTION
Most of the issues here are due to ajv having a bug and interpreting `id: <uuid>` as schema id even when they're used in examples. See https://github.com/stoplightio/spectral/issues/2081

Also, we seem to be mixing openapi 3.0.3 and 3.1.0 syntax for examples, which we should clean up at some point.