### PR TITLE
feat: remote_account_id on connection

### DIFF
--- a/apps/api/routes/mgmt/v1/index.ts
+++ b/apps/api/routes/mgmt/v1/index.ts
@@ -1,17 +1,24 @@
+import { getDependencyContainer } from '@/dependency_container';
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
 import { openapiMiddleware } from '@/middleware/openapi';
-import { Router } from 'express';
+import { Request, Response, Router } from 'express';
 import customer from './customer';
 import integration from './integration';
 import syncHistory from './sync_history';
 import syncInfo from './sync_info';
 import webhook from './webhook';
 
+const { connectionService } = getDependencyContainer();
+
 export default function init(app: Router): void {
   const v1Router = Router();
 
-  v1Router.use(openapiMiddleware('mgmt'));
   v1Router.use(apiKeyHeaderMiddleware);
+  v1Router.post('/_backfill_remote_account_ids', async (req: Request, res: Response) => {
+    await connectionService.backfillRemoteAccountIds(req.supaglueApplication.id);
+    return res.status(200).send();
+  });
+  v1Router.use(openapiMiddleware('mgmt'));
 
   customer(v1Router);
   integration(v1Router);

--- a/apps/api/routes/mgmt/v1/index.ts
+++ b/apps/api/routes/mgmt/v1/index.ts
@@ -15,8 +15,8 @@ export default function init(app: Router): void {
 
   v1Router.use(apiKeyHeaderMiddleware);
   // TODO: Remove once all customers are backfilled / migrated
-  v1Router.post('/_backfill_remote_account_ids', async (req: Request, res: Response) => {
-    await connectionService.backfillRemoteAccountIds(req.supaglueApplication.id);
+  v1Router.post('/_backfill_connection_remote_ids', async (req: Request, res: Response) => {
+    await connectionService.backfillRemoteIds(req.supaglueApplication.id);
     return res.status(200).send();
   });
   v1Router.use(openapiMiddleware('mgmt'));

--- a/apps/api/routes/mgmt/v1/index.ts
+++ b/apps/api/routes/mgmt/v1/index.ts
@@ -14,6 +14,7 @@ export default function init(app: Router): void {
   const v1Router = Router();
 
   v1Router.use(apiKeyHeaderMiddleware);
+  // TODO: Remove once all customers are backfilled / migrated
   v1Router.post('/_backfill_remote_account_ids', async (req: Request, res: Response) => {
     await connectionService.backfillRemoteAccountIds(req.supaglueApplication.id);
     return res.status(200).send();

--- a/apps/api/routes/oauth.ts
+++ b/apps/api/routes/oauth.ts
@@ -146,13 +146,13 @@ export default function init(app: Router): void {
         ...additionalAuthParams,
       });
 
-      let remoteAccountId = tokenWrapper.token['refresh_token'] as string;
+      let remoteId = tokenWrapper.token['refresh_token'] as string;
 
       if (providerName) {
         const accessToken = tokenWrapper.token['access_token'] as string;
         const hubspotClient = new HubspotClient({ accessToken: tokenWrapper.token['access_token'] as string });
         const { hubId } = await hubspotClient.oauth.accessTokensApi.getAccessToken(accessToken);
-        remoteAccountId = hubId.toString();
+        remoteId = hubId.toString();
       }
 
       const payload: ConnectionCreateParams | ConnectionUpsertParams = {
@@ -168,7 +168,7 @@ export default function init(app: Router): void {
           instanceUrl: tokenWrapper.token['instance_url'] as string,
           expiresAt: tokenWrapper.token['expires_at'] as string,
         },
-        remoteAccountId,
+        remoteId,
       };
 
       try {

--- a/apps/api/services/connection_writer_service.ts
+++ b/apps/api/services/connection_writer_service.ts
@@ -93,6 +93,7 @@ export class ConnectionWriterService {
           integrationId: integration.id,
           status,
           credentials: encrypt(JSON.stringify(params.credentials)),
+          remoteAccountId: params.remoteAccountId,
         },
       });
       const connection = fromConnectionModelToConnectionUnsafe(connectionModel);

--- a/apps/api/services/connection_writer_service.ts
+++ b/apps/api/services/connection_writer_service.ts
@@ -93,7 +93,7 @@ export class ConnectionWriterService {
           integrationId: integration.id,
           status,
           credentials: encrypt(JSON.stringify(params.credentials)),
-          remoteAccountId: params.remoteAccountId,
+          remoteId: params.remoteId,
         },
       });
       const connection = fromConnectionModelToConnectionUnsafe(connectionModel);

--- a/openapi/mgmt/components/schemas/objects/connection.yaml
+++ b/openapi/mgmt/components/schemas/objects/connection.yaml
@@ -24,6 +24,9 @@ properties:
     $ref: ./provider_name.yaml
   category:
     $ref: ./category.yaml
+  remote_account_id:
+    type: string
+    example: 123456
 required:
   - id
   - status
@@ -32,3 +35,4 @@ required:
   - integration_id
   - provider_name
   - category
+  - remote_account_id

--- a/openapi/mgmt/components/schemas/objects/connection.yaml
+++ b/openapi/mgmt/components/schemas/objects/connection.yaml
@@ -24,7 +24,7 @@ properties:
     $ref: ./provider_name.yaml
   category:
     $ref: ./category.yaml
-  remote_account_id:
+  remote_id:
     type: string
     example: 123456
 required:
@@ -35,4 +35,4 @@ required:
   - integration_id
   - provider_name
   - category
-  - remote_account_id
+  - remote_id

--- a/openapi/mgmt/openapi.bundle.json
+++ b/openapi/mgmt/openapi.bundle.json
@@ -538,7 +538,7 @@
                         "integration_id": "db40a684-3150-46d2-bfd2-acb341a72681",
                         "provider_name": "hubspot",
                         "category": "crm",
-                        "remote_account_id": 1234567
+                        "remote_id": 1234567
                       }
                     ]
                   }
@@ -590,7 +590,7 @@
                       "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
                       "provider_name": "salesforce",
                       "category": "crm",
-                      "remote_account_id": "https://supaglue-dev-ed.develop.my.salesforce.com"
+                      "remote_id": "https://supaglue-dev-ed.develop.my.salesforce.com"
                     }
                   }
                 }
@@ -1055,7 +1055,7 @@
           "category": {
             "$ref": "#/components/schemas/category"
           },
-          "remote_account_id": {
+          "remote_id": {
             "type": "string",
             "example": 123456
           }
@@ -1068,7 +1068,7 @@
           "integration_id",
           "provider_name",
           "category",
-          "remote_account_id"
+          "remote_id"
         ]
       },
       "category": {

--- a/openapi/mgmt/openapi.bundle.json
+++ b/openapi/mgmt/openapi.bundle.json
@@ -535,9 +535,10 @@
                         "application_id": "d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69",
                         "customer_id": "my-customer-2",
                         "status": "available",
-                        "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
-                        "provider_name": "salesforce",
-                        "category": "crm"
+                        "integration_id": "db40a684-3150-46d2-bfd2-acb341a72681",
+                        "provider_name": "hubspot",
+                        "category": "crm",
+                        "remote_account_id": 1234567
                       }
                     ]
                   }
@@ -588,7 +589,8 @@
                       "status": "available",
                       "integration_id": "9572d08b-f19f-48cc-a992-1eb7031d3f6a",
                       "provider_name": "salesforce",
-                      "category": "crm"
+                      "category": "crm",
+                      "remote_account_id": "https://supaglue-dev-ed.develop.my.salesforce.com"
                     }
                   }
                 }
@@ -1052,6 +1054,10 @@
           },
           "category": {
             "$ref": "#/components/schemas/category"
+          },
+          "remote_account_id": {
+            "type": "string",
+            "example": 123456
           }
         },
         "required": [
@@ -1061,7 +1067,8 @@
           "customer_id",
           "integration_id",
           "provider_name",
-          "category"
+          "category",
+          "remote_account_id"
         ]
       },
       "category": {

--- a/openapi/mgmt/paths/connections.yaml
+++ b/openapi/mgmt/paths/connections.yaml
@@ -33,7 +33,7 @@ get:
                   integration_id: db40a684-3150-46d2-bfd2-acb341a72681
                   provider_name: hubspot 
                   category: crm
-                  remote_account_id: 1234567
+                  remote_id: 1234567
 parameters:
   - name: customer_id
     in: path

--- a/openapi/mgmt/paths/connections.yaml
+++ b/openapi/mgmt/paths/connections.yaml
@@ -30,9 +30,10 @@ get:
                   application_id: d8ceb3ff-8b7f-4fa7-b8de-849292f6ca69
                   customer_id: my-customer-2
                   status: available
-                  integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
-                  provider_name: salesforce
+                  integration_id: db40a684-3150-46d2-bfd2-acb341a72681
+                  provider_name: hubspot 
                   category: crm
+                  remote_account_id: 1234567
 parameters:
   - name: customer_id
     in: path

--- a/openapi/mgmt/paths/connections@{connection_id}.yaml
+++ b/openapi/mgmt/paths/connections@{connection_id}.yaml
@@ -22,7 +22,7 @@ get:
                 integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
                 provider_name: salesforce
                 category: crm
-                remote_account_id: https://supaglue-dev-ed.develop.my.salesforce.com
+                remote_id: https://supaglue-dev-ed.develop.my.salesforce.com
 delete:
   operationId: deleteConnection
   summary: Delete connection

--- a/openapi/mgmt/paths/connections@{connection_id}.yaml
+++ b/openapi/mgmt/paths/connections@{connection_id}.yaml
@@ -22,6 +22,7 @@ get:
                 integration_id: 9572d08b-f19f-48cc-a992-1eb7031d3f6a
                 provider_name: salesforce
                 category: crm
+                remote_account_id: https://supaglue-dev-ed.develop.my.salesforce.com
 delete:
   operationId: deleteConnection
   summary: Delete connection

--- a/packages/core/mappers/connection.ts
+++ b/packages/core/mappers/connection.ts
@@ -11,6 +11,7 @@ export const fromConnectionModelToConnectionUnsafe = ({
   providerName,
   status,
   credentials,
+  remoteAccountId,
 }: ConnectionModel): ConnectionUnsafe => {
   const { applicationId, externalCustomerId } = parseCustomerIdPk(customerId);
   return {
@@ -22,6 +23,8 @@ export const fromConnectionModelToConnectionUnsafe = ({
     status: status as ConnectionStatus,
     providerName: providerName as CRMProviderName,
     credentials: JSON.parse(decrypt(credentials)),
+    // TODO: Clean up after all customers are migrated
+    remoteAccountId: remoteAccountId ?? '',
   };
 };
 
@@ -32,6 +35,7 @@ export const fromConnectionModelToConnectionSafe = ({
   integrationId,
   providerName,
   status,
+  remoteAccountId,
 }: ConnectionModel): ConnectionSafe => {
   const { applicationId, externalCustomerId } = parseCustomerIdPk(customerId);
   return {
@@ -42,5 +46,7 @@ export const fromConnectionModelToConnectionSafe = ({
     category: category as 'crm',
     status: status as ConnectionStatus,
     providerName: providerName as CRMProviderName,
+    // TODO: Clean up after all customers are migrated
+    remoteAccountId: remoteAccountId ?? '',
   };
 };

--- a/packages/core/mappers/connection.ts
+++ b/packages/core/mappers/connection.ts
@@ -11,7 +11,7 @@ export const fromConnectionModelToConnectionUnsafe = ({
   providerName,
   status,
   credentials,
-  remoteAccountId,
+  remoteId,
 }: ConnectionModel): ConnectionUnsafe => {
   const { applicationId, externalCustomerId } = parseCustomerIdPk(customerId);
   return {
@@ -24,7 +24,7 @@ export const fromConnectionModelToConnectionUnsafe = ({
     providerName: providerName as CRMProviderName,
     credentials: JSON.parse(decrypt(credentials)),
     // TODO: Clean up after all customers are migrated
-    remoteAccountId: remoteAccountId ?? '',
+    remoteId: remoteId ?? '',
   };
 };
 
@@ -35,7 +35,7 @@ export const fromConnectionModelToConnectionSafe = ({
   integrationId,
   providerName,
   status,
-  remoteAccountId,
+  remoteId,
 }: ConnectionModel): ConnectionSafe => {
   const { applicationId, externalCustomerId } = parseCustomerIdPk(customerId);
   return {
@@ -47,6 +47,6 @@ export const fromConnectionModelToConnectionSafe = ({
     status: status as ConnectionStatus,
     providerName: providerName as CRMProviderName,
     // TODO: Clean up after all customers are migrated
-    remoteAccountId: remoteAccountId ?? '',
+    remoteId: remoteId ?? '',
   };
 };

--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -458,6 +458,13 @@ class HubSpotClient extends AbstractCrmRemoteClient {
     await this.maybeRefreshAccessToken();
     return await super.sendPassthroughRequest(request);
   }
+
+  // TODO: Delete once all customers are migrated and backfilled
+  public async getRemoteAccountId() {
+    await this.maybeRefreshAccessToken();
+    const { hubId } = await this.#client.oauth.accessTokensApi.getAccessToken(this.#credentials.accessToken);
+    return hubId.toString();
+  }
 }
 
 // TODO: We should pass in a type-narrowed CRMConnection

--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -460,7 +460,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
   }
 
   // TODO: Delete once all customers are migrated and backfilled
-  public async getRemoteAccountId() {
+  public async getHubId() {
     await this.maybeRefreshAccessToken();
     const { hubId } = await this.#client.oauth.accessTokensApi.getAccessToken(this.#credentials.accessToken);
     return hubId.toString();

--- a/packages/core/services/connection_service.ts
+++ b/packages/core/services/connection_service.ts
@@ -61,7 +61,7 @@ export class ConnectionService {
   }
 
   // TODO: Delete once all customers are migrated and backfilled
-  public async backfillRemoteAccountIds(applicationId: string): Promise<void> {
+  public async backfillRemoteIds(applicationId: string): Promise<void> {
     const integrations = await this.#integrationService.list(applicationId);
     const integrationIds = integrations.map(({ id }) => id);
     const models = await this.#prisma.connection.findMany({
@@ -70,8 +70,8 @@ export class ConnectionService {
     const connections = models.map((connection) => fromConnectionModelToConnectionUnsafe(connection));
     await Promise.all(
       connections.map(async (connection) => {
-        const remoteAccountId = await this.getRemoteAccountId(connection);
-        await this.#prisma.connection.update({ where: { id: connection.id }, data: { remoteAccountId } });
+        const remoteId = await this.getRemoteAccountId(connection);
+        await this.#prisma.connection.update({ where: { id: connection.id }, data: { remoteId } });
       })
     );
   }
@@ -83,7 +83,7 @@ export class ConnectionService {
     }
     const integration = await this.#integrationService.getById(connection.integrationId);
     const hubspotClient = newClient(connection, integration as CompleteIntegration);
-    return hubspotClient.getRemoteAccountId();
+    return hubspotClient.getHubId();
   }
 
   public async delete(id: string, applicationId: string): Promise<void> {

--- a/packages/core/services/connection_service.ts
+++ b/packages/core/services/connection_service.ts
@@ -2,7 +2,8 @@ import type { PrismaClient } from '@supaglue/db';
 import { NotFoundError } from '../errors';
 import { decrypt, encrypt } from '../lib/crypt';
 import { fromConnectionModelToConnectionSafe, fromConnectionModelToConnectionUnsafe } from '../mappers';
-import type { ConnectionCredentialsDecrypted, ConnectionSafe, ConnectionUnsafe } from '../types';
+import { newClient } from '../remotes/crm/hubspot/index';
+import type { CompleteIntegration, ConnectionCredentialsDecrypted, ConnectionSafe, ConnectionUnsafe } from '../types';
 import { IntegrationService } from './integration_service';
 
 export class ConnectionService {
@@ -57,6 +58,32 @@ export class ConnectionService {
       where: { integrationId: { in: integrationIds }, customerId: customerId, providerName: providerName },
     });
     return connections.map((connection) => fromConnectionModelToConnectionSafe(connection));
+  }
+
+  // TODO: Delete once all customers are migrated and backfilled
+  public async backfillRemoteAccountIds(applicationId: string): Promise<void> {
+    const integrations = await this.#integrationService.list(applicationId);
+    const integrationIds = integrations.map(({ id }) => id);
+    const models = await this.#prisma.connection.findMany({
+      where: { integrationId: { in: integrationIds } },
+    });
+    const connections = models.map((connection) => fromConnectionModelToConnectionUnsafe(connection));
+    await Promise.all(
+      connections.map(async (connection) => {
+        const remoteAccountId = await this.getRemoteAccountId(connection);
+        await this.#prisma.connection.update({ where: { id: connection.id }, data: { remoteAccountId } });
+      })
+    );
+  }
+
+  // TODO: Delete once all customers are migrated and backfilled
+  private async getRemoteAccountId(connection: ConnectionUnsafe): Promise<string> {
+    if (connection.providerName !== 'hubspot') {
+      return connection.credentials.instanceUrl;
+    }
+    const integration = await this.#integrationService.getById(connection.integrationId);
+    const hubspotClient = newClient(connection, integration as CompleteIntegration);
+    return hubspotClient.getRemoteAccountId();
   }
 
   public async delete(id: string, applicationId: string): Promise<void> {

--- a/packages/core/types/connection.ts
+++ b/packages/core/types/connection.ts
@@ -16,7 +16,7 @@ type BaseConnectionCreateParams = {
   customerId: string;
   integrationId: string;
   credentials: ConnectionCredentialsDecrypted;
-  remoteAccountId: string;
+  remoteId: string;
 };
 
 type BaseConnection = BaseConnectionCreateParams & {

--- a/packages/core/types/connection.ts
+++ b/packages/core/types/connection.ts
@@ -16,6 +16,7 @@ type BaseConnectionCreateParams = {
   customerId: string;
   integrationId: string;
   credentials: ConnectionCredentialsDecrypted;
+  remoteAccountId: string;
 };
 
 type BaseConnection = BaseConnectionCreateParams & {

--- a/packages/db/prisma/migrations/20230327202406_connection_remote_account_id/migration.sql
+++ b/packages/db/prisma/migrations/20230327202406_connection_remote_account_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "connections" ADD COLUMN     "remote_account_id" TEXT;

--- a/packages/db/prisma/migrations/20230327202406_connection_remote_account_id/migration.sql
+++ b/packages/db/prisma/migrations/20230327202406_connection_remote_account_id/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "connections" ADD COLUMN     "remote_account_id" TEXT;

--- a/packages/db/prisma/migrations/20230328175058_connection_remote_id/migration.sql
+++ b/packages/db/prisma/migrations/20230328175058_connection_remote_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "connections" ADD COLUMN     "remote_id" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -68,7 +68,7 @@ model Connection {
   customer        Customer      @relation(fields: [customerId], references: [id], onDelete: Cascade)
   customerId      String        @map("customer_id")
   // TODO: Make it non-optional after all customers have been migrated.
-  remoteAccountId String?       @map("remote_account_id")
+  remoteId        String?       @map("remote_id")
   createdAt       DateTime      @default(now()) @map("created_at")
   updatedAt       DateTime      @updatedAt @map("updated_at")
   syncs           Sync[]

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -67,6 +67,8 @@ model Connection {
   credentials     Bytes // encrypted, {type, access_token, refresh_token, expires_at, raw}
   customer        Customer      @relation(fields: [customerId], references: [id], onDelete: Cascade)
   customerId      String        @map("customer_id")
+  // TODO: Make it non-optional after all customers have been migrated.
+  remoteAccountId String?       @map("remote_account_id")
   createdAt       DateTime      @default(now()) @map("created_at")
   updatedAt       DateTime      @updatedAt @map("updated_at")
   syncs           Sync[]

--- a/packages/schemas/gen/mgmt.ts
+++ b/packages/schemas/gen/mgmt.ts
@@ -151,7 +151,7 @@ export interface components {
       provider_name: components["schemas"]["provider_name"];
       category: components["schemas"]["category"];
       /** @example 123456 */
-      remote_account_id: string;
+      remote_id: string;
     };
     /** @enum {string} */
     category: "crm";

--- a/packages/schemas/gen/mgmt.ts
+++ b/packages/schemas/gen/mgmt.ts
@@ -150,6 +150,8 @@ export interface components {
       integration_id: string;
       provider_name: components["schemas"]["provider_name"];
       category: components["schemas"]["category"];
+      /** @example 123456 */
+      remote_account_id: string;
     };
     /** @enum {string} */
     category: "crm";


### PR DESCRIPTION
All `connection` objects now have a `remote_account_id` representing the account Id in the remote provider (see screenshot below)

![Screenshot 2023-03-27 at 2 56 45 PM](https://user-images.githubusercontent.com/1498449/228076724-f5bff61e-ffcd-4877-86a8-eff463b8363e.png)

### Migration instructions
Please reset all your connections, or hit the `{{baseUrl}}/mgmt/v1/_backfill_remote_account_ids` endpoint to backfill the `remote_account_id`s