### PR TITLE
chore: remove additional fields for openapi

### DIFF
--- a/apps/api/middleware/openapi.ts
+++ b/apps/api/middleware/openapi.ts
@@ -13,6 +13,9 @@ export const openapiMiddleware = (specDir: string) => {
     apiSpec,
     // TODO: switch to true when we support X-Account-Token
     validateSecurity: false,
+    validateRequests: {
+      removeAdditional: 'all',
+    },
   });
 };
 


### PR DESCRIPTION
just so we don't accidentally send any extra fields anywhere