### PR TITLE
feat: [Part 2] incremental syncs in hubspot

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "types": "index.ts",
   "packageManager": "yarn@3.4.1",
   "dependencies": {
-    "@hubspot/api-client": "8.3.2",
+    "@hubspot/api-client": "8.8.1",
     "@sentry/integrations": "^7.43.0",
     "@sentry/node": "^7.43.0",
     "@supaglue/db": "workspace:*",

--- a/packages/core/remotes/crm/base.ts
+++ b/packages/core/remotes/crm/base.ts
@@ -19,24 +19,24 @@ import { CompleteIntegration } from '../../types/integration';
 import { AbstractRemoteClient, RemoteClient } from '../base';
 
 export interface CrmRemoteClient extends RemoteClient {
-  listAccounts(): Promise<Readable>; // streams RemoteAccount
+  listAccounts(updatedAfter?: Date): Promise<Readable>; // streams RemoteAccount
   createAccount(params: RemoteAccountCreateParams): Promise<RemoteAccount>;
   updateAccount(params: RemoteAccountUpdateParams): Promise<RemoteAccount>;
 
-  listContacts(): Promise<Readable>; // streams RemoteContact
+  listContacts(updatedAfter?: Date): Promise<Readable>; // streams RemoteContact
   createContact(params: RemoteContactCreateParams): Promise<RemoteContact>;
   updateContact(params: RemoteContactUpdateParams): Promise<RemoteContact>;
 
-  listLeads(): Promise<Readable>; // streams RemoteLead
+  listLeads(updatedAfter?: Date): Promise<Readable>; // streams RemoteLead
   createLead(params: RemoteLeadCreateParams): Promise<RemoteLead>;
   updateLead(params: RemoteLeadUpdateParams): Promise<RemoteLead>;
 
-  listOpportunities(): Promise<Readable>; // streams RemoteOpportunity
+  listOpportunities(updatedAfter?: Date): Promise<Readable>; // streams RemoteOpportunity
   createOpportunity(params: RemoteOpportunityCreateParams): Promise<RemoteOpportunity>;
   updateOpportunity(params: RemoteOpportunityUpdateParams): Promise<RemoteOpportunity>;
 
   // Note: User creation/updates are not supported
-  listUsers(): Promise<Readable>; // streams RemoteUser
+  listUsers(updatedAfter?: Date): Promise<Readable>; // streams RemoteUser
 }
 
 export abstract class AbstractCrmRemoteClient extends AbstractRemoteClient implements CrmRemoteClient {
@@ -44,24 +44,24 @@ export abstract class AbstractCrmRemoteClient extends AbstractRemoteClient imple
     super(...args);
   }
 
-  abstract listAccounts(): Promise<Readable>; // streams RemoteAccount
+  abstract listAccounts(updatedAfter?: Date): Promise<Readable>; // streams RemoteAccount
   abstract createAccount(params: RemoteAccountCreateParams): Promise<RemoteAccount>;
   abstract updateAccount(params: RemoteAccountUpdateParams): Promise<RemoteAccount>;
 
-  abstract listContacts(): Promise<Readable>; // streams RemoteContact
+  abstract listContacts(updatedAfter?: Date): Promise<Readable>; // streams RemoteContact
   abstract createContact(params: RemoteContactCreateParams): Promise<RemoteContact>;
   abstract updateContact(params: RemoteContactUpdateParams): Promise<RemoteContact>;
 
-  abstract listLeads(): Promise<Readable>; // streams RemoteLead
+  abstract listLeads(updatedAfter?: Date): Promise<Readable>; // streams RemoteLead
   abstract createLead(params: RemoteLeadCreateParams): Promise<RemoteLead>;
   abstract updateLead(params: RemoteLeadUpdateParams): Promise<RemoteLead>;
 
-  abstract listOpportunities(): Promise<Readable>; // streams RemoteOpportunity
+  abstract listOpportunities(updatedAfter?: Date): Promise<Readable>; // streams RemoteOpportunity
   abstract createOpportunity(params: RemoteOpportunityCreateParams): Promise<RemoteOpportunity>;
   abstract updateOpportunity(params: RemoteOpportunityUpdateParams): Promise<RemoteOpportunity>;
 
   // Note: User creation/updates are not supported
-  abstract listUsers(): Promise<Readable>; // streams RemoteUser
+  abstract listUsers(updatedAfter?: Date): Promise<Readable>; // streams RemoteUser
 }
 
 export abstract class CrmRemoteClientEventEmitter extends EventEmitter {}

--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -79,7 +79,7 @@ const propertiesToFetch = {
     'hs_createdate', // TODO: Use this or createdate?
     'hs_is_contact', // TODO: distinguish from "visitor"?
     'hubspot_owner_id',
-    'lastmodifieddate',
+    'lastmodifieddate', // hs_lastmodifieddate is missing
     'lastname',
     'mobilephone',
     'phone',
@@ -97,6 +97,7 @@ const propertiesToFetch = {
     'closedate',
     'hs_is_closed_won',
     'hs_is_closed',
+    'hs_lastmodifieddate',
   ],
 };
 
@@ -466,7 +467,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
             {
               filters: [
                 {
-                  propertyName: 'lastmodifieddate',
+                  propertyName: 'lastmodifieddate', // hubspot doesn't set hs_lastmodifieddate for some reason
                   operator: 'GT', // TODO: should we do GTE in case there are multiple records updated at the same timestamp?
                   value: updatedAfter.getTime().toString(),
                 },

--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -340,7 +340,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
         const dealIds = response.results.map((deal) => deal.id);
 
         // Get associations
-        const contactToDealsMap = await this.#listAssociations(
+        const dealToCompaniesMap = await this.#listAssociations(
           'deal',
           'company',
           dealIds.map((id) => id)
@@ -354,7 +354,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
             ...deal,
             associations: {
               companies: {
-                results: contactToDealsMap[deal.id].map((id) => ({ id, type: 'deal_to_company' })),
+                results: dealToCompaniesMap[deal.id].map((id) => ({ id, type: 'deal_to_company' })),
               },
             },
           })),

--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -154,13 +154,17 @@ class HubSpotClient extends AbstractCrmRemoteClient {
     }
   }
 
-  public async listAccounts(): Promise<Readable> {
+  public async listAccounts(updatedAfter?: Date): Promise<Readable> {
+    const impl = updatedAfter
+      ? this.#listAccountsIncrementalImpl.bind(this, updatedAfter)
+      : this.#listAccountsFullImpl.bind(this);
+
     const passThrough = new PassThrough({ objectMode: true });
 
     (async () => {
       let after = undefined;
       do {
-        const currResults: HubspotPaginatedCompanies = await this.listAccountsImpl(after);
+        const currResults: HubspotPaginatedCompanies = await impl(after);
         const remoteAccounts = currResults.results.map(fromHubSpotCompanyToRemoteAccount);
         after = currResults.paging?.next?.after;
 
@@ -181,7 +185,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
     return passThrough;
   }
 
-  private async listAccountsImpl(after?: string): Promise<HubspotPaginatedCompanies> {
+  async #listAccountsFullImpl(after?: string): Promise<HubspotPaginatedCompanies> {
     const helper = async () => {
       try {
         await this.maybeRefreshAccessToken();
@@ -190,6 +194,41 @@ class HubSpotClient extends AbstractCrmRemoteClient {
           after,
           propertiesToFetch.company
         );
+        return companies;
+      } catch (e: any) {
+        logger.error(e, 'Error encountered');
+        throw e;
+      }
+    };
+    return await retry(helper, ASYNC_RETRY_OPTIONS);
+  }
+
+  async #listAccountsIncrementalImpl(updatedAfter: Date, after?: string): Promise<HubspotPaginatedCompanies> {
+    const helper = async () => {
+      try {
+        await this.maybeRefreshAccessToken();
+        const companies = await this.#client.crm.companies.searchApi.doSearch({
+          filterGroups: [
+            {
+              filters: [
+                {
+                  propertyName: 'hs_lastmodifieddate',
+                  operator: 'GT', // TODO: should we do GTE in case there are multiple records updated at the same timestamp?
+                  value: updatedAfter.getTime().toString(),
+                },
+              ],
+            },
+          ],
+          sorts: [
+            {
+              propertyName: 'hs_lastmodifieddate',
+              direction: 'ASCENDING',
+            } as unknown as string, // hubspot sdk has wrong types
+          ],
+          properties: propertiesToFetch.company,
+          limit: HUBSPOT_RECORD_LIMIT,
+          after: after as unknown as number, // hubspot sdk has wrong types
+        });
         return companies;
       } catch (e: any) {
         logger.error(e, 'Error encountered');
@@ -221,13 +260,17 @@ class HubSpotClient extends AbstractCrmRemoteClient {
     return await this.getAccount(company.id);
   }
 
-  public async listOpportunities(): Promise<Readable> {
+  public async listOpportunities(updatedAfter?: Date): Promise<Readable> {
+    const impl = updatedAfter
+      ? this.#listOpportunitiesIncrementalImpl.bind(this, updatedAfter)
+      : this.#listOpportunitiesFullImpl.bind(this);
+
     const passThrough = new PassThrough({ objectMode: true });
 
     (async () => {
       let after = undefined;
       do {
-        const currResults: HubspotPaginatedDeals = await this.listOpportunitiesImpl(after);
+        const currResults: HubspotPaginatedDeals = await impl(after);
         const remoteOpportunities = currResults.results.map(fromHubSpotDealToRemoteOpportunity);
         after = currResults.paging?.next?.after;
 
@@ -248,7 +291,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
     return passThrough;
   }
 
-  private async listOpportunitiesImpl(after?: string): Promise<HubspotPaginatedDeals> {
+  async #listOpportunitiesFullImpl(after?: string): Promise<HubspotPaginatedDeals> {
     const helper = async () => {
       try {
         await this.maybeRefreshAccessToken();
@@ -259,6 +302,51 @@ class HubSpotClient extends AbstractCrmRemoteClient {
           /* propertiesWithHistory */ undefined,
           /* associations */ ['company']
         );
+        return deals;
+      } catch (e: any) {
+        logger.error(e, 'Error encountered');
+        throw e;
+      }
+    };
+    return await retry(helper, ASYNC_RETRY_OPTIONS);
+  }
+
+  async #listOpportunitiesIncrementalImpl(updatedAfter: Date, after?: string): Promise<HubspotPaginatedDeals> {
+    const helper = async () => {
+      try {
+        await this.maybeRefreshAccessToken();
+        // TODO: need to grab associations too
+        const deals = await this.#client.crm.deals.searchApi.doSearch({
+          filterGroups: [
+            {
+              filters: [
+                {
+                  propertyName: 'hs_lastmodifieddate',
+                  operator: 'GT', // TODO: should we do GTE in case there are multiple records updated at the same timestamp?
+                  value: updatedAfter.getTime().toString(),
+                },
+              ],
+            },
+          ],
+          sorts: [
+            {
+              propertyName: 'hs_lastmodifieddate',
+              direction: 'ASCENDING',
+            } as unknown as string, // hubspot sdk has wrong types
+          ],
+          properties: propertiesToFetch.deal,
+          limit: HUBSPOT_RECORD_LIMIT,
+          after: after as unknown as number, // hubspot sdk has wrong types
+        });
+
+        // TODO: get associations
+
+        //   HUBSPOT_RECORD_LIMIT,
+        //   after,
+        //   propertiesToFetch.deal,
+        //   /* propertiesWithHistory */ undefined,
+        //   /* associations */ ['company']
+        // );
         return deals;
       } catch (e: any) {
         logger.error(e, 'Error encountered');
@@ -305,13 +393,17 @@ class HubSpotClient extends AbstractCrmRemoteClient {
     return await this.getOpportunity(deal.id);
   }
 
-  public async listContacts(): Promise<Readable> {
+  public async listContacts(updatedAfter?: Date): Promise<Readable> {
+    const impl = updatedAfter
+      ? this.#listContactsIncrementalImpl.bind(this, updatedAfter)
+      : this.#listContactsFullImpl.bind(this);
+
     const passThrough = new PassThrough({ objectMode: true });
 
     (async () => {
       let after = undefined;
       do {
-        const currResults: HubspotPaginatedContacts = await this.listContactsImpl(after);
+        const currResults: HubspotPaginatedContacts = await impl(after);
         const remoteContacts = currResults.results.map(fromHubSpotContactToRemoteContact);
         after = currResults.paging?.next?.after;
 
@@ -332,7 +424,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
     return passThrough;
   }
 
-  private async listContactsImpl(after?: string): Promise<HubspotPaginatedContacts> {
+  async #listContactsFullImpl(after?: string): Promise<HubspotPaginatedContacts> {
     const helper = async () => {
       try {
         await this.maybeRefreshAccessToken();
@@ -344,6 +436,54 @@ class HubSpotClient extends AbstractCrmRemoteClient {
           /* associations */ ['company']
         );
         return contacts;
+      } catch (e: any) {
+        logger.error(e, 'Error encountered');
+        throw e;
+      }
+    };
+    return await retry(helper, ASYNC_RETRY_OPTIONS);
+  }
+
+  async #listContactsIncrementalImpl(updatedAfter: Date, after?: string): Promise<HubspotPaginatedContacts> {
+    const helper = async () => {
+      try {
+        await this.maybeRefreshAccessToken();
+
+        // Get contacts
+        const contacts = await this.#client.crm.contacts.searchApi.doSearch({
+          filterGroups: [
+            {
+              filters: [
+                {
+                  propertyName: 'lastmodifieddate',
+                  operator: 'GT', // TODO: should we do GTE in case there are multiple records updated at the same timestamp?
+                  value: updatedAfter.getTime().toString(),
+                },
+              ],
+            },
+          ],
+          sorts: [
+            {
+              propertyName: 'lastmodifieddate',
+              direction: 'ASCENDING',
+            } as unknown as string, // hubspot sdk has wrong types
+          ],
+          properties: propertiesToFetch.contact,
+          limit: HUBSPOT_RECORD_LIMIT,
+          after: after as unknown as number, // hubspot sdk has wrong types
+        });
+        return contacts;
+
+        // TODO: Get associations
+
+        // const contacts = await this.#client.crm.contacts.basicApi.getPage(
+        //   HUBSPOT_RECORD_LIMIT,
+        //   after,
+        //   propertiesToFetch.contact,
+        //   /* propertiesWithHistory */ undefined,
+        //   /* associations */ ['company']
+        // );
+        // return contacts;
       } catch (e: any) {
         logger.error(e, 'Error encountered');
         throw e;
@@ -395,7 +535,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
     return await this.getContact(contact.id);
   }
 
-  public async listLeads(limit?: number): Promise<Readable> {
+  public async listLeads(updatedAfter?: Date): Promise<Readable> {
     return Readable.from([]);
   }
 
@@ -407,18 +547,30 @@ class HubSpotClient extends AbstractCrmRemoteClient {
     throw new Error('Not supported');
   }
 
-  public async listUsers(): Promise<Readable> {
+  public async listUsers(updatedAfter?: Date): Promise<Readable> {
     const passThrough = new PassThrough({ objectMode: true });
 
     (async () => {
       let after = undefined;
       do {
         const currResults: HubspotPaginatedOwners = await this.listUsersImpl(after);
-        const remoteAccounts = currResults.results.map(fromHubspotOwnerToRemoteUser);
+        const remoteUsers = currResults.results.map(fromHubspotOwnerToRemoteUser);
         after = currResults.paging?.next?.after;
 
         // Do not emit 'end' event until the last batch
-        const readable = Readable.from(remoteAccounts);
+        const readable = Readable.from(
+          remoteUsers.filter((remoteUser) => {
+            if (!updatedAfter) {
+              return true;
+            }
+
+            if (!remoteUser.remoteUpdatedAt) {
+              return true;
+            }
+
+            return updatedAfter < remoteUser.remoteUpdatedAt;
+          })
+        );
         readable.pipe(passThrough, { end: !after });
         readable.on('error', (err) => passThrough.emit('error', err));
 

--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -637,7 +637,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
         inputs: fromObjectIds.map((id) => ({ id })),
       });
       return associations.results
-        .map((result) => result.to.map(({ id }) => ({ [result._from.id]: id })))
+        .map((result) => ({ [result._from.id]: result.to.map(({ id }) => id) }))
         .reduce((acc, curr) => ({ ...acc, ...curr }), {});
     };
     return await retry(helper, ASYNC_RETRY_OPTIONS);

--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -222,11 +222,11 @@ class HubSpotClient extends AbstractCrmRemoteClient {
             {
               propertyName: 'hs_lastmodifieddate',
               direction: 'ASCENDING',
-            } as unknown as string, // hubspot sdk has wrong types
+            } as unknown as string, // hubspot sdk has wrong types https://github.com/HubSpot/hubspot-api-nodejs/issues/350
           ],
           properties: propertiesToFetch.company,
           limit: HUBSPOT_RECORD_LIMIT,
-          after: after as unknown as number, // hubspot sdk has wrong types
+          after: after as unknown as number, // hubspot sdk has wrong types https://github.com/HubSpot/hubspot-api-nodejs/issues/350
         });
         return companies;
       } catch (e: any) {
@@ -330,11 +330,11 @@ class HubSpotClient extends AbstractCrmRemoteClient {
             {
               propertyName: 'hs_lastmodifieddate',
               direction: 'ASCENDING',
-            } as unknown as string, // hubspot sdk has wrong types
+            } as unknown as string, // hubspot sdk has wrong types https://github.com/HubSpot/hubspot-api-nodejs/issues/350
           ],
           properties: propertiesToFetch.deal,
           limit: HUBSPOT_RECORD_LIMIT,
-          after: after as unknown as number, // hubspot sdk has wrong types
+          after: after as unknown as number, // hubspot sdk has wrong types https://github.com/HubSpot/hubspot-api-nodejs/issues/350
         });
 
         const dealIds = response.results.map((deal) => deal.id);

--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -354,7 +354,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
             ...deal,
             associations: {
               companies: {
-                results: dealToCompaniesMap[deal.id].map((id) => ({ id, type: 'deal_to_company' })),
+                results: (dealToCompaniesMap[deal.id] ?? []).map((id) => ({ id, type: 'deal_to_company' })),
               },
             },
           })),
@@ -501,7 +501,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
             ...contact,
             associations: {
               companies: {
-                results: contactToCompaniesMap[contact.id].map((id) => ({ id, type: 'contact_to_company' })),
+                results: (contactToCompaniesMap[contact.id] ?? []).map((id) => ({ id, type: 'contact_to_company' })),
               },
             },
           })),

--- a/packages/core/services/common_models/account_service.ts
+++ b/packages/core/services/common_models/account_service.ts
@@ -202,6 +202,18 @@ export class AccountService extends CommonModelBaseService {
     const accountsTable = COMMON_MODEL_DB_TABLES['accounts'];
     const usersTable = COMMON_MODEL_DB_TABLES['users'];
 
+    await this.prisma.crmAccount.updateMany({
+      where: {
+        remoteOwnerId: null,
+        ownerId: {
+          not: null,
+        },
+      },
+      data: {
+        ownerId: null,
+      },
+    });
+
     await this.prisma.$executeRawUnsafe(`
       UPDATE ${accountsTable} c
       SET owner_id = u.id

--- a/packages/core/services/common_models/contact_service.ts
+++ b/packages/core/services/common_models/contact_service.ts
@@ -226,6 +226,18 @@ export class ContactService extends CommonModelBaseService {
     const contactsTable = COMMON_MODEL_DB_TABLES['contacts'];
     const accountsTable = COMMON_MODEL_DB_TABLES['accounts'];
 
+    await this.prisma.crmContact.updateMany({
+      where: {
+        remoteAccountId: null,
+        accountId: {
+          not: null,
+        },
+      },
+      data: {
+        accountId: null,
+      },
+    });
+
     await this.prisma.$executeRawUnsafe(`
       UPDATE ${contactsTable} c
       SET account_id = a.id
@@ -242,6 +254,18 @@ export class ContactService extends CommonModelBaseService {
   public async updateDanglingOwners(connectionId: string): Promise<void> {
     const contactsTable = COMMON_MODEL_DB_TABLES['contacts'];
     const usersTable = COMMON_MODEL_DB_TABLES['users'];
+
+    await this.prisma.crmContact.updateMany({
+      where: {
+        remoteOwnerId: null,
+        ownerId: {
+          not: null,
+        },
+      },
+      data: {
+        ownerId: null,
+      },
+    });
 
     await this.prisma.$executeRawUnsafe(`
       UPDATE ${contactsTable} c

--- a/packages/core/services/common_models/lead_service.ts
+++ b/packages/core/services/common_models/lead_service.ts
@@ -177,6 +177,18 @@ export class LeadService extends CommonModelBaseService {
     const leadsTable = COMMON_MODEL_DB_TABLES['leads'];
     const accountsTable = COMMON_MODEL_DB_TABLES['accounts'];
 
+    await this.prisma.crmLead.updateMany({
+      where: {
+        convertedRemoteAccountId: null,
+        convertedAccountId: {
+          not: null,
+        },
+      },
+      data: {
+        convertedAccountId: null,
+      },
+    });
+
     await this.prisma.$executeRawUnsafe(`
       UPDATE ${leadsTable} l
       SET converted_account_id = a.id
@@ -194,6 +206,18 @@ export class LeadService extends CommonModelBaseService {
     const leadsTable = COMMON_MODEL_DB_TABLES['leads'];
     const contactsTable = COMMON_MODEL_DB_TABLES['contacts'];
 
+    await this.prisma.crmLead.updateMany({
+      where: {
+        convertedRemoteContactId: null,
+        convertedContactId: {
+          not: null,
+        },
+      },
+      data: {
+        convertedContactId: null,
+      },
+    });
+
     await this.prisma.$executeRawUnsafe(`
       UPDATE ${leadsTable} l
       SET converted_contact_id = c.id
@@ -210,6 +234,18 @@ export class LeadService extends CommonModelBaseService {
   public async updateDanglingOwners(connectionId: string): Promise<void> {
     const leadsTable = COMMON_MODEL_DB_TABLES['leads'];
     const usersTable = COMMON_MODEL_DB_TABLES['users'];
+
+    await this.prisma.crmLead.updateMany({
+      where: {
+        remoteOwnerId: null,
+        ownerId: {
+          not: null,
+        },
+      },
+      data: {
+        ownerId: null,
+      },
+    });
 
     await this.prisma.$executeRawUnsafe(`
       UPDATE ${leadsTable} c

--- a/packages/core/services/common_models/opportunity_service.ts
+++ b/packages/core/services/common_models/opportunity_service.ts
@@ -232,6 +232,18 @@ export class OpportunityService extends CommonModelBaseService {
     const opportunitiesTable = COMMON_MODEL_DB_TABLES['opportunities'];
     const accountsTable = COMMON_MODEL_DB_TABLES['accounts'];
 
+    await this.prisma.crmOpportunity.updateMany({
+      where: {
+        remoteAccountId: null,
+        accountId: {
+          not: null,
+        },
+      },
+      data: {
+        accountId: null,
+      },
+    });
+
     await this.prisma.$executeRawUnsafe(`
       UPDATE ${opportunitiesTable} o
       SET account_id = a.id
@@ -248,6 +260,18 @@ export class OpportunityService extends CommonModelBaseService {
   public async updateDanglingOwners(connectionId: string): Promise<void> {
     const opportunitiesTable = COMMON_MODEL_DB_TABLES['opportunities'];
     const usersTable = COMMON_MODEL_DB_TABLES['users'];
+
+    await this.prisma.crmOpportunity.updateMany({
+      where: {
+        remoteOwnerId: null,
+        ownerId: {
+          not: null,
+        },
+      },
+      data: {
+        ownerId: null,
+      },
+    });
 
     await this.prisma.$executeRawUnsafe(`
       UPDATE ${opportunitiesTable} c

--- a/packages/core/types/sync.ts
+++ b/packages/core/types/sync.ts
@@ -47,10 +47,10 @@ export type ReverseThenForwardSync = BaseSync & {
 export type SyncType = 'full then incremental' | 'reverse then forward';
 export type Sync = FullThenIncrementalSync | ReverseThenForwardSync;
 
-type FullThenIncrementalSyncStateCreatedPhase = {
+export type FullThenIncrementalSyncStateCreatedPhase = {
   phase: 'created';
 };
-type FullThenIncrementalSyncStateLivePhase = {
+export type FullThenIncrementalSyncStateLivePhase = {
   phase: 'full' | 'incremental';
   status: 'in progress' | 'done';
   maxRemoteUpdatedAtMsMap: Record<CommonModel, number>;

--- a/packages/sync-workflows/activities/import_records.ts
+++ b/packages/sync-workflows/activities/import_records.ts
@@ -16,6 +16,7 @@ export type ImportRecordsArgs = {
   syncId: string;
   connectionId: string;
   commonModel: CommonModel;
+  updatedAfterMs?: number;
 };
 
 export type ImportRecordsResult = {
@@ -36,6 +37,7 @@ export function createImportRecords(
     syncId,
     connectionId,
     commonModel,
+    updatedAfterMs,
   }: ImportRecordsArgs): Promise<ImportRecordsResult> {
     const connection = await connectionService.getSafeById(connectionId);
     const client = await remoteService.getCrmRemoteClient(connectionId);
@@ -47,9 +49,11 @@ export function createImportRecords(
 
     logEvent({ eventName: 'Start Sync', syncId, providerName: connection.providerName, modelName: commonModel });
 
+    const updatedAfter = updatedAfterMs ? new Date(updatedAfterMs) : undefined;
+
     switch (commonModel) {
       case 'account': {
-        const readable = await client.listAccounts();
+        const readable = await client.listAccounts(updatedAfter);
         result = await accountService.upsertRemoteAccounts(
           connection.id,
           connection.customerId,
@@ -58,7 +62,7 @@ export function createImportRecords(
         break;
       }
       case 'contact': {
-        const readable = await client.listContacts();
+        const readable = await client.listContacts(updatedAfter);
         result = await contactService.upsertRemoteContacts(
           connection.id,
           connection.customerId,
@@ -67,7 +71,7 @@ export function createImportRecords(
         break;
       }
       case 'opportunity': {
-        const readable = await client.listOpportunities();
+        const readable = await client.listOpportunities(updatedAfter);
         result = await opportunityService.upsertRemoteOpportunities(
           connection.id,
           connection.customerId,
@@ -76,7 +80,7 @@ export function createImportRecords(
         break;
       }
       case 'lead': {
-        const readable = await client.listLeads();
+        const readable = await client.listLeads(updatedAfter);
         result = await leadService.upsertRemoteLeads(
           connection.id,
           connection.customerId,
@@ -85,7 +89,7 @@ export function createImportRecords(
         break;
       }
       case 'user': {
-        const readable = await client.listUsers();
+        const readable = await client.listUsers(updatedAfter);
         result = await userService.upsertRemoteUsers(
           connection.id,
           connection.customerId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,9 +3151,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hubspot/api-client@npm:8.3.2":
-  version: 8.3.2
-  resolution: "@hubspot/api-client@npm:8.3.2"
+"@hubspot/api-client@npm:8.8.1":
+  version: 8.8.1
+  resolution: "@hubspot/api-client@npm:8.8.1"
   dependencies:
     "@types/node-fetch": ^2.5.7
     bottleneck: ^2.19.5
@@ -3163,7 +3163,7 @@ __metadata:
     lodash.merge: ^4.6.2
     node-fetch: ^2.6.0
     url-parse: ^1.4.3
-  checksum: 965c25c5265f9dc43cce88291d3a8144f28fea12f90e0b1ec2ed04c0cc396da3d3994fc93041b3f04ff330f16b0ec1d26d83445e0f7de47069d5e1d2d9e9568c
+  checksum: 43102bfae44ebaeb1c41aabca6d75af3125b01362d5814461187c3782fb9514353fbf6f43c08d715ef83a9fbd27f5d31663fc2bbaa1abec5fbcc20966eb1e14c
   languageName: node
   linkType: hard
 
@@ -4275,7 +4275,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@supaglue/core@workspace:packages/core"
   dependencies:
-    "@hubspot/api-client": 8.3.2
+    "@hubspot/api-client": 8.8.1
     "@sentry/integrations": ^7.43.0
     "@sentry/node": ^7.43.0
     "@supaglue/db": "workspace:*"


### PR DESCRIPTION
https://github.com/supaglue-labs/supaglue/issues/306

1. For all common models in hubspot, this first calls the search endpoint to get new records.
2. For deals and contacts in hubspot, this also calls the association endpoint to get all associated companies for those two object types.