### PR TITLE
chore: developer opted-in deployment id

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - SUPAGLUE_POSTHOG_API_KEY
       - SUPAGLUE_API_ENCRYPTION_SECRET
       - SUPAGLUE_INTERNAL_TOKEN
+      - SUPAGLUE_DEPLOYMENT_ID
     restart: on-failure
 
   sync-worker:
@@ -53,6 +54,7 @@ services:
       - SUPAGLUE_DISABLE_ERROR_REPORTING
       - SUPAGLUE_POSTHOG_API_KEY
       - SUPAGLUE_API_ENCRYPTION_SECRET
+      - SUPAGLUE_DEPLOYMENT_ID
     restart: on-failure
 
   temporal:

--- a/packages/core/lib/distinct_identifier.ts
+++ b/packages/core/lib/distinct_identifier.ts
@@ -1,25 +1,33 @@
+import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
+const sgDeploymentId = process.env.SUPAGLUE_DEPLOYMENT_ID;
 const configPath = path.join(os.homedir(), '.supaglue', 'session.json');
 let distinctIdentifier: string | undefined = undefined;
+
+function generateDistinctId() {
+  const suffix = crypto.randomBytes(4).toString('hex');
+  return sgDeploymentId ? `${sgDeploymentId}-${suffix}` : uuidv4();
+}
 
 // read distinctId from config file or write it if it doesn't exist
 if (fs.existsSync(configPath)) {
   const session = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 
   if (!session.distinctIdentifier) {
-    session.distinctIdentifier = uuidv4();
+    session.distinctIdentifier = generateDistinctId();
     fs.writeFileSync(configPath, JSON.stringify(session), 'utf8');
   }
 
   ({ distinctIdentifier } = session);
 } else {
-  distinctIdentifier = uuidv4();
+  distinctIdentifier = generateDistinctId();
   fs.mkdirSync(path.join(os.homedir(), '.supaglue'), { recursive: true });
   fs.writeFileSync(configPath, JSON.stringify({ distinctIdentifier }));
 }
 
+// The distinctIdentifier "session" lives from the time a developer runs docker compose to the time that they delete `session.json` from their home directory on the filesystem. Locally, tt persists across docker compose up/down/restart and updates.
 export const distinctId = distinctIdentifier && `session:${distinctIdentifier}`;

--- a/packages/core/lib/distinct_identifier.ts
+++ b/packages/core/lib/distinct_identifier.ts
@@ -29,5 +29,5 @@ if (fs.existsSync(configPath)) {
   fs.writeFileSync(configPath, JSON.stringify({ distinctIdentifier }));
 }
 
-// The distinctIdentifier "session" lives from the time a developer runs docker compose to the time that they delete `session.json` from their home directory on the filesystem. Locally, tt persists across docker compose up/down/restart and updates.
+// The distinctIdentifier "session" lives from the time a developer runs docker compose to the time that they delete `session.json` from their home directory on the filesystem. Locally, it persists across docker compose up/down/restart and updates.
 export const distinctId = distinctIdentifier && `session:${distinctIdentifier}`;


### PR DESCRIPTION
- use `SUPAGLUE_DEPLOYMENT_ID` if a developer opts in, suffix it to avoid collisions

SUP1-62