### PR TITLE
fix: downgrade hubspot client to fix token refresh and add temporal heartbeating

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-nmHoistingLimits: workspaces
+nmHoistingLimits: none
 
 nodeLinker: node-modules
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "types": "index.ts",
   "packageManager": "yarn@3.4.1",
   "dependencies": {
-    "@hubspot/api-client": "^8.6.0",
+    "@hubspot/api-client": "8.3.2",
     "@supaglue/db": "workspace:*",
     "async-retry": "^1.3.3",
     "csv-parse": "^5.3.5",

--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -34,7 +34,7 @@ const ASYNC_RETRY_OPTIONS = {
   forever: true,
   factor: 2,
   minTimeout: 1000,
-  maxTimeout: 60 * 6000,
+  maxTimeout: 60 * 1000,
 };
 
 const propertiesToFetch = {
@@ -112,7 +112,6 @@ class HubSpotClient extends CrmRemoteClientEventEmitter implements CrmRemoteClie
     const { accessToken } = credentials;
     this.#client = new Client({
       accessToken,
-      numberOfApiCallRetries: 1,
     });
     this.#credentials = credentials;
   }
@@ -145,7 +144,7 @@ class HubSpotClient extends CrmRemoteClientEventEmitter implements CrmRemoteClie
     (async () => {
       let after = undefined;
       do {
-        const currResults: HubspotPaginatedDeals = await this.listAccountsImpl(after);
+        const currResults: HubspotPaginatedCompanies = await this.listAccountsImpl(after);
         const remoteAccounts = currResults.results.map(fromHubSpotCompanyToRemoteAccount);
         after = currResults.paging?.next?.after;
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -27,5 +27,8 @@
   ],
   "prisma": {
     "seed": "tsx prisma/seed.ts"
+  },
+  "installConfig": {
+    "hoistingLimits": "workspaces"
   }
 }

--- a/packages/sync-workflows/activities/do_sync.ts
+++ b/packages/sync-workflows/activities/do_sync.ts
@@ -7,6 +7,8 @@ import {
   RemoteService,
 } from '@supaglue/core/services';
 import { CommonModel } from '@supaglue/core/types';
+import { Context } from '@temporalio/activity';
+import { pipeline, Readable, Transform } from 'stream';
 import { logEvent } from '../lib/analytics';
 
 export type DoSyncArgs = {
@@ -40,12 +42,20 @@ export function createDoSync(
     switch (commonModel) {
       case 'account': {
         const readable = await client.listAccounts();
-        numRecordsSynced = await accountService.upsertRemoteAccounts(connection.id, connection.customerId, readable);
+        numRecordsSynced = await accountService.upsertRemoteAccounts(
+          connection.id,
+          connection.customerId,
+          toHeartbeatingReadable(readable)
+        );
         break;
       }
       case 'contact': {
         const readable = await client.listContacts();
-        numRecordsSynced = await contactService.upsertRemoteContacts(connection.id, connection.customerId, readable);
+        numRecordsSynced = await contactService.upsertRemoteContacts(
+          connection.id,
+          connection.customerId,
+          toHeartbeatingReadable(readable)
+        );
         break;
       }
       case 'opportunity': {
@@ -53,13 +63,17 @@ export function createDoSync(
         numRecordsSynced = await opportunityService.upsertRemoteOpportunities(
           connection.id,
           connection.customerId,
-          readable
+          toHeartbeatingReadable(readable)
         );
         break;
       }
       case 'lead': {
         const readable = await client.listLeads();
-        numRecordsSynced = await leadService.upsertRemoteLeads(connection.id, connection.customerId, readable);
+        numRecordsSynced = await leadService.upsertRemoteLeads(
+          connection.id,
+          connection.customerId,
+          toHeartbeatingReadable(readable)
+        );
         break;
       }
     }
@@ -72,4 +86,27 @@ export function createDoSync(
       numRecordsSynced,
     };
   };
+}
+
+function toHeartbeatingReadable(readable: Readable): Readable {
+  // TODO: While this ensures rescheduling of this activity if the process dies,
+  // it does not ensure that we stop the stream processing.
+  // We need to include a timeout here to clean up the pipeline when we
+  // exceed the heartbeat timeout.
+  return pipeline(
+    readable,
+    new Transform({
+      objectMode: true,
+      transform: (chunk, encoding, callback) => {
+        Context.current().heartbeat();
+        try {
+          callback(null, chunk);
+        } catch (e: any) {
+          return callback(e);
+        }
+      },
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    () => {}
+  );
 }

--- a/packages/sync-workflows/workflows/run_syncs.ts
+++ b/packages/sync-workflows/workflows/run_syncs.ts
@@ -7,6 +7,7 @@ const { doSync, populateAssociations, logSyncStart, logSyncFinish, maybeSendSync
   ReturnType<typeof createActivities>
 >({
   startToCloseTimeout: '120 minute',
+  heartbeatTimeout: '30 seconds',
 });
 
 export const getRunSyncsScheduleId = (connectionId: string): string => `run-syncs-cid-${connectionId}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3070,9 +3070,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hubspot/api-client@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "@hubspot/api-client@npm:8.6.0"
+"@hubspot/api-client@npm:8.3.2":
+  version: 8.3.2
+  resolution: "@hubspot/api-client@npm:8.3.2"
   dependencies:
     "@types/node-fetch": ^2.5.7
     bottleneck: ^2.19.5
@@ -3082,7 +3082,7 @@ __metadata:
     lodash.merge: ^4.6.2
     node-fetch: ^2.6.0
     url-parse: ^1.4.3
-  checksum: c1c2bdddd324a2fe00ce9680f57425819efede1c261ab4e17d7633c221b246d6dcb3f72a58774e30deb1a5677c3c8d5e34703373a8f5c3623ea927ffd492bbca
+  checksum: 965c25c5265f9dc43cce88291d3a8144f28fea12f90e0b1ec2ed04c0cc396da3d3994fc93041b3f04ff330f16b0ec1d26d83445e0f7de47069d5e1d2d9e9568c
   languageName: node
   linkType: hard
 
@@ -3949,7 +3949,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@supaglue/core@workspace:packages/core"
   dependencies:
-    "@hubspot/api-client": ^8.6.0
+    "@hubspot/api-client": 8.3.2
     "@supaglue/db": "workspace:*"
     "@tsconfig/node18": ^1.0.1
     "@types/async-retry": ^1


### PR DESCRIPTION
We can get back to a more modern version of hubspot-api-nodejs when https://github.com/HubSpot/hubspot-api-nodejs/issues/341 is fixed.