### PR TITLE
chore: bump hubspot to latest version while avoiding token refresh issue

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "types": "index.ts",
   "packageManager": "yarn@3.4.1",
   "dependencies": {
-    "@hubspot/api-client": "8.3.2",
+    "@hubspot/api-client": "8.8.0",
     "@sentry/integrations": "^7.43.0",
     "@sentry/node": "^7.43.0",
     "@supaglue/db": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "types": "index.ts",
   "packageManager": "yarn@3.4.1",
   "dependencies": {
-    "@hubspot/api-client": "8.8.0",
+    "@hubspot/api-client": "^8.8.1",
     "@sentry/integrations": "^7.43.0",
     "@sentry/node": "^7.43.0",
     "@supaglue/db": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,9 +3151,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hubspot/api-client@npm:8.8.0":
-  version: 8.8.0
-  resolution: "@hubspot/api-client@npm:8.8.0"
+"@hubspot/api-client@npm:^8.8.1":
+  version: 8.8.1
+  resolution: "@hubspot/api-client@npm:8.8.1"
   dependencies:
     "@types/node-fetch": ^2.5.7
     bottleneck: ^2.19.5
@@ -3163,7 +3163,7 @@ __metadata:
     lodash.merge: ^4.6.2
     node-fetch: ^2.6.0
     url-parse: ^1.4.3
-  checksum: 4b726b5d37a6a3d112c90ed2ef7d1812791ed0fa17318fdc5187b129bd118c7cf12dc7e02057f4c5e7f2aeeeb821fe700d22d4a0649a1e5d64bb73918df127f9
+  checksum: 43102bfae44ebaeb1c41aabca6d75af3125b01362d5814461187c3782fb9514353fbf6f43c08d715ef83a9fbd27f5d31663fc2bbaa1abec5fbcc20966eb1e14c
   languageName: node
   linkType: hard
 
@@ -4275,7 +4275,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@supaglue/core@workspace:packages/core"
   dependencies:
-    "@hubspot/api-client": 8.8.0
+    "@hubspot/api-client": ^8.8.1
     "@sentry/integrations": ^7.43.0
     "@sentry/node": ^7.43.0
     "@supaglue/db": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,9 +3151,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hubspot/api-client@npm:8.3.2":
-  version: 8.3.2
-  resolution: "@hubspot/api-client@npm:8.3.2"
+"@hubspot/api-client@npm:8.8.0":
+  version: 8.8.0
+  resolution: "@hubspot/api-client@npm:8.8.0"
   dependencies:
     "@types/node-fetch": ^2.5.7
     bottleneck: ^2.19.5
@@ -3163,7 +3163,7 @@ __metadata:
     lodash.merge: ^4.6.2
     node-fetch: ^2.6.0
     url-parse: ^1.4.3
-  checksum: 965c25c5265f9dc43cce88291d3a8144f28fea12f90e0b1ec2ed04c0cc396da3d3994fc93041b3f04ff330f16b0ec1d26d83445e0f7de47069d5e1d2d9e9568c
+  checksum: 4b726b5d37a6a3d112c90ed2ef7d1812791ed0fa17318fdc5187b129bd118c7cf12dc7e02057f4c5e7f2aeeeb821fe700d22d4a0649a1e5d64bb73918df127f9
   languageName: node
   linkType: hard
 
@@ -4275,7 +4275,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@supaglue/core@workspace:packages/core"
   dependencies:
-    "@hubspot/api-client": 8.3.2
+    "@hubspot/api-client": 8.8.0
     "@sentry/integrations": ^7.43.0
     "@sentry/node": ^7.43.0
     "@supaglue/db": "workspace:*"


### PR DESCRIPTION
the hubspot client still has a bug for token refresh, but we work around it by not specifying limiterOptions or numberOfApiCallRetries, as suggested in this issue for now: https://github.com/HubSpot/hubspot-api-nodejs/issues/341

already removed the offending option in the last PR when we downgraded to 8.3.2: https://github.com/supaglue-labs/supaglue/pull/250/files#r1132997212