### PR TITLE
fix: don't send up connection credentials

### DIFF
--- a/apps/api/routes/internal/v1/customer/index.ts
+++ b/apps/api/routes/internal/v1/customer/index.ts
@@ -10,7 +10,6 @@ import {
   GetCustomerResponse,
   GetCustomersPathParams,
   GetCustomersRequest,
-  GetCustomersResponse,
   UpsertCustomerPathParams,
   UpsertCustomerRequest,
   UpsertCustomerResponse,
@@ -26,10 +25,11 @@ export default function init(app: Router): void {
   customerRouter.get(
     '/',
     async (
-      req: Request<GetCustomersPathParams, GetCustomersResponse, GetCustomersRequest>,
-      res: Response<GetCustomersResponse>
+      req: Request<GetCustomersPathParams, any, GetCustomersRequest>,
+      res: Response // TODO: this response differs from the public /mgmt because we return a joined relation.
+      // We need to decide if we want openapi for internal endpoints or use something like tRPC or GraphQL
     ) => {
-      const customers = await customerService.list();
+      const customers = await customerService.listExpandedSafe();
       return res.status(200).send(customers.map(snakecaseKeys));
     }
   );

--- a/packages/core/mappers/customer.ts
+++ b/packages/core/mappers/customer.ts
@@ -1,19 +1,31 @@
-import { Customer, CustomerModelExpanded } from '../types/customer';
-import { fromConnectionModelToConnectionUnsafe } from './connection';
+import type { Customer as CustomerModel } from '@supaglue/db';
+import { Customer, CustomerExpandedSafe, CustomerModelExpanded } from '../types/customer';
+import { fromConnectionModelToConnectionSafe } from './connection';
 
-export const fromCustomerModel = (
-  { id, applicationId, externalIdentifier, name, email, connections }: CustomerModelExpanded,
-  includeRelations = false
-): Customer => {
+export const fromCustomerModel = ({ id, applicationId, externalIdentifier, name, email }: CustomerModel): Customer => {
   return {
     id,
     applicationId,
     externalIdentifier,
     name,
     email,
-    connections:
-      includeRelations && connections
-        ? connections.map((connection) => fromConnectionModelToConnectionUnsafe(connection))
-        : undefined,
+  };
+};
+
+export const fromCustomerModelExpandedUnsafe = ({
+  id,
+  applicationId,
+  externalIdentifier,
+  name,
+  email,
+  connections,
+}: CustomerModelExpanded): CustomerExpandedSafe => {
+  return {
+    id,
+    applicationId,
+    externalIdentifier,
+    name,
+    email,
+    connections: connections ? connections.map((connection) => fromConnectionModelToConnectionSafe(connection)) : [],
   };
 };

--- a/packages/core/services/customer_service.ts
+++ b/packages/core/services/customer_service.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient } from '@supaglue/db';
 import { NotFoundError } from '../errors';
-import { fromCustomerModel } from '../mappers/customer';
-import { Customer, CustomerUpsertParams } from '../types/customer';
+import { fromCustomerModel, fromCustomerModelExpandedUnsafe } from '../mappers/customer';
+import { Customer, CustomerExpandedSafe, CustomerUpsertParams } from '../types/customer';
 
 export class CustomerService {
   #prisma: PrismaClient;
@@ -22,12 +22,18 @@ export class CustomerService {
 
   // TODO: paginate
   public async list(): Promise<Customer[]> {
+    const customers = await this.#prisma.customer.findMany();
+    return customers.map((customer) => fromCustomerModel(customer));
+  }
+
+  // TODO: paginate
+  public async listExpandedSafe(): Promise<CustomerExpandedSafe[]> {
     const customers = await this.#prisma.customer.findMany({
       include: {
         connections: true,
       },
     });
-    return customers.map((customer) => fromCustomerModel(customer, true));
+    return customers.map((customer) => fromCustomerModelExpandedUnsafe(customer));
   }
 
   public async upsert(customer: CustomerUpsertParams): Promise<Customer> {

--- a/packages/core/types/customer.ts
+++ b/packages/core/types/customer.ts
@@ -1,6 +1,6 @@
 import type { Customer as CustomerModel } from '@supaglue/db';
 import { Connection as ConnectionModel } from '@supaglue/db';
-import { ConnectionUnsafe } from '../types/connection';
+import { ConnectionSafe } from '../types/connection';
 
 export type CustomerModelExpanded = CustomerModel & {
   connections?: ConnectionModel[] | null;
@@ -15,7 +15,10 @@ export type BaseCustomer = {
 
 export type Customer = BaseCustomer & {
   id: string;
-  connections?: ConnectionUnsafe[];
+};
+
+export type CustomerExpandedSafe = Customer & {
+  connections: ConnectionSafe[];
 };
 
 export type BaseCustomerCreateParams = BaseCustomer;


### PR DESCRIPTION
- Revert to the non-joined Customer type for public API
- Use a safe joined-relation for internal API

SUP1-140