### PR TITLE
docs: add mgmt api reference

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -71,6 +71,10 @@ const config = {
             spec: '../openapi/crm/openapi.bundle.json',
             route: '/api/crm',
           },
+          {
+            spec: '../openapi/mgmt/openapi.bundle.json',
+            route: '/api/mgmt',
+          },
         ],
         // Theme Options for modifying how redoc renders them
         theme: {


### PR DESCRIPTION
While this adds the docs at `/api/mgmt`, it doesn't provide a link to it yet. We can address that in another PR.