### PR TITLE
feat: customerId as concat of `applicationId:externalId`, misc fixes

### DIFF
--- a/apps/api/dependency_container.ts
+++ b/apps/api/dependency_container.ts
@@ -22,8 +22,7 @@ let dependencyContainer: DependencyContainer | undefined = undefined;
 
 function createDependencyContainer(): DependencyContainer {
   const coreDependencyContainer = getCoreDependencyContainer();
-  const { prisma, integrationService, remoteService, applicationService, connectionService, customerService } =
-    coreDependencyContainer;
+  const { prisma, integrationService, remoteService, applicationService, connectionService } = coreDependencyContainer;
 
   const temporalClient = new Client({
     connection: Connection.lazy({
@@ -31,7 +30,7 @@ function createDependencyContainer(): DependencyContainer {
     }),
   });
 
-  const syncService = new SyncService(temporalClient, connectionService, customerService);
+  const syncService = new SyncService(temporalClient, connectionService);
   const connectionWriterService = new ConnectionWriterService(
     prisma,
     syncService,

--- a/apps/api/middleware/connection.ts
+++ b/apps/api/middleware/connection.ts
@@ -1,8 +1,9 @@
 import { UnauthorizedError } from '@supaglue/core/errors';
+import { getCustomerId } from '@supaglue/core/lib/customerid';
 import { NextFunction, Request, Response } from 'express';
 import { getDependencyContainer } from '../dependency_container';
 
-const { customerService, connectionService, integrationService } = getDependencyContainer();
+const { connectionService, integrationService } = getDependencyContainer();
 
 export async function connectionHeaderMiddleware(req: Request, res: Response, next: NextFunction) {
   const externalCustomerId = req.headers['x-customer-id'] as string;
@@ -11,12 +12,12 @@ export async function connectionHeaderMiddleware(req: Request, res: Response, ne
     throw new UnauthorizedError(`x-customer-id and x-provider-name headers must be set`);
   }
 
-  const customer = await customerService.getByExternalId(req.supaglueApplication.id, externalCustomerId);
+  const customerId = getCustomerId(req.supaglueApplication.id, externalCustomerId);
 
   const integration = await integrationService.getByProviderName(providerName);
 
   req.customerConnection = await connectionService.getSafeByCustomerIdAndIntegrationId({
-    customerId: customer.id,
+    customerId,
     integrationId: integration.id,
   });
 

--- a/apps/api/routes/mgmt/v1/sync_history.ts
+++ b/apps/api/routes/mgmt/v1/sync_history.ts
@@ -29,7 +29,7 @@ export default function init(app: Router) {
         snakecaseKeys({
           ...result,
           startTimestamp: result.startTimestamp.toISOString(),
-          endTimestamp: result.endTimestamp?.toISOString(),
+          endTimestamp: result.endTimestamp?.toISOString() ?? null,
         })
       );
       return res.status(200).send({ next, previous, results: snakeCaseResults });

--- a/apps/api/routes/mgmt/v1/sync_info.ts
+++ b/apps/api/routes/mgmt/v1/sync_info.ts
@@ -27,8 +27,8 @@ export default function init(app: Router): void {
       const syncInfoListRes = syncInfoList.map((syncInfo) =>
         snakecaseKeys({
           ...syncInfo,
-          lastSyncStart: syncInfo.lastSyncStart?.toISOString(),
-          nextSyncStart: syncInfo.nextSyncStart?.toISOString(),
+          lastSyncStart: syncInfo.lastSyncStart?.toISOString() ?? null,
+          nextSyncStart: syncInfo.nextSyncStart?.toISOString() ?? null,
         })
       );
       return res.status(200).send(syncInfoListRes);

--- a/apps/api/routes/oauth.ts
+++ b/apps/api/routes/oauth.ts
@@ -63,7 +63,7 @@ export default function init(app: Router): void {
         state: JSON.stringify({
           returnUrl: returnUrl ?? RETURN_URL,
           applicationId,
-          externalCustomerId: customerId,
+          customerId,
           providerName,
           scope: oauthScopes.join(' '), // TODO: this should be in a session
         }),
@@ -91,14 +91,14 @@ export default function init(app: Router): void {
         returnUrl,
         scope,
         providerName,
-        externalCustomerId,
+        customerId,
         applicationId,
       }: {
         returnUrl: string;
         scope?: string;
         applicationId?: string;
         providerName?: CRMProviderName;
-        externalCustomerId?: string;
+        customerId?: string;
       } = JSON.parse(decodeURIComponent(state));
 
       if (!providerName || !SUPPORTED_CRM_CONNECTIONS.includes(providerName)) {
@@ -113,8 +113,8 @@ export default function init(app: Router): void {
         throw new Error('No applicationId on state object');
       }
 
-      if (!externalCustomerId) {
-        throw new Error('No externalCustomerId on state object');
+      if (!customerId) {
+        throw new Error('No customerId on state object');
       }
 
       const integration = await integrationService.getByProviderName(providerName);
@@ -122,8 +122,6 @@ export default function init(app: Router): void {
       if (!integration.config) {
         throw new Error('Integration is not configured');
       }
-
-      const customer = await customerService.getByExternalId(applicationId, externalCustomerId);
 
       const { oauthClientId, oauthClientSecret } = integration.config.oauth.credentials;
 
@@ -150,7 +148,8 @@ export default function init(app: Router): void {
       const payload: ConnectionCreateParams | ConnectionUpsertParams = {
         category: 'crm',
         providerName,
-        customerId: customer.id,
+        applicationId,
+        customerId,
         integrationId: integration.id,
         credentials: {
           type: 'oauth2',

--- a/apps/api/services/connection_writer_service.ts
+++ b/apps/api/services/connection_writer_service.ts
@@ -1,5 +1,6 @@
 import { sendWebhookPayload } from '@supaglue/core/lib';
 import { encrypt } from '@supaglue/core/lib/crypt';
+import { getCustomerId } from '@supaglue/core/lib/customerid';
 import { fromConnectionModelToConnectionUnsafe } from '@supaglue/core/mappers/connection';
 import { ApplicationService, IntegrationService } from '@supaglue/core/services';
 import type {
@@ -44,12 +45,14 @@ export class ConnectionWriterService {
     const connection = await this.#prisma.connection.upsert({
       create: {
         ...params,
+        customerId: getCustomerId(params.applicationId, params.customerId),
         integrationId: integration.id,
         status,
         credentials: encrypt(JSON.stringify(params.credentials)),
       },
       update: {
         ...params,
+        customerId: getCustomerId(params.applicationId, params.customerId),
         integrationId: integration.id,
         status,
         credentials: encrypt(JSON.stringify(params.credentials)),
@@ -75,6 +78,7 @@ export class ConnectionWriterService {
       const connection = await this.#prisma.connection.create({
         data: {
           ...params,
+          customerId: getCustomerId(params.applicationId, params.customerId),
           integrationId: integration.id,
           status,
           credentials: encrypt(JSON.stringify(params.credentials)),

--- a/apps/api/services/sync_service.ts
+++ b/apps/api/services/sync_service.ts
@@ -1,5 +1,5 @@
+import { getCustomerId } from '@supaglue/core/lib/customerid';
 import { ConnectionService } from '@supaglue/core/services/connection_service';
-import { CustomerService } from '@supaglue/core/services/customer_service';
 import { ConnectionSafe, CRM_COMMON_MODELS } from '@supaglue/core/types/';
 import { CommonModel } from '@supaglue/core/types/common';
 import { SyncInfo, SyncInfoFilter } from '@supaglue/core/types/sync_info';
@@ -10,12 +10,10 @@ import { Client, ScheduleAlreadyRunning } from '@temporalio/client';
 export class SyncService {
   #temporalClient: Client;
   #connectionService: ConnectionService;
-  #customerService: CustomerService;
 
-  public constructor(temporalClient: Client, connectionService: ConnectionService, customerService: CustomerService) {
+  public constructor(temporalClient: Client, connectionService: ConnectionService) {
     this.#temporalClient = temporalClient;
     this.#connectionService = connectionService;
-    this.#customerService = customerService;
   }
 
   public async getSyncInfoList({
@@ -23,18 +21,14 @@ export class SyncService {
     externalCustomerId,
     providerName,
   }: SyncInfoFilter): Promise<SyncInfo[]> {
-    let customerId = undefined;
-    if (externalCustomerId) {
-      const customer = await this.#customerService.getByExternalId(applicationId, externalCustomerId);
-      customerId = customer.id;
-    }
+    const customerId = externalCustomerId ? getCustomerId(applicationId, externalCustomerId) : undefined;
     const connections = await this.#connectionService.listSafe(applicationId, customerId, providerName);
     const out = await Promise.all(connections.flatMap((connection) => this.getSyncInfoListFromConnection(connection)));
     return out.flat();
   }
 
   private async getSyncInfoFromConnectionAndCommonModel(
-    { id: connectionId, customerId, category, providerName }: ConnectionSafe,
+    { id: connectionId, applicationId, customerId, category, providerName }: ConnectionSafe,
     commonModel: CommonModel
   ): Promise<SyncInfo> {
     const scheduleId = getRunSyncsScheduleId(connectionId);
@@ -53,6 +47,7 @@ export class SyncService {
       nextSyncStart,
       status,
       connectionId,
+      applicationId,
       customerId,
       category,
       providerName,

--- a/docs/docs/embedded-links.mdx
+++ b/docs/docs/embedded-links.mdx
@@ -27,9 +27,9 @@ To obtain a `{PROVIDER_NAME}`, use the [Supaglue API](/api/crm) to create new in
 
 Examples:
 
-- [http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot](http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot)
+- [http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-hubspot&providerName=hubspot](http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-hubspot&providerName=hubspot)
 
-- [http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api](http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api)
+- [http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-hubspot&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api](http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-hubspot&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api)
 
 export const IntegrationCard = ({ icon, provider, description, to }) => (
   <div className="mb-4 p-6 max-w-4xl flex flex-col border rounded-md border-slate-200 border-solid items-start">
@@ -57,14 +57,14 @@ Embedded Links can be used in any UI components in your frontend application. Fo
   icon="/img/salesforce.svg"
   provider="Salesforce"
   description="Sync your leads in and out of Salesforce"
-  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-0&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-salesforce&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 
 <IntegrationCard
   icon="/img/hubspot.svg"
   provider="Hubspot"
   description="Sync your leads in and out of Hubspot"
-  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-hubspot&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 </div>
 

--- a/docs/docs/embedded-links.mdx
+++ b/docs/docs/embedded-links.mdx
@@ -12,23 +12,24 @@ An Embedded Link is a customer-facing HTTP link that developers add into their a
 
 An Embedded Link takes the following form:
 
-`{PROTOCOL}{DOMAIN}`/oauth/connect?customerId=`{CUSTOMER_ID}`&providerName=`{PROVIDER_NAME}`&returnUrl=`{RETURN_URL}`
+`{PROTOCOL}{DOMAIN}`/oauth/connect?applicationId=`{APPLICATION_ID}`&customerId=`{CUSTOMER_ID}`&providerName=`{PROVIDER_NAME}`&returnUrl=`{RETURN_URL}`
 
-| Parameter         | Description                                                                              | Required |
-| ----------------- | ---------------------------------------------------------------------------------------- | -------- |
-| `{PROTOCOL}`      | `http://` if running locally or `https://` if hosted on the cloud                        | Yes      |
-| `{DOMAIN}`        | The domain at which the Supaglue backend is hosted (e.g. `localhost:8080`)               | Yes      |
-| `{CUSTOMER_ID}`   | The unique identifier for a customer in your application                                 | Yes      |
-| `{PROVIDER_NAME}` | The name of the third-party provider (e.g. `salesforce`, `hubspot`, etc.)                | Yes      |
-| `{RETURN_URL}`    | The URL to return to once the OAuth connection is complete, note: this can be uriEncoded | No       |
+| Parameter          | Description                                                                              | Required |
+| ------------------ | ---------------------------------------------------------------------------------------- | -------- |
+| `{PROTOCOL}`       | `http://` if running locally or `https://` if hosted on the cloud                        | Yes      |
+| `{DOMAIN}`         | The domain at which the Supaglue backend is hosted (e.g. `localhost:8080`)               | Yes      |
+| `{APPLICATION_ID}` | The unique identifier for your Supaglue application                                      | Yes      |
+| `{CUSTOMER_ID}`    | The unique identifier for a customer in your application                                 | Yes      |
+| `{PROVIDER_NAME}`  | The name of the third-party provider (e.g. `salesforce`, `hubspot`, etc.)                | Yes      |
+| `{RETURN_URL}`     | The URL to return to once the OAuth connection is complete, note: this can be uriEncoded | No       |
 
 To obtain a `{PROVIDER_NAME}`, use the [Supaglue API](/api/crm) to create new integrations for your customers to have available for them to connect to.
 
 Examples:
 
-- [http://localhost:8080/oauth/connect?customerId=9ca0cd70-ae74-4f8f-81fd-9dd5d0a41677&providerName=salesforce](http://localhost:8080/oauth/connect?customerId=9ca0cd70-ae74-4f8f-81fd-9dd5d0a41677&providerName=salesforce)
+- [http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot](http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot)
 
-- [http://localhost:8080/oauth/connect?customerId=9ca0cd70-ae74-4f8f-81fd-9dd5d0a41677&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api](http://localhost:8080/oauth/connect?customerId=9ca0cd70-ae74-4f8f-81fd-9dd5d0a41677&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api)
+- [http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api](http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api)
 
 export const IntegrationCard = ({ icon, provider, description, to }) => (
   <div className="mb-4 p-6 max-w-4xl flex flex-col border rounded-md border-slate-200 border-solid items-start">
@@ -56,14 +57,14 @@ Embedded Links can be used in any UI components in your frontend application. Fo
   icon="/img/salesforce.svg"
   provider="Salesforce"
   description="Sync your leads in and out of Salesforce"
-  to="http://localhost:8080/oauth/connect?customerId=9ca0cd70-ae74-4f8f-81fd-9dd5d0a41677&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-0&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 
 <IntegrationCard
   icon="/img/hubspot.svg"
   provider="Hubspot"
   description="Sync your leads in and out of Hubspot"
-  to="http://localhost:8080/oauth/connect?customerId=ea3039fa-27de-4535-90d8-db2bab0c0252&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 </div>
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -131,14 +131,14 @@ export const IntegrationCard = ({ icon, provider, description, to }) => (
   icon="/img/salesforce.svg"
   provider="Salesforce"
   description="Sync your leads in and out of Salesforce"
-  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-0&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-salesforce&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 
 <IntegrationCard
   icon="/img/hubspot.svg"
   provider="Hubspot"
   description="Sync your leads in and out of Hubspot"
-  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-hubspot&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 </div>
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -131,14 +131,14 @@ export const IntegrationCard = ({ icon, provider, description, to }) => (
   icon="/img/salesforce.svg"
   provider="Salesforce"
   description="Sync your leads in and out of Salesforce"
-  to="http://localhost:8080/oauth/connect?customerId=9ca0cd70-ae74-4f8f-81fd-9dd5d0a41677&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-0&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 
 <IntegrationCard
   icon="/img/hubspot.svg"
   provider="Hubspot"
   description="Sync your leads in and out of Hubspot"
-  to="http://localhost:8080/oauth/connect?customerId=ea3039fa-27de-4535-90d8-db2bab0c0252&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 </div>
 

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -56,14 +56,14 @@ export const IntegrationCard = ({ icon, provider, description, to }) => (
   icon="/img/salesforce.svg"
   provider="Salesforce"
   description="Sync your leads in and out of Salesforce"
-  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-0&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-salesforce&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 
 <IntegrationCard
   icon="/img/hubspot.svg"
   provider="Hubspot"
   description="Sync your leads in and out of Hubspot"
-  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-hubspot&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 </div>
 

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -56,14 +56,14 @@ export const IntegrationCard = ({ icon, provider, description, to }) => (
   icon="/img/salesforce.svg"
   provider="Salesforce"
   description="Sync your leads in and out of Salesforce"
-  to="http://localhost:8080/oauth/connect?customerId=9ca0cd70-ae74-4f8f-81fd-9dd5d0a41677&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-0&providerName=salesforce&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 
 <IntegrationCard
   icon="/img/hubspot.svg"
   provider="Hubspot"
   description="Sync your leads in and out of Hubspot"
-  to="http://localhost:8080/oauth/connect?customerId=ea3039fa-27de-4535-90d8-db2bab0c0252&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
+  to="http://localhost:8080/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&providerName=hubspot&returnUrl=https%3A%2F%2Fdocs.supaglue.com%2Fquickstart%233-query-the-supaglue-unified-api"
 />
 </div>
 

--- a/helm/GKE_RUNBOOK.md
+++ b/helm/GKE_RUNBOOK.md
@@ -121,4 +121,4 @@ Log into the management UI at `https://$MANAGEMENT_HOST` with the 'admin' user a
 Create a test customer using postman.
 
 Go to
-<https://$API_HOST/oauth/connect?customerId=13967cfe-385a-427a-b8cf-b9cad04637b1&providerName=salesforce&returnUrl=https://$MANAGEMENT_HOST>
+<https://$API_HOST/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&returnUrl=https://$MANAGEMENT_HOST>

--- a/helm/GKE_RUNBOOK.md
+++ b/helm/GKE_RUNBOOK.md
@@ -121,4 +121,4 @@ Log into the management UI at `https://$MANAGEMENT_HOST` with the 'admin' user a
 Create a test customer using postman.
 
 Go to
-<https://$API_HOST/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-1&returnUrl=https://$MANAGEMENT_HOST>
+<https://$API_HOST/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-hubspot&returnUrl=https://$MANAGEMENT_HOST>

--- a/openapi/mgmt/components/schemas/objects/connection.yaml
+++ b/openapi/mgmt/components/schemas/objects/connection.yaml
@@ -11,9 +11,12 @@ properties:
       - authorized
       - callable
     example: available
-  customer_id:
+  application_id:
     type: string
     example: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+  customer_id:
+    type: string
+    example: my-customer-1
   integration_id:
     type: string
     example: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
@@ -24,21 +27,8 @@ properties:
 required:
   - id
   - status
+  - application_id
   - customer_id
   - integration_id
   - provider_name
   - category
-# ajv has issues with interpreting the id here as a schema id
-# example:
-#   id: e888cedf-e9d0-42c5-9485-2d72984faef3
-#   customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
-#   status: available
-#   integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
-#   provider_name: salesforce
-#   category: crm
-#   credentials:
-#   - type: oauth2
-#     access_token: FILL THIS
-#     refresh_token: FILL THIS
-#     instance_url: https://myapp-dev-ed.develop.my.salesforce.com
-#     expires_at: 2023-03-09T21:55:54Z

--- a/openapi/mgmt/components/schemas/sync_history.yaml
+++ b/openapi/mgmt/components/schemas/sync_history.yaml
@@ -13,9 +13,35 @@ properties:
     type: string
     nullable: true
     example: 2023-02-22T20:55:17.559537Z
+  application_id:
+    type: string
+    example: 974125fa-ffb6-47fc-b12f-44c566fc5da1
+  customer_id:
+    type: string
+    example: my-customer-1
+  provider_name:
+    type: string
+    example: hubspot
+  category:
+    type: string
+    enum: [crm]
+  connection_id:
+    type: string
+    example: 3217ea51-11c8-43c9-9547-6f197e02e5e4
   status:
     type: string # TODO enum?
     enum:
       - SUCCESS
       - IN_PROGRESS
       - FAILURE
+required:
+  - model_name
+  - start_timestamp
+  - end_timestamp
+  - application_id
+  - customer_id
+  - status
+  - error_message
+  - provider_name
+  - category
+  - connection_id

--- a/openapi/mgmt/components/schemas/sync_info.yaml
+++ b/openapi/mgmt/components/schemas/sync_info.yaml
@@ -12,8 +12,33 @@ properties:
     nullable: true
     example: 2023-02-22T20:55:17.559537Z
   status:
-    type: string # TODO enum?
+    type: string
     nullable: true
     enum:
       - SYNCING
       - DONE
+  application_id:
+    type: string
+    example: 974125fa-ffb6-47fc-b12f-44c566fc5da1
+  customer_id:
+    type: string
+    example: my-customer-1
+  provider_name:
+    type: string
+    example: hubspot
+  category:
+    type: string
+    enum: [crm]
+  connection_id:
+    type: string
+    example: 3217ea51-11c8-43c9-9547-6f197e02e5e4
+required:
+  - model_name
+  - last_sync_start
+  - next_sync_start
+  - status
+  - application_id
+  - customer_id
+  - provider_name
+  - category
+  - connection_id

--- a/openapi/mgmt/openapi.bundle.json
+++ b/openapi/mgmt/openapi.bundle.json
@@ -523,7 +523,8 @@
                     "value": [
                       {
                         "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6b",
-                        "customer_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
+                        "application_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
+                        "customer_id": "my-customer-1",
                         "status": "available",
                         "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
                         "provider_name": "salesforce",
@@ -531,7 +532,8 @@
                       },
                       {
                         "id": "e888cedf-e9d0-42c5-9485-2d72984faef7",
-                        "customer_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
+                        "application_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
+                        "customer_id": "my-customer-2",
                         "status": "available",
                         "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
                         "provider_name": "salesforce",
@@ -581,7 +583,8 @@
                   "Example": {
                     "value": {
                       "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6c",
-                      "customer_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
+                      "application_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
+                      "customer_id": "my-customer-1",
                       "status": "available",
                       "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
                       "provider_name": "salesforce",
@@ -617,7 +620,8 @@
                   "Example": {
                     "value": {
                       "id": "9572d08b-f19f-48cc-a992-1eb7031d3f6d",
-                      "customer_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
+                      "application_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
+                      "customer_id": "my-customer-1",
                       "status": "available",
                       "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
                       "provider_name": "salesforce",
@@ -780,7 +784,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "example": "1bae5050-b8ff-472e-8b9f-01f29a81d1ee"
+              "example": "my-customer-1"
             },
             "description": "The customer ID that uniquely identifies the customer in your application"
           },
@@ -847,14 +851,24 @@
                         {
                           "model_name": "account",
                           "start_timestamp": "2023-02-22T19:55:17.559Z",
-                          "status": "IN_PROGRESS"
+                          "status": "IN_PROGRESS",
+                          "application_id": "3217ea51-11c8-43c9-9547-6f197e02e5e4",
+                          "customer_id": "my-customer-1",
+                          "provider_name": "hubspot",
+                          "category": "crm",
+                          "connection_id": "f723e58c-3034-4056-babf-a8871ac12480"
                         },
                         {
                           "model_name": "contact",
                           "start_timestamp": "2023-02-22T19:50:17.559Z",
                           "end_timestamp": "2023-02-22T20:50:17.559Z",
                           "status": "ERROR",
-                          "error_message": "Error: Something went wrong"
+                          "error_message": "Error: Something went wrong",
+                          "application_id": "3217ea51-11c8-43c9-9547-6f197e02e5e4",
+                          "customer_id": "my-customer-1",
+                          "provider_name": "hubspot",
+                          "category": "crm",
+                          "connection_id": "f723e58c-3034-4056-babf-a8871ac12480"
                         }
                       ]
                     }
@@ -885,7 +899,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "example": "1bae5050-b8ff-472e-8b9f-01f29a81d1ee"
+              "example": "my-customer-1"
             },
             "description": "The customer ID that uniquely identifies the customer in your application"
           },
@@ -917,13 +931,23 @@
                         "model_name": "account",
                         "last_sync_start": "2023-02-22T19:55:17.559Z",
                         "next_sync_start": "2023-02-22T20:55:17.559Z",
-                        "status": "SYNCING"
+                        "status": "SYNCING",
+                        "application_id": "3217ea51-11c8-43c9-9547-6f197e02e5e4",
+                        "customer_id": "my-customer-1",
+                        "provider_name": "hubspot",
+                        "category": "crm",
+                        "connection_id": "f723e58c-3034-4056-babf-a8871ac12480"
                       },
                       {
                         "model_name": "contact",
                         "last_sync_start": "2023-02-22T19:50:17.559Z",
                         "next_sync_start": "2023-02-22T20:50:17.559Z",
-                        "status": "DONE"
+                        "status": "DONE",
+                        "application_id": "3217ea51-11c8-43c9-9547-6f197e02e5e4",
+                        "customer_id": "my-customer-1",
+                        "provider_name": "hubspot",
+                        "category": "crm",
+                        "connection_id": "f723e58c-3034-4056-babf-a8871ac12480"
                       }
                     ]
                   }
@@ -1031,9 +1055,13 @@
             ],
             "example": "available"
           },
-          "customer_id": {
+          "application_id": {
             "type": "string",
             "example": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69"
+          },
+          "customer_id": {
+            "type": "string",
+            "example": "my-customer-1"
           },
           "integration_id": {
             "type": "string",
@@ -1049,6 +1077,7 @@
         "required": [
           "id",
           "status",
+          "application_id",
           "customer_id",
           "integration_id",
           "provider_name",
@@ -1276,8 +1305,41 @@
               "SYNCING",
               "DONE"
             ]
+          },
+          "application_id": {
+            "type": "string",
+            "example": "974125fa-ffb6-47fc-b12f-44c566fc5da1"
+          },
+          "customer_id": {
+            "type": "string",
+            "example": "my-customer-1"
+          },
+          "provider_name": {
+            "type": "string",
+            "example": "hubspot"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "crm"
+            ]
+          },
+          "connection_id": {
+            "type": "string",
+            "example": "3217ea51-11c8-43c9-9547-6f197e02e5e4"
           }
-        }
+        },
+        "required": [
+          "model_name",
+          "last_sync_start",
+          "next_sync_start",
+          "status",
+          "application_id",
+          "customer_id",
+          "provider_name",
+          "category",
+          "connection_id"
+        ]
       },
       "sync_history": {
         "type": "object",
@@ -1299,6 +1361,28 @@
             "nullable": true,
             "example": "2023-02-22T20:55:17.559Z"
           },
+          "application_id": {
+            "type": "string",
+            "example": "974125fa-ffb6-47fc-b12f-44c566fc5da1"
+          },
+          "customer_id": {
+            "type": "string",
+            "example": "my-customer-1"
+          },
+          "provider_name": {
+            "type": "string",
+            "example": "hubspot"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "crm"
+            ]
+          },
+          "connection_id": {
+            "type": "string",
+            "example": "3217ea51-11c8-43c9-9547-6f197e02e5e4"
+          },
           "status": {
             "type": "string",
             "enum": [
@@ -1307,7 +1391,19 @@
               "FAILURE"
             ]
           }
-        }
+        },
+        "required": [
+          "model_name",
+          "start_timestamp",
+          "end_timestamp",
+          "application_id",
+          "customer_id",
+          "status",
+          "error_message",
+          "provider_name",
+          "category",
+          "connection_id"
+        ]
       },
       "webhook-payload": {
         "oneOf": [

--- a/openapi/mgmt/paths/connections.yaml
+++ b/openapi/mgmt/paths/connections.yaml
@@ -20,13 +20,15 @@ get:
             Example:
               value:
                 - id: 9572d08b-f19f-48cc-a992-1eb7031d3f6b
-                  customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+                  application_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+                  customer_id: my-customer-1
                   status: available
                   integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
                   provider_name: salesforce
                   category: crm
                 - id: e888cedf-e9d0-42c5-9485-2d72984faef7
-                  customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+                  application_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+                  customer_id: my-customer-2
                   status: available
                   integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
                   provider_name: salesforce

--- a/openapi/mgmt/paths/connections@{connection_id}.yaml
+++ b/openapi/mgmt/paths/connections@{connection_id}.yaml
@@ -16,7 +16,8 @@ get:
             Example:
               value:
                 id: 9572d08b-f19f-48cc-a992-1eb7031d3f6c
-                customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+                application_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+                customer_id: my-customer-1
                 status: available
                 integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
                 provider_name: salesforce
@@ -39,7 +40,8 @@ delete:
             Example:
               value:
                 id: 9572d08b-f19f-48cc-a992-1eb7031d3f6d
-                customer_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+                application_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
+                customer_id: my-customer-1
                 status: available
                 integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
                 provider_name: salesforce

--- a/openapi/mgmt/paths/sync_history.yaml
+++ b/openapi/mgmt/paths/sync_history.yaml
@@ -24,7 +24,7 @@ get:
       in: query
       schema:
         type: string
-        example: 1bae5050-b8ff-472e-8b9f-01f29a81d1ee
+        example: my-customer-1
       description: The customer ID that uniquely identifies the customer in your application
     - name: provider_name
       in: query
@@ -61,8 +61,18 @@ get:
                   - model_name: account
                     start_timestamp: 2023-02-22T19:55:17.559537Z
                     status: IN_PROGRESS
+                    application_id: 3217ea51-11c8-43c9-9547-6f197e02e5e4
+                    customer_id: my-customer-1
+                    provider_name: hubspot
+                    category: crm
+                    connection_id: f723e58c-3034-4056-babf-a8871ac12480
                   - model_name: contact
                     start_timestamp: 2023-02-22T19:50:17.559537Z
                     end_timestamp: 2023-02-22T20:50:17.559537Z
                     status: ERROR
                     error_message: 'Error: Something went wrong'
+                    application_id: 3217ea51-11c8-43c9-9547-6f197e02e5e4
+                    customer_id: my-customer-1
+                    provider_name: hubspot
+                    category: crm
+                    connection_id: f723e58c-3034-4056-babf-a8871ac12480

--- a/openapi/mgmt/paths/sync_info.yaml
+++ b/openapi/mgmt/paths/sync_info.yaml
@@ -12,7 +12,7 @@ get:
       in: query
       schema:
         type: string
-        example: 1bae5050-b8ff-472e-8b9f-01f29a81d1ee
+        example: my-customer-1 
       description: The customer ID that uniquely identifies the customer in your application
     - name: provider_name
       in: query
@@ -36,7 +36,17 @@ get:
                   last_sync_start: 2023-02-22T19:55:17.559537Z
                   next_sync_start: 2023-02-22T20:55:17.559537Z
                   status: SYNCING
+                  application_id: 3217ea51-11c8-43c9-9547-6f197e02e5e4
+                  customer_id: my-customer-1
+                  provider_name: hubspot
+                  category: crm
+                  connection_id: f723e58c-3034-4056-babf-a8871ac12480
                 - model_name: contact
                   last_sync_start: 2023-02-22T19:50:17.559537Z
                   next_sync_start: 2023-02-22T20:50:17.559537Z
                   status: DONE
+                  application_id: 3217ea51-11c8-43c9-9547-6f197e02e5e4
+                  customer_id: my-customer-1
+                  provider_name: hubspot
+                  category: crm
+                  connection_id: f723e58c-3034-4056-babf-a8871ac12480

--- a/packages/core/dependency_container.ts
+++ b/packages/core/dependency_container.ts
@@ -57,7 +57,7 @@ function createCoreDependencyContainer(): CoreDependencyContainer {
   const leadService = new LeadService(pgPool, prisma, remoteService);
   const opportunityService = new OpportunityService(pgPool, prisma, remoteService);
   const contactService = new ContactService(pgPool, prisma, remoteService);
-  const syncHistoryService = new SyncHistoryService(prisma, connectionService, customerService);
+  const syncHistoryService = new SyncHistoryService(prisma, connectionService);
   const userService = new UserService(pgPool, prisma, remoteService);
 
   return {

--- a/packages/core/lib/customerid.ts
+++ b/packages/core/lib/customerid.ts
@@ -1,0 +1,16 @@
+import { InternalServerError } from '@supaglue/core/errors';
+
+export const getCustomerId = (applicationId: string, externalCustomerId: string): string => {
+  return `${applicationId}:${externalCustomerId}`;
+};
+
+export const parseCustomerId = (customerId: string): { applicationId: string; externalCustomerId: string } => {
+  const split = customerId.split(/:(.*)/s);
+  if (split.length < 2) {
+    throw new InternalServerError(`Invalid customerId: ${customerId}`);
+  }
+  return {
+    applicationId: split[0],
+    externalCustomerId: split[1],
+  };
+};

--- a/packages/core/mappers/connection.ts
+++ b/packages/core/mappers/connection.ts
@@ -1,5 +1,6 @@
 import type { Connection as ConnectionModel } from '@supaglue/db';
 import { decrypt } from '../lib/crypt';
+import { parseCustomerId } from '../lib/customerid';
 import { ConnectionSafe, ConnectionStatus, ConnectionUnsafe, CRMProviderName } from '../types';
 
 export const fromConnectionModelToConnectionUnsafe = ({
@@ -11,9 +12,11 @@ export const fromConnectionModelToConnectionUnsafe = ({
   status,
   credentials,
 }: ConnectionModel): ConnectionUnsafe => {
+  const { applicationId, externalCustomerId } = parseCustomerId(customerId);
   return {
     id,
-    customerId,
+    applicationId,
+    customerId: externalCustomerId,
     integrationId,
     category: category as 'crm',
     status: status as ConnectionStatus,
@@ -30,9 +33,11 @@ export const fromConnectionModelToConnectionSafe = ({
   providerName,
   status,
 }: ConnectionModel): ConnectionSafe => {
+  const { applicationId, externalCustomerId } = parseCustomerId(customerId);
   return {
     id,
-    customerId,
+    applicationId,
+    customerId: externalCustomerId,
     integrationId,
     category: category as 'crm',
     status: status as ConnectionStatus,

--- a/packages/core/mappers/customer.ts
+++ b/packages/core/mappers/customer.ts
@@ -14,7 +14,7 @@ export const fromCustomerModel = ({ id, applicationId, externalIdentifier, name,
 
 export const toCustomerModelCreateParams = ({
   applicationId,
-  customerId,
+  customerId: customerId,
   name,
   email,
 }: CustomerUpsertParams): Omit<CustomerModel, 'id' | 'createdAt' | 'updatedAt'> => {

--- a/packages/core/mappers/sync_history.ts
+++ b/packages/core/mappers/sync_history.ts
@@ -1,3 +1,4 @@
+import { parseCustomerId } from '../lib/customerid';
 import { SyncHistory, SyncHistoryModelExpanded, SyncHistoryStatus } from '../types';
 
 export const fromSyncHistoryModelAndConnection = ({
@@ -9,16 +10,18 @@ export const fromSyncHistoryModelAndConnection = ({
   endTimestamp,
   connection,
 }: SyncHistoryModelExpanded): SyncHistory => {
+  const { applicationId, externalCustomerId } = parseCustomerId(connection.customerId);
   return {
     id,
-    model,
+    modelName: model,
     status: status as SyncHistoryStatus,
     errorMessage,
     startTimestamp,
     endTimestamp,
     connectionId: connection.id,
-    customerId: connection.customerId,
+    applicationId,
+    customerId: externalCustomerId,
     providerName: connection.providerName,
-    category: connection.category,
+    category: connection.category as 'crm',
   };
 };

--- a/packages/core/services/customer_service.ts
+++ b/packages/core/services/customer_service.ts
@@ -56,7 +56,10 @@ export class CustomerService {
           externalIdentifier: customer.customerId,
         },
       }, // TODO: (SUP1-58) applicationId should come from the session for security
-      create: toCustomerModelCreateParams(customer),
+      create: {
+        ...toCustomerModelCreateParams(customer),
+        id: `${customer.applicationId}:${customer.customerId}`,
+      },
       update: toCustomerModelCreateParams(customer),
     });
     return fromCustomerModel(updatedCustomer);

--- a/packages/core/services/sync_history_service.ts
+++ b/packages/core/services/sync_history_service.ts
@@ -1,4 +1,5 @@
 import type { PrismaClient } from '@supaglue/db';
+import { getCustomerId } from '../lib/customerid';
 import { getPaginationParams, getPaginationResult } from '../lib/pagination';
 import { fromSyncHistoryModelAndConnection } from '../mappers';
 import type {
@@ -10,17 +11,14 @@ import type {
   SyncHistoryStatus,
 } from '../types';
 import { ConnectionService } from './connection_service';
-import { CustomerService } from './customer_service';
 
 export class SyncHistoryService {
   #prisma: PrismaClient;
   #connectionService: ConnectionService;
-  #customerService: CustomerService;
 
-  constructor(prisma: PrismaClient, connectionService: ConnectionService, customerService: CustomerService) {
+  constructor(prisma: PrismaClient, connectionService: ConnectionService) {
     this.#prisma = prisma;
     this.#connectionService = connectionService;
-    this.#customerService = customerService;
   }
 
   public async create({
@@ -101,11 +99,7 @@ export class SyncHistoryService {
     externalCustomerId,
     providerName,
   }: SyncHistoryFilter): Promise<PaginatedResult<SyncHistory>> {
-    let customerId = undefined;
-    if (externalCustomerId) {
-      const customer = await this.#customerService.getByExternalId(applicationId, externalCustomerId);
-      customerId = customer.id;
-    }
+    const customerId = externalCustomerId ? getCustomerId(applicationId, externalCustomerId) : undefined;
     const connections = await this.#connectionService.listSafe(applicationId, customerId, providerName);
     const connectionIds = connections.map(({ id }) => id);
     const { page_size, cursor } = paginationParams;

--- a/packages/core/types/connection.ts
+++ b/packages/core/types/connection.ts
@@ -11,6 +11,8 @@ export type ConnectionCredentialsDecrypted = {
 };
 
 type BaseConnectionCreateParams = {
+  applicationId: string;
+  // External customer Id
   customerId: string;
   integrationId: string;
   credentials: ConnectionCredentialsDecrypted;

--- a/packages/core/types/customer.ts
+++ b/packages/core/types/customer.ts
@@ -8,6 +8,7 @@ export type CustomerModelExpanded = CustomerModel & {
 
 export type BaseCustomer = {
   applicationId: string;
+  // Externally provided
   customerId: string;
   name: string;
   email: string;

--- a/packages/core/types/sync_history.ts
+++ b/packages/core/types/sync_history.ts
@@ -10,14 +10,16 @@ export type SyncHistoryModelExpanded = SyncHistoryModel & {
 
 export type SyncHistory = {
   id: number;
-  model: string;
+  modelName: string;
   status: SyncHistoryStatus;
   errorMessage: string | null;
   startTimestamp: Date;
   endTimestamp: Date | null;
+  applicationId: string;
+  // External Id
   customerId: string;
   providerName: string;
-  category: string;
+  category: 'crm';
   connectionId: string;
 };
 

--- a/packages/core/types/sync_info.ts
+++ b/packages/core/types/sync_info.ts
@@ -6,9 +6,11 @@ export type SyncInfo = {
   nextSyncStart: Date | null;
   status: SyncStatus | null;
   // isInitialSync: boolean;
+  applicationId: string;
+  // External Id
   customerId: string;
   providerName: string;
-  category: string;
+  category: 'crm';
   connectionId: string;
 };
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -34,7 +34,7 @@ model Application {
 }
 
 model Customer {
-  id                 String       @id @default(uuid())
+  id                 String       @id // `applicationId:externalIdentifier`
   externalIdentifier String       @map("external_identifier")
   applicationId      String       @map("application_id")
   application        Application  @relation(fields: [applicationId], references: [id], onDelete: Cascade)

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -59,19 +59,20 @@ const {
 const SG_USER_ID = 'd56b851b-5a36-4480-bc43-515d677f46e3';
 const APPLICATION_ID = 'a4398523-03a2-42dd-9681-c91e3e2efaf4';
 
-const SALESFORCE_CUSTOMER_ID = '9ca0cd70-ae74-4f8f-81fd-9dd5d0a41677';
-const HUBSPOT_CUSTOMER_ID = 'ea3039fa-27de-4535-90d8-db2bab0c0252';
+const SALESFORCE_CUSTOMER_ID = 'external-customer-salesforce';
+const HUBSPOT_CUSTOMER_ID = 'external-customer-hubspot';
+const PIPEDRIVE_CUSTOMER_ID = 'external-customer-pipedrive';
+const ZENDESK_SELL_CUSTOMER_ID = 'external-customer-zendesk';
+const MS_DYNAMICS_365_SELL_CUSTOMER_ID = 'external-customer-ms-dynamics-365';
+const ZOHO_CRM_CUSTOMER_ID = 'external-customer-zoho';
+const CAPSULE_CUSTOMER_ID = 'external-customer-capsule';
+
 const SALESFORCE_INTEGRATION_ID = '9b725cc5-98f8-4cf7-bda4-c72242b456e2';
 const HUBSPOT_INTEGRATION_ID = '7ba1d794-8b15-476e-b81a-790513c287e9';
-const PIPEDRIVE_CUSTOMER_ID = 'eee222cf-6591-4195-a6da-a1b4a491fa8a';
 const PIPEDRIVE_INTEGRATION_ID = 'cbf33d3c-f798-4321-842f-d6f9cf56a27c';
-const ZENDESK_SELL_CUSTOMER_ID = 'c46667c3-fc64-4d92-9c89-582fb2ca6de1';
 const ZENDESK_SELL_INTEGRATION_ID = '767619f8-ecc9-487a-97f9-1e06f3702d4f';
-const MS_DYNAMICS_365_SELL_CUSTOMER_ID = '1d2c8f45-42df-44be-a18a-414cbbf5a8ec';
 const MS_DYNAMICS_365_SELL_INTEGRATION_ID = '59c80887-9326-43bd-bf66-dc6bd07f0a96';
-const ZOHO_CRM_CUSTOMER_ID = '313a5e13-5db8-44fb-b6b7-06a23e5fe25a';
 const ZOHO_CRM_INTEGRATION_ID = 'a86d14f9-d0ec-4e10-bdf1-65fafbd771d2';
-const CAPSULE_CUSTOMER_ID = 'e523cd5a-e044-4593-981b-ef07fc7a7f09';
 const CAPSULE_INTEGRATION_ID = 'f7e8ea69-f19d-4b61-8301-c1dd791757c4';
 
 const OAUTH_CLIENT_IDS = [
@@ -110,7 +111,7 @@ const OAUTH_APP_IDS = [
   DEV_ZOHO_CRM_APP_ID,
   DEV_CAPSULE_APP_ID,
 ];
-const CUSTOMER_IDS = [
+const EXTERNAL_CUSTOMER_IDS = [
   SALESFORCE_CUSTOMER_ID,
   HUBSPOT_CUSTOMER_ID,
   PIPEDRIVE_CUSTOMER_ID,
@@ -217,18 +218,23 @@ async function seedCustomers() {
 
   // Create customers
   await Promise.all(
-    CUSTOMER_IDS.map((id, idx) =>
+    EXTERNAL_CUSTOMER_IDS.map((externalCustomerId, idx) =>
       prisma.customer.upsert({
         where: {
-          id,
+          id: `${APPLICATION_ID}:${externalCustomerId}`,
         },
-        update: {},
-        create: {
-          id,
+        update: {
           applicationId: APPLICATION_ID,
           name: `customer-${idx}`,
           email: `customer-${idx}@email.com`,
-          externalIdentifier: `external-customer-${idx}`,
+          externalIdentifier: externalCustomerId,
+        },
+        create: {
+          id: `${APPLICATION_ID}:${externalCustomerId}`,
+          applicationId: APPLICATION_ID,
+          name: `customer-${idx}`,
+          email: `customer-${idx}@email.com`,
+          externalIdentifier: externalCustomerId,
         },
       })
     )

--- a/packages/schemas/gen/mgmt.ts
+++ b/packages/schemas/gen/mgmt.ts
@@ -143,6 +143,8 @@ export interface components {
        */
       status: "available" | "added" | "authorized" | "callable";
       /** @example d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69 */
+      application_id: string;
+      /** @example my-customer-1 */
       customer_id: string;
       /** @example 9572d08b-f19f-48cc-a992-1eb7031d3f6a */
       integration_id: string;
@@ -226,24 +228,44 @@ export interface components {
     };
     sync_info: {
       /** @example Account */
-      model_name?: string;
+      model_name: string;
       /** @example 2023-02-22T19:55:17.559Z */
-      last_sync_start?: string | null;
+      last_sync_start: string | null;
       /** @example 2023-02-22T20:55:17.559Z */
-      next_sync_start?: string | null;
+      next_sync_start: string | null;
       /** @enum {string|null} */
-      status?: "SYNCING" | "DONE" | null;
+      status: "SYNCING" | "DONE" | null;
+      /** @example 974125fa-ffb6-47fc-b12f-44c566fc5da1 */
+      application_id: string;
+      /** @example my-customer-1 */
+      customer_id: string;
+      /** @example hubspot */
+      provider_name: string;
+      /** @enum {string} */
+      category: "crm";
+      /** @example 3217ea51-11c8-43c9-9547-6f197e02e5e4 */
+      connection_id: string;
     };
     sync_history: {
       /** @example Account */
-      model_name?: string;
-      error_message?: string | null;
+      model_name: string;
+      error_message: string | null;
       /** @example 2023-02-22T19:55:17.559Z */
-      start_timestamp?: string;
+      start_timestamp: string;
       /** @example 2023-02-22T20:55:17.559Z */
-      end_timestamp?: string | null;
+      end_timestamp: string | null;
+      /** @example 974125fa-ffb6-47fc-b12f-44c566fc5da1 */
+      application_id: string;
+      /** @example my-customer-1 */
+      customer_id: string;
+      /** @example hubspot */
+      provider_name: string;
       /** @enum {string} */
-      status?: "SUCCESS" | "IN_PROGRESS" | "FAILURE";
+      category: "crm";
+      /** @example 3217ea51-11c8-43c9-9547-6f197e02e5e4 */
+      connection_id: string;
+      /** @enum {string} */
+      status: "SUCCESS" | "IN_PROGRESS" | "FAILURE";
     };
     "webhook-payload": OneOf<[{
       /** @enum {unknown} */


### PR DESCRIPTION
* `Customer.Id` is now `applicationId:externalId` instead of UUID
* `Connection`, `SyncInfo`, `SyncHistory` now contain `applicationId` and `customerId` (the external one)
* misc fixes to open API endpoints