### PR TITLE
fix: strictly type email addresses, addresses, and phone number types

### DIFF
--- a/openapi/crm/components/schemas/objects/account.yaml
+++ b/openapi/crm/components/schemas/objects/account.yaml
@@ -51,7 +51,7 @@ properties:
 # Multiple examples are only supported in OpenAPI 3.1.0, and this is the wrong format
 # example:
 #   - addresses:
-#       - address_type: Shipping
+#       - address_type: shipping
 #         city: San Francisco
 #         country: US
 #         postal_code: '94107'
@@ -67,12 +67,12 @@ properties:
 #     owner_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
 #     phone_numbers:
 #       - phone_number: '+14151234567'
-#         phone_number_type: Mobile
+#         phone_number_type: mobile
 #     created_at: '2022-02-27T00:00:00Z'
 #     updated_at: '2022-02-27T00:00:00Z'
 #     website: https://supaglue.com/
 #   - addresses:
-#       - address_type: Shipping
+#       - address_type: shipping
 #         city: San Francisco
 #         country: US
 #         postal_code: '94107'
@@ -88,7 +88,7 @@ properties:
 #     owner_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
 #     phone_numbers:
 #       - phone_number: '+14151234567'
-#         phone_number_type: Mobile
+#         phone_number_type: mobile
 #     created_at: '2022-02-27T00:00:00Z'
 #     updated_at: '2022-02-27T00:00:00Z'
 #     website: https://supaglue.com/

--- a/openapi/crm/components/schemas/objects/addresses.yaml
+++ b/openapi/crm/components/schemas/objects/addresses.yaml
@@ -4,8 +4,12 @@ items:
   properties:
     address_type:
       type: string
-      nullable: true
-      example: Shipping
+      enum:
+        - primary
+        - mailing
+        - other
+        - billing
+        - shipping
     city:
       type: string
       nullable: true
@@ -31,7 +35,7 @@ items:
       nullable: true
       example: ~
 example:
-  - address_type: Shipping
+  - address_type: shipping
     city: San Francisco
     country: US
     postal_code: '94107'

--- a/openapi/crm/components/schemas/objects/email_addresses.yaml
+++ b/openapi/crm/components/schemas/objects/email_addresses.yaml
@@ -7,8 +7,9 @@ items:
       example: hello@supaglue.com
     email_address_type:
       type: string
-      nullable: true
-      example: Work
+      enum:
+        - primary
+        - work
 example:
   - email_address: hello@supaglue.com
-    email_address_type: Work
+    email_address_type: work

--- a/openapi/crm/components/schemas/objects/phone_numbers.yaml
+++ b/openapi/crm/components/schemas/objects/phone_numbers.yaml
@@ -8,8 +8,10 @@ items:
       example: '+14151234567'
     phone_number_type:
       type: string
-      nullable: true
-      example: Mobile
+      enum:
+        - primary
+        - mobile
+        - fax
 example:
   - phone_number: '+14151234567'
-    phone_number_type: Mobile
+    phone_number_type: primary

--- a/openapi/crm/openapi.bundle.json
+++ b/openapi/crm/openapi.bundle.json
@@ -89,7 +89,7 @@
                         {
                           "addresses": [
                             {
-                              "address_type": "Shipping",
+                              "address_type": "shipping",
                               "city": "San Francisco",
                               "country": "US",
                               "postal_code": "94107",
@@ -108,7 +108,7 @@
                           "phone_numbers": [
                             {
                               "phone_number": "+14151234567",
-                              "phone_number_type": "Mobile"
+                              "phone_number_type": "mobile"
                             }
                           ],
                           "created_at": "2021-11-10T00:00:00Z",
@@ -118,7 +118,7 @@
                         {
                           "addresses": [
                             {
-                              "address_type": "Shipping",
+                              "address_type": "shipping",
                               "city": "San Francisco",
                               "country": "US",
                               "postal_code": "94107",
@@ -137,7 +137,7 @@
                           "phone_numbers": [
                             {
                               "phone_number": "+14151234567",
-                              "phone_number_type": "Mobile"
+                              "phone_number_type": "mobile"
                             }
                           ],
                           "created_at": "2023-02-27T00:00:00Z",
@@ -294,7 +294,7 @@
                         {
                           "addresses": [
                             {
-                              "address_type": "Shipping",
+                              "address_type": "shipping",
                               "city": "San Francisco",
                               "country": "US",
                               "postal_code": "94107",
@@ -313,7 +313,7 @@
                           "phone_numbers": [
                             {
                               "phone_number": "+14151234567",
-                              "phone_number_type": "Mobile"
+                              "phone_number_type": "mobile"
                             }
                           ],
                           "created_at": "2021-11-10T00:00:00Z",
@@ -323,7 +323,7 @@
                         {
                           "addresses": [
                             {
-                              "address_type": "Shipping",
+                              "address_type": "shipping",
                               "city": "San Francisco",
                               "country": "US",
                               "postal_code": "94107",
@@ -342,7 +342,7 @@
                           "phone_numbers": [
                             {
                               "phone_number": "+14151234567",
-                              "phone_number_type": "Mobile"
+                              "phone_number_type": "mobile"
                             }
                           ],
                           "created_at": "2023-02-27T00:00:00Z",
@@ -425,7 +425,7 @@
                       "phone_numbers": [
                         {
                           "phone_number": "+14151234567",
-                          "phone_number_type": "Mobile"
+                          "phone_number_type": "mobile"
                         }
                       ],
                       "created_at": "2023-02-27T00:00:00Z",
@@ -583,7 +583,7 @@
                           "account_id": "9377fd4d-d420-4e0b-93ea-789078a3eab4",
                           "addresses": [
                             {
-                              "address_type": "Shipping",
+                              "address_type": "shipping",
                               "city": "San Francisco",
                               "country": "US",
                               "postal_code": "94107",
@@ -595,7 +595,7 @@
                           "email_addresses": [
                             {
                               "email_address": "hello@supaglue.com",
-                              "email_address_type": "Work"
+                              "email_address_type": "work"
                             }
                           ],
                           "first_name": "George",
@@ -605,7 +605,7 @@
                           "phone_numbers": [
                             {
                               "phone_number": "+14151234567",
-                              "phone_number_type": "Mobile"
+                              "phone_number_type": "mobile"
                             }
                           ],
                           "created_at": "2023-02-27T00:00:00Z"
@@ -614,7 +614,7 @@
                           "account": "9377fd4d-d420-4e0b-93ea-789078a3eab4",
                           "addresses": [
                             {
-                              "address_type": "Shipping",
+                              "address_type": "shipping",
                               "city": "San Francisco",
                               "country": "US",
                               "postal_code": "94107",
@@ -626,7 +626,7 @@
                           "email_addresses": [
                             {
                               "email_address": "hello@supaglue.com",
-                              "email_address_type": "Work"
+                              "email_address_type": "work"
                             }
                           ],
                           "first_name": "George",
@@ -636,7 +636,7 @@
                           "phone_numbers": [
                             {
                               "phone_number": "+14151234567",
-                              "phone_number_type": "Mobile"
+                              "phone_number_type": "mobile"
                             }
                           ],
                           "created_at": "2023-02-27T00:00:00Z"
@@ -800,7 +800,7 @@
                           "account_id": "9377fd4d-d420-4e0b-93ea-789078a3eab4",
                           "addresses": [
                             {
-                              "address_type": "Shipping",
+                              "address_type": "shipping",
                               "city": "San Francisco",
                               "country": "US",
                               "postal_code": "94107",
@@ -812,7 +812,7 @@
                           "email_addresses": [
                             {
                               "email_address": "hello@supaglue.com",
-                              "email_address_type": "Work"
+                              "email_address_type": "work"
                             }
                           ],
                           "first_name": "George",
@@ -822,7 +822,7 @@
                           "phone_numbers": [
                             {
                               "phone_number": "+14151234567",
-                              "phone_number_type": "Mobile"
+                              "phone_number_type": "mobile"
                             }
                           ],
                           "created_at": "2023-02-27T00:00:00Z"
@@ -831,7 +831,7 @@
                           "account": "9377fd4d-d420-4e0b-93ea-789078a3eab4",
                           "addresses": [
                             {
-                              "address_type": "Shipping",
+                              "address_type": "shipping",
                               "city": "San Francisco",
                               "country": "US",
                               "postal_code": "94107",
@@ -843,7 +843,7 @@
                           "email_addresses": [
                             {
                               "email_address": "hello@supaglue.com",
-                              "email_address_type": "Work"
+                              "email_address_type": "work"
                             }
                           ],
                           "first_name": "George",
@@ -853,7 +853,7 @@
                           "phone_numbers": [
                             {
                               "phone_number": "+14151234567",
-                              "phone_number_type": "Mobile"
+                              "phone_number_type": "mobile"
                             }
                           ],
                           "created_at": "2023-02-27T00:00:00Z"
@@ -1060,7 +1060,7 @@
                         {
                           "addresses": [
                             {
-                              "address_type": "Shipping",
+                              "address_type": "shipping",
                               "city": "San Francisco",
                               "country": "US",
                               "postal_code": "94107",
@@ -1076,7 +1076,7 @@
                           "email_addresses": [
                             {
                               "email_address": "hello@supaglue.com",
-                              "email_address_type": "Work"
+                              "email_address_type": "work"
                             }
                           ],
                           "first_name": "George",
@@ -1087,7 +1087,7 @@
                           "phone_numbers": [
                             {
                               "phone_number": "+14151234567",
-                              "phone_number_type": "Mobile"
+                              "phone_number_type": "mobile"
                             }
                           ],
                           "created_at": "2023-02-27T00:00:00Z",
@@ -1097,7 +1097,7 @@
                         {
                           "addresses": [
                             {
-                              "address_type": "Shipping",
+                              "address_type": "shipping",
                               "city": "San Francisco",
                               "country": "US",
                               "postal_code": "94107",
@@ -1113,7 +1113,7 @@
                           "email_addresses": [
                             {
                               "email_address": "hello@supaglue.com",
-                              "email_address_type": "Work"
+                              "email_address_type": "work"
                             }
                           ],
                           "first_name": "George",
@@ -1124,7 +1124,7 @@
                           "phone_numbers": [
                             {
                               "phone_number": "+14151234567",
-                              "phone_number_type": "Mobile"
+                              "phone_number_type": "mobile"
                             }
                           ],
                           "created_at": "2023-02-27T00:00:00Z",
@@ -2766,8 +2766,13 @@
           "properties": {
             "address_type": {
               "type": "string",
-              "nullable": true,
-              "example": "Shipping"
+              "enum": [
+                "primary",
+                "mailing",
+                "other",
+                "billing",
+                "shipping"
+              ]
             },
             "city": {
               "type": "string",
@@ -2803,7 +2808,7 @@
         },
         "example": [
           {
-            "address_type": "Shipping",
+            "address_type": "shipping",
             "city": "San Francisco",
             "country": "US",
             "postal_code": "94107",
@@ -2824,15 +2829,17 @@
             },
             "email_address_type": {
               "type": "string",
-              "nullable": true,
-              "example": "Work"
+              "enum": [
+                "primary",
+                "work"
+              ]
             }
           }
         },
         "example": [
           {
             "email_address": "hello@supaglue.com",
-            "email_address_type": "Work"
+            "email_address_type": "work"
           }
         ]
       },
@@ -2848,15 +2855,18 @@
             },
             "phone_number_type": {
               "type": "string",
-              "nullable": true,
-              "example": "Mobile"
+              "enum": [
+                "primary",
+                "mobile",
+                "fax"
+              ]
             }
           }
         },
         "example": [
           {
             "phone_number": "+14151234567",
-            "phone_number_type": "Mobile"
+            "phone_number_type": "primary"
           }
         ]
       },

--- a/openapi/crm/paths/accounts.yaml
+++ b/openapi/crm/paths/accounts.yaml
@@ -36,7 +36,7 @@ get:
                 previous: eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9
                 results:
                   - addresses:
-                      - address_type: Shipping
+                      - address_type: shipping
                         city: San Francisco
                         country: US
                         postal_code: '94107'
@@ -52,12 +52,12 @@ get:
                     owner_id: cb40ff24-6587-4b24-82a3-9269a05d5dda
                     phone_numbers:
                       - phone_number: '+14151234567'
-                        phone_number_type: Mobile
+                        phone_number_type: mobile
                     created_at: '2021-11-10T00:00:00Z'
                     updated_at: '2022-01-09T00:00:00Z'
                     website: https://supaglue.com/
                   - addresses:
-                      - address_type: Shipping
+                      - address_type: shipping
                         city: San Francisco
                         country: US
                         postal_code: '94107'
@@ -73,7 +73,7 @@ get:
                     owner_id: cb40ff24-6587-4b24-82a3-9269a05d5dda
                     phone_numbers:
                       - phone_number: '+14151234567'
-                        phone_number_type: Mobile
+                        phone_number_type: mobile
                     created_at: '2023-02-27T00:00:00Z'
                     updated_at: '2023-02-27T00:00:00Z'
                     website: https://supaglue.com/

--- a/openapi/crm/paths/accounts@_search.yaml
+++ b/openapi/crm/paths/accounts@_search.yaml
@@ -43,7 +43,7 @@ post:
                 previous: eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9
                 results:
                   - addresses:
-                      - address_type: Shipping
+                      - address_type: shipping
                         city: San Francisco
                         country: US
                         postal_code: '94107'
@@ -59,12 +59,12 @@ post:
                     owner_id: cb40ff24-6587-4b24-82a3-9269a05d5dda
                     phone_numbers:
                       - phone_number: '+14151234567'
-                        phone_number_type: Mobile
+                        phone_number_type: mobile
                     created_at: '2021-11-10T00:00:00Z'
                     updated_at: '2022-01-09T00:00:00Z'
                     website: https://supaglue.com/
                   - addresses:
-                      - address_type: Shipping
+                      - address_type: shipping
                         city: San Francisco
                         country: US
                         postal_code: '94107'
@@ -80,7 +80,7 @@ post:
                     owner_id: cb40ff24-6587-4b24-82a3-9269a05d5dda
                     phone_numbers:
                       - phone_number: '+14151234567'
-                        phone_number_type: Mobile
+                        phone_number_type: mobile
                     created_at: '2023-02-27T00:00:00Z'
                     updated_at: '2023-02-27T00:00:00Z'
                     website: https://supaglue.com/

--- a/openapi/crm/paths/accounts@{account_id}.yaml
+++ b/openapi/crm/paths/accounts@{account_id}.yaml
@@ -41,7 +41,7 @@ get:
                 owner_id: 9377fd4d-d420-4e0b-93ea-789078a3eab4
                 phone_numbers:
                   - phone_number: '+14151234567'
-                    phone_number_type: Mobile
+                    phone_number_type: mobile
                 created_at: '2023-02-27T00:00:00Z'
                 updated_at: '2023-02-27T00:00:00Z'
                 website: https://supaglue.com/

--- a/openapi/crm/paths/contacts.yaml
+++ b/openapi/crm/paths/contacts.yaml
@@ -37,7 +37,7 @@ get:
                 results:
                   - account_id: 9377fd4d-d420-4e0b-93ea-789078a3eab4
                     addresses:
-                      - address_type: Shipping
+                      - address_type: shipping
                         city: San Francisco
                         country: US
                         postal_code: '94107'
@@ -46,18 +46,18 @@ get:
                         street_2: ~
                     email_addresses:
                       - email_address: hello@supaglue.com
-                        email_address_type: Work
+                        email_address_type: work
                     first_name: George
                     id: 43a45011-c55e-42f3-81a1-99158c956775
                     last_activity_at: '2023-02-27T00:00:00Z'
                     last_name: Xing
                     phone_numbers:
                       - phone_number: '+14151234567'
-                        phone_number_type: Mobile
+                        phone_number_type: mobile
                     created_at: '2023-02-27T00:00:00Z'
                   - account: 9377fd4d-d420-4e0b-93ea-789078a3eab4
                     addresses:
-                      - address_type: Shipping
+                      - address_type: shipping
                         city: San Francisco
                         country: US
                         postal_code: '94107'
@@ -66,14 +66,14 @@ get:
                         street_2: ~
                     email_addresses:
                       - email_address: hello@supaglue.com
-                        email_address_type: Work
+                        email_address_type: work
                     first_name: George
                     id: 5733a8b6-472d-45fa-8f10-e0b00727cced
                     last_activity_at: '2023-02-27T00:00:00Z'
                     last_name: Xing
                     phone_numbers:
                       - phone_number: '+14151234567'
-                        phone_number_type: Mobile
+                        phone_number_type: mobile
                     created_at: '2023-02-27T00:00:00Z'
 post:
   operationId: createContact

--- a/openapi/crm/paths/contacts@_search.yaml
+++ b/openapi/crm/paths/contacts@_search.yaml
@@ -44,7 +44,7 @@ post:
                 results:
                   - account_id: 9377fd4d-d420-4e0b-93ea-789078a3eab4
                     addresses:
-                      - address_type: Shipping
+                      - address_type: shipping
                         city: San Francisco
                         country: US
                         postal_code: '94107'
@@ -53,18 +53,18 @@ post:
                         street_2: ~
                     email_addresses:
                       - email_address: hello@supaglue.com
-                        email_address_type: Work
+                        email_address_type: work
                     first_name: George
                     id: 43a45011-c55e-42f3-81a1-99158c956775
                     last_activity_at: '2023-02-27T00:00:00Z'
                     last_name: Xing
                     phone_numbers:
                       - phone_number: '+14151234567'
-                        phone_number_type: Mobile
+                        phone_number_type: mobile
                     created_at: '2023-02-27T00:00:00Z'
                   - account: 9377fd4d-d420-4e0b-93ea-789078a3eab4
                     addresses:
-                      - address_type: Shipping
+                      - address_type: shipping
                         city: San Francisco
                         country: US
                         postal_code: '94107'
@@ -73,14 +73,14 @@ post:
                         street_2: ~
                     email_addresses:
                       - email_address: hello@supaglue.com
-                        email_address_type: Work
+                        email_address_type: work
                     first_name: George
                     id: 5733a8b6-472d-45fa-8f10-e0b00727cced
                     last_activity_at: '2023-02-27T00:00:00Z'
                     last_name: Xing
                     phone_numbers:
                       - phone_number: '+14151234567'
-                        phone_number_type: Mobile
+                        phone_number_type: mobile
                     created_at: '2023-02-27T00:00:00Z'
 parameters:
   - $ref: ../../common/components/parameters/x-customer-id.yaml

--- a/openapi/crm/paths/leads.yaml
+++ b/openapi/crm/paths/leads.yaml
@@ -36,7 +36,7 @@ get:
                 previous: eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9
                 results:
                   - addresses:
-                      - address_type: Shipping
+                      - address_type: shipping
                         city: San Francisco
                         country: US
                         postal_code: '94107'
@@ -49,7 +49,7 @@ get:
                     converted_date: '2023-02-27T00:00:00Z'
                     email_addresses:
                       - email_address: hello@supaglue.com
-                        email_address_type: Work
+                        email_address_type: work
                     first_name: George
                     id: 62bd34b8-54fa-4628-ae75-5fd6be59e4b7
                     last_name: Xing
@@ -57,12 +57,12 @@ get:
                     owner_id: 04363f99-e807-4f69-b233-3d31b92f9bb2
                     phone_numbers:
                       - phone_number: '+14151234567'
-                        phone_number_type: Mobile
+                        phone_number_type: mobile
                     created_at: '2023-02-27T00:00:00Z'
                     updated_at: '2023-02-27T00:00:00Z'
                     title: Co-Founder
                   - addresses:
-                      - address_type: Shipping
+                      - address_type: shipping
                         city: San Francisco
                         country: US
                         postal_code: '94107'
@@ -75,7 +75,7 @@ get:
                     converted_date: '2022-03-10T00:00:00Z'
                     email_addresses:
                       - email_address: hello@supaglue.com
-                        email_address_type: Work
+                        email_address_type: work
                     first_name: George
                     id: 29b3e861-b1da-4f74-885a-e151c5759acf
                     last_name: Xing
@@ -83,7 +83,7 @@ get:
                     owner_id: 71e01ac4-5f21-46e2-b021-46555ade976d
                     phone_numbers:
                       - phone_number: '+14151234567'
-                        phone_number_type: Mobile
+                        phone_number_type: mobile
                     created_at: '2023-02-27T00:00:00Z'
                     updated_at: '2023-02-27T00:00:00Z'
                     title: Co-Founder

--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -75,11 +75,9 @@ const propertiesToFetch = {
     'email',
     'fax',
     'firstname',
-    'hs_additional_emails',
     'hs_createdate', // TODO: Use this or createdate?
     'hs_is_contact', // TODO: distinguish from "visitor"?
     'hs_lastmodifieddate', // TODO: Use this or lastmodifieddate?
-    'hs_whatsapp_phone_number',
     'hubspot_owner_id',
     'lastmodifieddate',
     'lastname',

--- a/packages/core/remotes/crm/hubspot/mappers.ts
+++ b/packages/core/remotes/crm/hubspot/mappers.ts
@@ -3,6 +3,7 @@ import { SimplePublicObjectWithAssociations as HubSpotContact } from '@hubspot/a
 import { SimplePublicObjectWithAssociations as HubSpotDeal } from '@hubspot/api-client/lib/codegen/crm/deals';
 import { PublicOwner as HubspotOwner } from '@hubspot/api-client/lib/codegen/crm/owners';
 import {
+  Address,
   EmailAddress,
   OpportunityStatus,
   PhoneNumber,
@@ -21,7 +22,7 @@ export const fromHubSpotCompanyToRemoteAccount = ({
   createdAt,
   updatedAt,
 }: HubSpotCompany): RemoteAccount => {
-  const addresses =
+  const addresses: Address[] =
     properties.address ||
     properties.address2 ||
     properties.city ||
@@ -36,16 +37,16 @@ export const fromHubSpotCompanyToRemoteAccount = ({
             state: properties.state ?? null,
             postalCode: properties.zip ?? null,
             country: properties.country ?? null,
-            addressType: null,
+            addressType: 'primary',
           },
         ]
       : [];
 
-  const phoneNumbers = properties.phone
+  const phoneNumbers: PhoneNumber[] = properties.phone
     ? [
         {
           phoneNumber: properties.phone ?? null,
-          phoneNumberType: null,
+          phoneNumberType: 'primary',
         },
       ]
     : [];
@@ -94,13 +95,6 @@ export const fromHubSpotContactToRemoteContact = ({
     remoteAccountId = associations.companies.results[0].id ?? null;
   }
 
-  // TODO: Handle hs_additional_emails
-  // if (properties.hs_additional_emails?.length) {
-  //   properties.hs_additional_emails.forEach((email) => {
-  //     emailAddresses.push({ emailAddress: email, emailAddressType: null });
-  //   });
-  // }
-
   const phoneNumbers = [
     properties.phone
       ? {
@@ -114,12 +108,6 @@ export const fromHubSpotContactToRemoteContact = ({
           phoneNumberType: 'mobile',
         }
       : null,
-    properties.hs_whatsapp_phone_number
-      ? {
-          phoneNumber: properties.hs_whatsapp_phone_number,
-          phoneNumberType: 'whatsapp',
-        }
-      : null,
     properties.fax
       ? {
           phoneNumber: properties.fax,
@@ -128,7 +116,7 @@ export const fromHubSpotContactToRemoteContact = ({
       : null,
   ].filter(Boolean) as PhoneNumber[];
 
-  const addresses =
+  const addresses: Address[] =
     properties.address ||
     properties.address2 ||
     properties.city ||
@@ -143,7 +131,7 @@ export const fromHubSpotContactToRemoteContact = ({
             state: properties.state ?? null,
             postalCode: properties.zip ?? null,
             country: properties.country ?? null,
-            addressType: null,
+            addressType: 'primary',
           },
         ]
       : [];

--- a/packages/core/remotes/crm/salesforce/index.ts
+++ b/packages/core/remotes/crm/salesforce/index.ts
@@ -76,8 +76,6 @@ const propertiesToFetch = {
     'Fax',
     'HomePhone',
     'MobilePhone',
-    'OtherPhone',
-    'AssistantPhone',
     'CreatedDate',
     'LastActivityDate',
     // We may not need all of these fields in order to map to common model

--- a/packages/core/remotes/crm/salesforce/mappers.ts
+++ b/packages/core/remotes/crm/salesforce/mappers.ts
@@ -1,10 +1,6 @@
 import {
   Address,
-  BILLING_ADDRESS_TYPE,
-  FAX_PHONE_NUMBER_TYPE,
-  MAILING_ADDRESS_TYPE,
   OpportunityStatus,
-  OTHER_ADDRESS_TYPE,
   PhoneNumber,
   RemoteAccount,
   RemoteAccountCreateParams,
@@ -18,7 +14,6 @@ import {
   RemoteOpportunity,
   RemoteOpportunityCreateParams,
   RemoteOpportunityUpdateParams,
-  SHIPPING_ADDRESS_TYPE,
 } from '../../../types';
 
 export const fromSalesforceAccountToRemoteAccount = (record: Record<string, any>): RemoteAccount => {
@@ -35,7 +30,7 @@ export const fromSalesforceAccountToRemoteAccount = (record: Record<string, any>
           state: record.BillingState ?? null,
           postalCode: record.postalCode ?? null,
           country: record.country ?? null,
-          addressType: BILLING_ADDRESS_TYPE,
+          addressType: 'billing',
         }
       : null;
 
@@ -52,7 +47,7 @@ export const fromSalesforceAccountToRemoteAccount = (record: Record<string, any>
           state: record.ShippingState ?? null,
           postalCode: record.postalCode ?? null,
           country: record.country ?? null,
-          addressType: SHIPPING_ADDRESS_TYPE,
+          addressType: 'shipping',
         }
       : null;
 
@@ -61,13 +56,13 @@ export const fromSalesforceAccountToRemoteAccount = (record: Record<string, any>
   const phoneNumber: PhoneNumber | null = record.Phone
     ? {
         phoneNumber: record.Phone,
-        phoneNumberType: null,
+        phoneNumberType: 'primary',
       }
     : null;
   const faxPhoneNumber: PhoneNumber | null = record.Fax
     ? {
         phoneNumber: record.Fax,
-        phoneNumberType: FAX_PHONE_NUMBER_TYPE,
+        phoneNumberType: 'fax',
       }
     : null;
 
@@ -122,7 +117,7 @@ export const fromSalesforceContactToRemoteContact = (record: Record<string, any>
           state: record.MailingState ?? null,
           postalCode: record.MailingPostalCode ?? null,
           country: record.MailingCountry ?? null,
-          addressType: MAILING_ADDRESS_TYPE,
+          addressType: 'mailing',
         }
       : null;
 
@@ -135,7 +130,7 @@ export const fromSalesforceContactToRemoteContact = (record: Record<string, any>
           state: record.OtherState ?? null,
           postalCode: record.OtherPostalCode ?? null,
           country: record.OtherCountry ?? null,
-          addressType: OTHER_ADDRESS_TYPE,
+          addressType: 'other',
         }
       : null;
 
@@ -156,27 +151,6 @@ export const fromSalesforceContactToRemoteContact = (record: Record<string, any>
     });
   }
 
-  if (record.HomePhone) {
-    phoneNumbers.push({
-      phoneNumber: record.HomePhone,
-      phoneNumberType: 'home',
-    });
-  }
-
-  if (record.AssistantPhone) {
-    phoneNumbers.push({
-      phoneNumber: record.AssistantPhone,
-      phoneNumberType: 'assistant',
-    });
-  }
-
-  if (record.OtherPhone) {
-    phoneNumbers.push({
-      phoneNumber: record.OtherPhone,
-      phoneNumberType: 'other',
-    });
-  }
-
   if (record.Fax) {
     phoneNumbers.push({
       phoneNumber: record.Fax,
@@ -191,7 +165,7 @@ export const fromSalesforceContactToRemoteContact = (record: Record<string, any>
     firstName: record.FirstName ?? null,
     lastName: record.LastName ?? null,
     addresses,
-    emailAddresses: [{ emailAddress: record.Email, emailAddressType: null }],
+    emailAddresses: [{ emailAddress: record.Email, emailAddressType: 'primary' }],
     phoneNumbers,
     lastActivityAt: record.LastActivityDate ? new Date(record.LastActivityDate) : null,
     remoteCreatedAt: record.CreatedDate ? new Date(record.CreatedDate) : null,
@@ -239,14 +213,14 @@ export const fromSalesforceLeadToRemoteLead = (
         state: record.State ?? null,
         country: record.Country ?? null,
         postalCode: record.PostalCode ?? null,
-        addressType: null,
+        addressType: 'primary',
       },
     ],
-    emailAddresses: [{ emailAddress: record.Email, emailAddressType: null }],
+    emailAddresses: [{ emailAddress: record.Email, emailAddressType: 'primary' }],
     phoneNumbers: [
       {
         phoneNumber: record.Phone ?? null,
-        phoneNumberType: null,
+        phoneNumberType: 'primary',
       },
     ],
     remoteCreatedAt: record.CreatedDate ? new Date(record.CreatedDate) : null,

--- a/packages/core/types/base.ts
+++ b/packages/core/types/base.ts
@@ -1,8 +1,3 @@
-export const BILLING_ADDRESS_TYPE = 'BILLING';
-export const MAILING_ADDRESS_TYPE = 'MAILING';
-export const OTHER_ADDRESS_TYPE = 'OTHER';
-export const SHIPPING_ADDRESS_TYPE = 'SHIPPING';
-
 export type Address = {
   street1: string | null;
   street2: string | null;
@@ -10,17 +5,17 @@ export type Address = {
   state: string | null;
   postalCode: string | null;
   country: string | null;
-  addressType: string | null;
+  addressType: 'primary' | 'billing' | 'mailing' | 'other' | 'shipping';
 };
 
 export const FAX_PHONE_NUMBER_TYPE = 'Fax';
 
 export type PhoneNumber = {
   phoneNumber: string | null;
-  phoneNumberType: string | null;
+  phoneNumberType: 'primary' | 'mobile' | 'fax';
 };
 
 export type EmailAddress = {
   emailAddress: string;
-  emailAddressType: string | null;
+  emailAddressType: 'primary' | 'work';
 };

--- a/packages/schemas/gen/crm.ts
+++ b/packages/schemas/gen/crm.ts
@@ -457,7 +457,7 @@ export interface components {
     /**
      * @example [
      *   {
-     *     "address_type": "Shipping",
+     *     "address_type": "shipping",
      *     "city": "San Francisco",
      *     "country": "US",
      *     "postal_code": "94107",
@@ -468,8 +468,8 @@ export interface components {
      * ]
      */
     addresses: ({
-        /** @example Shipping */
-        address_type?: string | null;
+        /** @enum {string} */
+        address_type?: "primary" | "mailing" | "other" | "billing" | "shipping";
         /** @example San Francisco */
         city?: string | null;
         /** @example USA */
@@ -487,29 +487,29 @@ export interface components {
      * @example [
      *   {
      *     "email_address": "hello@supaglue.com",
-     *     "email_address_type": "Work"
+     *     "email_address_type": "work"
      *   }
      * ]
      */
     email_addresses: ({
         /** @example hello@supaglue.com */
         email_address?: string;
-        /** @example Work */
-        email_address_type?: string | null;
+        /** @enum {string} */
+        email_address_type?: "primary" | "work";
       })[];
     /**
      * @example [
      *   {
      *     "phone_number": "+14151234567",
-     *     "phone_number_type": "Mobile"
+     *     "phone_number_type": "primary"
      *   }
      * ]
      */
     phone_numbers: ({
         /** @example +14151234567 */
         phone_number?: string | null;
-        /** @example Mobile */
-        phone_number_type?: string | null;
+        /** @enum {string} */
+        phone_number_type?: "primary" | "mobile" | "fax";
       })[];
     pagination: {
       /** @example eyJpZCI6IjQyNTc5ZjczLTg1MjQtNDU3MC05YjY3LWVjYmQ3MDJjNmIxNCIsInJldmVyc2UiOmZhbHNlfQ== */


### PR DESCRIPTION
supported email types: `primary`, `work`
supported phone types: `primary`, `mobile`, `fax`
supported address types:
- salesforce accounts: `billing` , `shipping`
- salesforce contacts: `mailing`, `other`
- salesforce leads: `primary`
- hubspot accounts: `primary`
- hubspot contacts: `primary`

Next PR will implement POST/PATCH for these fields