### PR TITLE
chore: remove relationship between SgUser and Application

### DIFF
--- a/apps/api/routes/internal/v1/auth/index.ts
+++ b/apps/api/routes/internal/v1/auth/index.ts
@@ -8,7 +8,6 @@ export default function init(app: Router): void {
 
   authRouter.post('/_login', async (req: Request, res: Response) => {
     const loggedInSgUser = await sgUserService.login({
-      applicationId: req.headers['x-application-id'] as string, // TODO: shouldn't be logging into an application, but an organization
       username: req.body.username,
       password: req.body.password,
     });

--- a/apps/mgmt-ui/src/pages/api/auth/[...nextauth].ts
+++ b/apps/mgmt-ui/src/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,6 @@
 import NextAuth from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
-import { API_HOST, SG_INTERNAL_TOKEN } from '..';
+import { API_HOST, APPLICATION_ID, SG_INTERNAL_TOKEN } from '..';
 
 export const authOptions = {
   providers: [
@@ -11,6 +11,7 @@ export const authOptions = {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'x-application-id': APPLICATION_ID, // TODO: shouldn't be logging into an application, but an organization
             'x-sg-internal-token': SG_INTERNAL_TOKEN,
           },
           body: JSON.stringify({

--- a/apps/mgmt-ui/src/pages/api/auth/[...nextauth].ts
+++ b/apps/mgmt-ui/src/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,6 @@
 import NextAuth from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
-import { API_HOST, APPLICATION_ID, SG_INTERNAL_TOKEN } from '..';
+import { API_HOST, SG_INTERNAL_TOKEN } from '..';
 
 export const authOptions = {
   providers: [
@@ -11,7 +11,6 @@ export const authOptions = {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'x-application-id': APPLICATION_ID, // TODO: shouldn't be logging into an application, but an organization
             'x-sg-internal-token': SG_INTERNAL_TOKEN,
           },
           body: JSON.stringify({

--- a/packages/core/mappers/sg_user.ts
+++ b/packages/core/mappers/sg_user.ts
@@ -1,12 +1,11 @@
 import type { SgUser as SgUserModel } from '@supaglue/db';
 import { SgUser } from '../types';
 
-export const fromSgUserModel = ({ id, authType, username, password, applicationId }: SgUserModel): SgUser => {
+export const fromSgUserModel = ({ id, authType, username, password }: SgUserModel): SgUser => {
   return {
     id,
     authType,
     username,
     password,
-    applicationId,
   };
 };

--- a/packages/core/services/sg_user_service.ts
+++ b/packages/core/services/sg_user_service.ts
@@ -10,21 +10,10 @@ export class SgUserService {
     this.#prisma = prisma;
   }
 
-  public async login({
-    applicationId,
-    username,
-    password,
-  }: {
-    applicationId: string;
-    username: string;
-    password: string;
-  }): Promise<SgUser | null> {
+  public async login({ username, password }: { username: string; password: string }): Promise<SgUser | null> {
     const sgUserModel = await this.#prisma.sgUser.findUnique({
       where: {
-        applicationId_username: {
-          applicationId,
-          username,
-        },
+        username,
       },
     });
 

--- a/packages/core/types/sg_user.ts
+++ b/packages/core/types/sg_user.ts
@@ -1,7 +1,6 @@
 type BaseSgUser = {
   username: string;
   password: string;
-  applicationId: string;
   authType: string;
 };
 

--- a/packages/db/prisma/migrations/20230320180203_application_sg_user_relation/migration.sql
+++ b/packages/db/prisma/migrations/20230320180203_application_sg_user_relation/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `application_id` on the `sg_users` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[username]` on the table `sg_users` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "sg_users" DROP CONSTRAINT "sg_users_application_id_fkey";
+
+-- DropIndex
+DROP INDEX "sg_users_application_id_username_key";
+
+-- AlterTable
+ALTER TABLE "sg_users" DROP COLUMN "application_id";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sg_users_username_key" ON "sg_users"("username");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -11,16 +11,13 @@ datasource db {
 }
 
 model SgUser {
-  id            String      @id @default(uuid())
-  authType      String      @map("auth_type") // [username-password]
-  username      String
-  password      String
-  applicationId String      @map("application_id")
-  application   Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
-  createdAt     DateTime    @default(now()) @map("created_at")
-  updatedAt     DateTime    @updatedAt @map("updated_at")
+  id        String   @id @default(uuid())
+  authType  String   @map("auth_type") // [username-password]
+  username  String   @unique
+  password  String
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
-  @@unique([applicationId, username])
   @@map("sg_users")
 }
 
@@ -32,7 +29,6 @@ model Application {
   updatedAt   DateTime      @updatedAt @map("updated_at")
   Customer    Customer[]
   Integration Integration[]
-  SgUser      SgUser[]
 
   @@map("applications")
 }

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -197,14 +197,12 @@ async function seedSgUser() {
       id: SG_USER_ID,
     },
     update: {
-      applicationId: APPLICATION_ID,
       authType: 'username/password',
       username: 'admin',
       password: ADMIN_PASSWORD ?? 'admin',
     },
     create: {
       id: SG_USER_ID,
-      applicationId: APPLICATION_ID,
       authType: 'username/password',
       username: 'admin',
       password: ADMIN_PASSWORD ?? 'admin',


### PR DESCRIPTION
For non-Cloud, any `SgUser` can access any `Application` and there are no roles. This gets rid of the relationship (to avoid dealing with roles, M-M mapping between SGUser and Application, etc.)