### PR TITLE
feat: pull in deleted objects from hubspot

### DIFF
--- a/packages/core/remotes/crm/hubspot/index.ts
+++ b/packages/core/remotes/crm/hubspot/index.ts
@@ -164,45 +164,42 @@ class HubSpotClient extends AbstractCrmRemoteClient {
 
     const passThrough = new PassThrough({ objectMode: true });
 
-    // Accounts
     (async () => {
-      let after = undefined;
-      do {
-        const currResults: HubspotPaginatedCompanies = await impl(after);
-        const remoteAccounts = currResults.results.map(fromHubSpotCompanyToRemoteAccount);
-        after = currResults.paging?.next?.after;
+      // Accounts
+      {
+        let after = undefined;
+        do {
+          const currResults: HubspotPaginatedCompanies = await impl(after);
+          const remoteAccounts = currResults.results.map(fromHubSpotCompanyToRemoteAccount);
+          after = currResults.paging?.next?.after;
 
-        // Do not emit 'end' event until the last batch
-        const readable = Readable.from(remoteAccounts);
-        readable.pipe(passThrough, { end: !after });
-        readable.on('error', (err) => passThrough.emit('error', err));
+          // Do not emit 'end' event until the last batch
+          const readable = Readable.from(remoteAccounts);
+          readable.pipe(passThrough, { end: false });
+          readable.on('error', (err) => passThrough.emit('error', err));
 
-        // Wait
-        await new Promise((resolve) => readable.on('end', resolve));
-      } while (after);
-    })().catch((err: unknown) => {
-      // We need to forward the error to the returned `Readable` because there
-      // is no way for the caller to find out about errors in the above async block otherwise.
-      passThrough.emit('error', err);
-    });
+          // Wait
+          await new Promise((resolve) => readable.on('end', resolve));
+        } while (after);
+      }
+      // Archived Accounts
+      // TODO: this doesn't respect the `updatedAfter` parameter because we can't use the search API for archived accounts
+      {
+        let after = undefined;
+        do {
+          const currResults: HubspotPaginatedCompanies = await this.#listAccountsFullImpl(after, /* archived */ true);
+          const remoteAccounts = currResults.results.map(fromHubSpotCompanyToRemoteAccount);
+          after = currResults.paging?.next?.after;
 
-    // Archived Accounts
-    // TODO: this doesn't respect the `updatedAfter` parameter because we can't use the search API for archived accounts
-    (async () => {
-      let after = undefined;
-      do {
-        const currResults: HubspotPaginatedCompanies = await this.#listAccountsFullImpl(after, /* archived */ true);
-        const remoteAccounts = currResults.results.map(fromHubSpotCompanyToRemoteAccount);
-        after = currResults.paging?.next?.after;
+          // Do not emit 'end' event until the last batch
+          const readable = Readable.from(remoteAccounts);
+          readable.pipe(passThrough, { end: !after });
+          readable.on('error', (err) => passThrough.emit('error', err));
 
-        // Do not emit 'end' event until the last batch
-        const readable = Readable.from(remoteAccounts);
-        readable.pipe(passThrough, { end: !after });
-        readable.on('error', (err) => passThrough.emit('error', err));
-
-        // Wait
-        await new Promise((resolve) => readable.on('end', resolve));
-      } while (after);
+          // Wait
+          await new Promise((resolve) => readable.on('end', resolve));
+        } while (after);
+      }
     })().catch((err: unknown) => {
       // We need to forward the error to the returned `Readable` because there
       // is no way for the caller to find out about errors in the above async block otherwise.
@@ -297,45 +294,42 @@ class HubSpotClient extends AbstractCrmRemoteClient {
 
     const passThrough = new PassThrough({ objectMode: true });
 
-    // Opportunities
     (async () => {
-      let after = undefined;
-      do {
-        const currResults: HubspotPaginatedDeals = await impl(after);
-        const remoteOpportunities = currResults.results.map(fromHubSpotDealToRemoteOpportunity);
-        after = currResults.paging?.next?.after;
+      // Opportunities
+      {
+        let after = undefined;
+        do {
+          const currResults: HubspotPaginatedDeals = await impl(after);
+          const remoteOpportunities = currResults.results.map(fromHubSpotDealToRemoteOpportunity);
+          after = currResults.paging?.next?.after;
 
-        // Do not emit 'end' event until the last batch
-        const readable = Readable.from(remoteOpportunities);
-        readable.pipe(passThrough, { end: !after });
-        readable.on('error', (err) => passThrough.emit('error', err));
+          // Do not emit 'end' event until the last batch
+          const readable = Readable.from(remoteOpportunities);
+          readable.pipe(passThrough, { end: false });
+          readable.on('error', (err) => passThrough.emit('error', err));
 
-        // Wait
-        await new Promise((resolve) => readable.on('end', resolve));
-      } while (after);
-    })().catch((err: unknown) => {
-      // We need to forward the error to the returned `Readable` because there
-      // is no way for the caller to find out about errors in the above async block otherwise.
-      passThrough.emit('error', err);
-    });
+          // Wait
+          await new Promise((resolve) => readable.on('end', resolve));
+        } while (after);
+      }
+      // Archived Opportunities
+      // TODO: this doesn't respect the `updatedAfter` parameter because we can't use the search API for archived opportunities
+      {
+        let after = undefined;
+        do {
+          const currResults: HubspotPaginatedDeals = await this.#listOpportunitiesFullImpl(after, /* archived */ true);
+          const remoteOpportunities = currResults.results.map(fromHubSpotDealToRemoteOpportunity);
+          after = currResults.paging?.next?.after;
 
-    // Archived Opportunities
-    // TODO: this doesn't respect the `updatedAfter` parameter because we can't use the search API for archived opportunities
-    (async () => {
-      let after = undefined;
-      do {
-        const currResults: HubspotPaginatedDeals = await this.#listOpportunitiesFullImpl(after, /* archived */ true);
-        const remoteOpportunities = currResults.results.map(fromHubSpotDealToRemoteOpportunity);
-        after = currResults.paging?.next?.after;
+          // Do not emit 'end' event until the last batch
+          const readable = Readable.from(remoteOpportunities);
+          readable.pipe(passThrough, { end: !after });
+          readable.on('error', (err) => passThrough.emit('error', err));
 
-        // Do not emit 'end' event until the last batch
-        const readable = Readable.from(remoteOpportunities);
-        readable.pipe(passThrough, { end: !after });
-        readable.on('error', (err) => passThrough.emit('error', err));
-
-        // Wait
-        await new Promise((resolve) => readable.on('end', resolve));
-      } while (after);
+          // Wait
+          await new Promise((resolve) => readable.on('end', resolve));
+        } while (after);
+      }
     })().catch((err: unknown) => {
       // We need to forward the error to the returned `Readable` because there
       // is no way for the caller to find out about errors in the above async block otherwise.
@@ -467,45 +461,42 @@ class HubSpotClient extends AbstractCrmRemoteClient {
 
     const passThrough = new PassThrough({ objectMode: true });
 
-    // Contacts
     (async () => {
-      let after = undefined;
-      do {
-        const currResults: HubspotPaginatedContacts = await impl(after);
-        const remoteContacts = currResults.results.map(fromHubSpotContactToRemoteContact);
-        after = currResults.paging?.next?.after;
+      // Contacts
+      {
+        let after = undefined;
+        do {
+          const currResults: HubspotPaginatedContacts = await impl(after);
+          const remoteContacts = currResults.results.map(fromHubSpotContactToRemoteContact);
+          after = currResults.paging?.next?.after;
 
-        // Do not emit 'end' event until the last batch
-        const readable = Readable.from(remoteContacts);
-        readable.pipe(passThrough, { end: !after });
-        readable.on('error', (err) => passThrough.emit('error', err));
+          // Do not emit 'end' event until the last batch
+          const readable = Readable.from(remoteContacts);
+          readable.pipe(passThrough, { end: false });
+          readable.on('error', (err) => passThrough.emit('error', err));
 
-        // Wait
-        await new Promise((resolve) => readable.on('end', resolve));
-      } while (after);
-    })().catch((err: unknown) => {
-      // We need to forward the error to the returned `Readable` because there
-      // is no way for the caller to find out about errors in the above async block otherwise.
-      passThrough.emit('error', err);
-    });
+          // Wait
+          await new Promise((resolve) => readable.on('end', resolve));
+        } while (after);
+      }
+      // Archived Contacts
+      // TODO: this doesn't respect the `updatedAfter` parameter because we can't use the search API for archived contacts
+      {
+        let after = undefined;
+        do {
+          const currResults: HubspotPaginatedContacts = await this.#listContactsFullImpl(after, /* archived */ true);
+          const remoteContacts = currResults.results.map(fromHubSpotContactToRemoteContact);
+          after = currResults.paging?.next?.after;
 
-    // Archived Contacts
-    // TODO: this doesn't respect the `updatedAfter` parameter because we can't use the search API for archived contacts
-    (async () => {
-      let after = undefined;
-      do {
-        const currResults: HubspotPaginatedContacts = await this.#listContactsFullImpl(after, /* archived */ true);
-        const remoteContacts = currResults.results.map(fromHubSpotContactToRemoteContact);
-        after = currResults.paging?.next?.after;
+          // Do not emit 'end' event until the last batch
+          const readable = Readable.from(remoteContacts);
+          readable.pipe(passThrough, { end: !after });
+          readable.on('error', (err) => passThrough.emit('error', err));
 
-        // Do not emit 'end' event until the last batch
-        const readable = Readable.from(remoteContacts);
-        readable.pipe(passThrough, { end: !after });
-        readable.on('error', (err) => passThrough.emit('error', err));
-
-        // Wait
-        await new Promise((resolve) => readable.on('end', resolve));
-      } while (after);
+          // Wait
+          await new Promise((resolve) => readable.on('end', resolve));
+        } while (after);
+      }
     })().catch((err: unknown) => {
       // We need to forward the error to the returned `Readable` because there
       // is no way for the caller to find out about errors in the above async block otherwise.
@@ -653,69 +644,54 @@ class HubSpotClient extends AbstractCrmRemoteClient {
   public async listUsers(updatedAfter?: Date): Promise<Readable> {
     const passThrough = new PassThrough({ objectMode: true });
 
-    // Users
     (async () => {
-      let after = undefined;
-      do {
-        const currResults: HubspotPaginatedOwners = await this.#listUsersImpl(after);
-        const remoteUsers = currResults.results.map(fromHubspotOwnerToRemoteUser);
-        after = currResults.paging?.next?.after;
+      // Users
+      {
+        let after = undefined;
+        do {
+          const currResults: HubspotPaginatedOwners = await this.#listUsersImpl(after);
+          const remoteUsers = currResults.results.map(fromHubspotOwnerToRemoteUser);
+          after = currResults.paging?.next?.after;
 
-        // Do not emit 'end' event until the last batch
-        const readable = Readable.from(
-          remoteUsers.filter((remoteUser) => {
-            if (!updatedAfter) {
-              return true;
-            }
+          // Do not emit 'end' event until the last batch
+          const readable = Readable.from(
+            remoteUsers.filter((remoteUser) => {
+              if (!updatedAfter) {
+                return true;
+              }
 
-            if (!remoteUser.remoteUpdatedAt) {
-              return true;
-            }
+              if (!remoteUser.remoteUpdatedAt) {
+                return true;
+              }
 
-            return updatedAfter < remoteUser.remoteUpdatedAt;
-          })
-        );
-        readable.pipe(passThrough, { end: !after });
-        readable.on('error', (err) => passThrough.emit('error', err));
+              return updatedAfter < remoteUser.remoteUpdatedAt;
+            })
+          );
+          readable.pipe(passThrough, { end: false });
+          readable.on('error', (err) => passThrough.emit('error', err));
 
-        // Wait
-        await new Promise((resolve) => readable.on('end', resolve));
-      } while (after);
-    })().catch((err: unknown) => {
-      // We need to forward the error to the returned `Readable` because there
-      // is no way for the caller to find out about errors in the above async block otherwise.
-      passThrough.emit('error', err);
-    });
+          // Wait
+          await new Promise((resolve) => readable.on('end', resolve));
+        } while (after);
+      }
+      // Archived Users
+      // TODO: this doesn't respect the `updatedAfter` parameter because we can't use the search API for archived users
+      {
+        let after = undefined;
+        do {
+          const currResults: HubspotPaginatedOwners = await this.#listUsersImpl(after, /* archived */ true);
+          const remoteUsers = currResults.results.map(fromHubspotOwnerToRemoteUser);
+          after = currResults.paging?.next?.after;
 
-    // Archived Users
-    // TODO: this doesn't respect the `updatedAfter` parameter because we can't use the search API for archived users
-    (async () => {
-      let after = undefined;
-      do {
-        const currResults: HubspotPaginatedOwners = await this.#listUsersImpl(after, /* archived */ true);
-        const remoteUsers = currResults.results.map(fromHubspotOwnerToRemoteUser);
-        after = currResults.paging?.next?.after;
+          // Do not emit 'end' event until the last batch
+          const readable = Readable.from(remoteUsers);
+          readable.pipe(passThrough, { end: !after });
+          readable.on('error', (err) => passThrough.emit('error', err));
 
-        // Do not emit 'end' event until the last batch
-        const readable = Readable.from(
-          remoteUsers.filter((remoteUser) => {
-            if (!updatedAfter) {
-              return true;
-            }
-
-            if (!remoteUser.remoteUpdatedAt) {
-              return true;
-            }
-
-            return updatedAfter < remoteUser.remoteUpdatedAt;
-          })
-        );
-        readable.pipe(passThrough, { end: !after });
-        readable.on('error', (err) => passThrough.emit('error', err));
-
-        // Wait
-        await new Promise((resolve) => readable.on('end', resolve));
-      } while (after);
+          // Wait
+          await new Promise((resolve) => readable.on('end', resolve));
+        } while (after);
+      }
     })().catch((err: unknown) => {
       // We need to forward the error to the returned `Readable` because there
       // is no way for the caller to find out about errors in the above async block otherwise.

--- a/packages/core/services/common_models/account_service.ts
+++ b/packages/core/services/common_models/account_service.ts
@@ -81,6 +81,7 @@ export class AccountService extends CommonModelBaseService {
           gt: modified_after,
           lt: modified_before,
         },
+        remoteWasDeleted: false,
       },
       include: {
         owner: expandedAssociations.includes('owner'),

--- a/packages/core/services/common_models/account_service.ts
+++ b/packages/core/services/common_models/account_service.ts
@@ -199,7 +199,13 @@ export class AccountService extends CommonModelBaseService {
       tempTable,
       columnsWithoutId,
       fromRemoteAccountToDbAccountParams,
-      (remoteAccount) => remoteAccount.remoteUpdatedAt
+      (remoteAccount) =>
+        new Date(
+          Math.max(
+            remoteAccount.remoteUpdatedAt?.getTime() || 0,
+            remoteAccount.detectedOrRemoteDeletedAt?.getTime() || 0
+          )
+        )
     );
   }
 

--- a/packages/core/services/common_models/base_service.ts
+++ b/packages/core/services/common_models/base_service.ts
@@ -87,6 +87,10 @@ export abstract class CommonModelBaseService {
       const columnsToUpdate = columnsWithoutId.join(',');
       const excludedColumnsToUpdate = columnsWithoutId.map((column) => `EXCLUDED.${column}`).join(',');
 
+      // IMPORTANT: we need to use DISTINCT ON because we may have multiple records with the same remote_id
+      // For example, hubspot will return the same record twice when querying for `archived: true` if
+      // the record was archived, restored, and archived again.
+      // TODO: This may have performance implications. We should look into this later.
       const result = await client.query(`INSERT INTO ${table}
 SELECT DISTINCT ON (remote_id) * FROM ${tempTable}
 ON CONFLICT (connection_id, remote_id)

--- a/packages/core/services/common_models/base_service.ts
+++ b/packages/core/services/common_models/base_service.ts
@@ -91,6 +91,7 @@ export abstract class CommonModelBaseService {
       // For example, hubspot will return the same record twice when querying for `archived: true` if
       // the record was archived, restored, and archived again.
       // TODO: This may have performance implications. We should look into this later.
+      // https://github.com/supaglue-labs/supaglue/issues/497
       const result = await client.query(`INSERT INTO ${table}
 SELECT DISTINCT ON (remote_id) * FROM ${tempTable}
 ON CONFLICT (connection_id, remote_id)

--- a/packages/core/services/common_models/contact_service.ts
+++ b/packages/core/services/common_models/contact_service.ts
@@ -85,6 +85,7 @@ export class ContactService extends CommonModelBaseService {
           gt: modified_after,
           lt: modified_before,
         },
+        remoteWasDeleted: false,
       },
       include: {
         account: expandedAssociations.includes('account'),

--- a/packages/core/services/common_models/contact_service.ts
+++ b/packages/core/services/common_models/contact_service.ts
@@ -223,7 +223,13 @@ export class ContactService extends CommonModelBaseService {
       tempTable,
       columnsWithoutId,
       fromRemoteContactToDbContactParams,
-      (remoteContact) => remoteContact.remoteUpdatedAt
+      (remoteContact) =>
+        new Date(
+          Math.max(
+            remoteContact.remoteUpdatedAt?.getTime() || 0,
+            remoteContact.detectedOrRemoteDeletedAt?.getTime() || 0
+          )
+        )
     );
   }
 

--- a/packages/core/services/common_models/lead_service.ts
+++ b/packages/core/services/common_models/lead_service.ts
@@ -173,7 +173,10 @@ export class LeadService extends CommonModelBaseService {
       tempTable,
       columnsWithoutId,
       fromRemoteLeadToDbLeadParams,
-      (remoteLead) => remoteLead.remoteUpdatedAt
+      (remoteLead) =>
+        new Date(
+          Math.max(remoteLead.remoteUpdatedAt?.getTime() || 0, remoteLead.detectedOrRemoteDeletedAt?.getTime() || 0)
+        )
     );
   }
 

--- a/packages/core/services/common_models/lead_service.ts
+++ b/packages/core/services/common_models/lead_service.ts
@@ -50,6 +50,7 @@ export class LeadService extends CommonModelBaseService {
           gt: modified_after,
           lt: modified_before,
         },
+        remoteWasDeleted: false,
       },
       include: {
         convertedAccount: expandedAssociations.includes('converted_account'),

--- a/packages/core/services/common_models/opportunity_service.ts
+++ b/packages/core/services/common_models/opportunity_service.ts
@@ -58,6 +58,7 @@ export class OpportunityService extends CommonModelBaseService {
           gt: modified_after,
           lt: modified_before,
         },
+        remoteWasDeleted: false,
       },
       include: {
         account: expandedAssociations.includes('account'),

--- a/packages/core/services/common_models/opportunity_service.ts
+++ b/packages/core/services/common_models/opportunity_service.ts
@@ -229,7 +229,13 @@ export class OpportunityService extends CommonModelBaseService {
       tempTable,
       columnsWithoutId,
       fromRemoteOpportunityToDbOpportunityParams,
-      (remoteOpportunity) => remoteOpportunity.remoteUpdatedAt
+      (remoteOpportunity) =>
+        new Date(
+          Math.max(
+            remoteOpportunity.remoteUpdatedAt?.getTime() || 0,
+            remoteOpportunity.detectedOrRemoteDeletedAt?.getTime() || 0
+          )
+        )
     );
   }
 

--- a/packages/core/services/common_models/user_service.ts
+++ b/packages/core/services/common_models/user_service.ts
@@ -40,6 +40,7 @@ export class UserService extends CommonModelBaseService {
           gt: modified_after,
           lt: modified_before,
         },
+        remoteWasDeleted: false,
       },
       orderBy: {
         id: 'asc',

--- a/packages/core/services/common_models/user_service.ts
+++ b/packages/core/services/common_models/user_service.ts
@@ -84,7 +84,10 @@ export class UserService extends CommonModelBaseService {
       tempTable,
       columnsWithoutId,
       fromRemoteUserToDbUserParams,
-      (remoteUser) => remoteUser.remoteUpdatedAt
+      (remoteUser) =>
+        new Date(
+          Math.max(remoteUser.remoteUpdatedAt?.getTime() || 0, remoteUser.detectedOrRemoteDeletedAt?.getTime() || 0)
+        )
     );
   }
 }

--- a/packages/core/types/crm/account.ts
+++ b/packages/core/types/crm/account.ts
@@ -7,6 +7,7 @@ export type CrmAccountExpanded = CrmAccount & {
 };
 
 type BaseAccount = {
+  remoteId: string;
   name: string | null;
   description: string | null;
   industry: string | null;
@@ -23,7 +24,6 @@ type BaseAccount = {
 
 export type Account = BaseAccount & {
   id: string;
-  remoteId: string;
   ownerId: string | null;
   owner?: User;
   lastModifiedAt: Date | null;
@@ -31,7 +31,6 @@ export type Account = BaseAccount & {
 };
 
 export type RemoteAccount = BaseAccount & {
-  remoteId: string;
   remoteOwnerId: string | null;
   remoteDeletedAt: Date | null;
   detectedOrRemoteDeletedAt: Date | null;

--- a/packages/core/types/crm/contact.ts
+++ b/packages/core/types/crm/contact.ts
@@ -9,6 +9,7 @@ export type CrmContactExpanded = CrmContact & {
 };
 
 export type BaseContact = {
+  remoteId: string;
   firstName: string | null;
   lastName: string | null;
   addresses: Address[];
@@ -23,7 +24,6 @@ export type BaseContact = {
 
 export type Contact = BaseContact & {
   id: string;
-  remoteId: string;
   ownerId: string | null;
   owner?: User;
   accountId: string | null;
@@ -33,7 +33,6 @@ export type Contact = BaseContact & {
 };
 
 export type RemoteContact = BaseContact & {
-  remoteId: string;
   remoteAccountId: string | null;
   remoteOwnerId: string | null;
   remoteDeletedAt: Date | null;

--- a/packages/core/types/crm/lead.ts
+++ b/packages/core/types/crm/lead.ts
@@ -8,6 +8,7 @@ export type CrmLeadExpanded = CrmLead & {
 };
 
 type BaseLead = {
+  remoteId: string;
   leadSource: string | null;
   title: string | null;
   company: string | null;
@@ -30,13 +31,11 @@ export type Lead = BaseLead & {
   ownerId: string | null;
   owner?: User;
   id: string;
-  remoteId: string;
   lastModifiedAt: Date | null;
   // Support field mappings + remote data etc
 };
 
 export type RemoteLead = BaseLead & {
-  remoteId: string;
   convertedRemoteContactId: string | null;
   convertedRemoteAccountId: string | null;
   remoteOwnerId: string | null;

--- a/packages/core/types/crm/opportunity.ts
+++ b/packages/core/types/crm/opportunity.ts
@@ -13,6 +13,7 @@ export const OPPORTUNITY_STATUSES = ['OPEN', 'WON', 'LOST'] as const;
 export type OpportunityStatus = (typeof OPPORTUNITY_STATUSES)[number];
 
 type BaseOpportunity = {
+  remoteId: string;
   name: string | null;
   description: string | null;
   amount: number | null;
@@ -32,13 +33,11 @@ export type Opportunity = BaseOpportunity & {
   ownerId: string | null;
   owner?: User;
   id: string;
-  remoteId: string;
   lastModifiedAt: Date | null;
   // Support field mappings + remote data etc
 };
 
 export type RemoteOpportunity = BaseOpportunity & {
-  remoteId: string;
   remoteAccountId: string | null;
   remoteOwnerId: string | null;
   remoteDeletedAt: Date | null;

--- a/packages/core/types/crm/user.ts
+++ b/packages/core/types/crm/user.ts
@@ -1,4 +1,5 @@
 type BaseUser = {
+  remoteId: string;
   name: string | null;
   email: string | null;
   isActive: boolean | null;
@@ -9,12 +10,10 @@ type BaseUser = {
 
 export type User = BaseUser & {
   id: string;
-  remoteId: string;
   lastModifiedAt: Date | null;
 };
 
 export type RemoteUser = BaseUser & {
-  remoteId: string;
   remoteDeletedAt: Date | null;
   detectedOrRemoteDeletedAt: Date | null;
 };

--- a/packages/core/types/sync.ts
+++ b/packages/core/types/sync.ts
@@ -53,7 +53,7 @@ export type FullThenIncrementalSyncStateCreatedPhase = {
 export type FullThenIncrementalSyncStateLivePhase = {
   phase: 'full' | 'incremental';
   status: 'in progress' | 'done';
-  maxRemoteUpdatedAtMsMap: Record<CommonModel, number>;
+  maxLastModifiedAtMsMap: Record<CommonModel, number>;
 };
 export type FullThenIncrementalSyncState =
   | FullThenIncrementalSyncStateCreatedPhase

--- a/packages/sync-workflows/activities/import_records.ts
+++ b/packages/sync-workflows/activities/import_records.ts
@@ -20,7 +20,7 @@ export type ImportRecordsArgs = {
 };
 
 export type ImportRecordsResult = {
-  maxRemoteUpdatedAtMs: number;
+  maxLastModifiedAtMs: number;
   numRecordsSynced: number;
 };
 
@@ -43,7 +43,7 @@ export function createImportRecords(
     const client = await remoteService.getCrmRemoteClient(connectionId);
 
     let result = {
-      maxRemoteUpdatedAt: null as Date | null,
+      maxLastModifiedAt: null as Date | null,
       numRecords: 0,
     };
 
@@ -102,7 +102,7 @@ export function createImportRecords(
     logEvent({ eventName: 'Completed Sync', syncId, providerName: connection.providerName, modelName: commonModel });
 
     return {
-      maxRemoteUpdatedAtMs: result.maxRemoteUpdatedAt ? result.maxRemoteUpdatedAt.getTime() : 0,
+      maxLastModifiedAtMs: result.maxLastModifiedAt ? result.maxLastModifiedAt.getTime() : 0,
       numRecordsSynced: result.numRecords,
     };
   };

--- a/packages/sync-workflows/workflows/run_syncs.ts
+++ b/packages/sync-workflows/workflows/run_syncs.ts
@@ -104,7 +104,7 @@ async function doFullThenIncrementalSync({
       state: {
         phase: 'full',
         status: 'in progress',
-        maxRemoteUpdatedAtMsMap: {
+        maxLastModifiedAtMsMap: {
           account: 0,
           lead: 0,
           opportunity: 0,
@@ -126,12 +126,12 @@ async function doFullThenIncrementalSync({
       )
     ) as Record<CommonModel, ImportRecordsResult>;
 
-    const newMaxRemoteUpdatedAtMsMap = {
-      account: importRecordsResultList['account'].maxRemoteUpdatedAtMs,
-      lead: importRecordsResultList['lead'].maxRemoteUpdatedAtMs,
-      opportunity: importRecordsResultList['opportunity'].maxRemoteUpdatedAtMs,
-      contact: importRecordsResultList['contact'].maxRemoteUpdatedAtMs,
-      user: importRecordsResultList['user'].maxRemoteUpdatedAtMs,
+    const newMaxLastModifiedAtMsMap = {
+      account: importRecordsResultList['account'].maxLastModifiedAtMs,
+      lead: importRecordsResultList['lead'].maxLastModifiedAtMs,
+      opportunity: importRecordsResultList['opportunity'].maxLastModifiedAtMs,
+      contact: importRecordsResultList['contact'].maxLastModifiedAtMs,
+      user: importRecordsResultList['user'].maxLastModifiedAtMs,
     };
 
     await updateSyncState({
@@ -139,7 +139,7 @@ async function doFullThenIncrementalSync({
       state: {
         phase: 'full',
         status: 'in progress',
-        maxRemoteUpdatedAtMsMap: newMaxRemoteUpdatedAtMsMap,
+        maxLastModifiedAtMsMap: newMaxLastModifiedAtMsMap,
       },
     });
 
@@ -150,7 +150,7 @@ async function doFullThenIncrementalSync({
       state: {
         phase: 'full',
         status: 'done',
-        maxRemoteUpdatedAtMsMap: newMaxRemoteUpdatedAtMsMap,
+        maxLastModifiedAtMsMap: newMaxLastModifiedAtMsMap,
       },
     });
 
@@ -160,7 +160,7 @@ async function doFullThenIncrementalSync({
   }
 
   async function doIncrementalPhase(): Promise<Record<CommonModel, number>> {
-    function getOriginalMaxRemoteUpdatedAtMsMap(): Record<CommonModel, number> {
+    function getOriginalMaxLastModifiedAtMsMap(): Record<CommonModel, number> {
       // TODO: we shouldn't need to do this, since it's not possible to
       // start the incremental phase if the full phase hasn't been completed.
       if (sync.state.phase === 'created') {
@@ -173,20 +173,20 @@ async function doFullThenIncrementalSync({
         };
       }
 
-      return sync.state.maxRemoteUpdatedAtMsMap;
+      return sync.state.maxLastModifiedAtMsMap;
     }
 
-    function computeUpdatedMaxRemoteUpdatedAtMsMap(
+    function computeUpdatedMaxLastModifiedAtMsMap(
       importRecordsResultList: Record<CommonModel, ImportRecordsResult>
     ): Record<CommonModel, number> {
-      const originalMaxRemoteUpdatedAtMsMap = getOriginalMaxRemoteUpdatedAtMsMap();
+      const originalMaxLastModifiedAtMsMap = getOriginalMaxLastModifiedAtMsMap();
 
       return Object.fromEntries(
         CRM_COMMON_MODELS.map((commonModel) => [
           commonModel,
           Math.max(
-            originalMaxRemoteUpdatedAtMsMap[commonModel],
-            importRecordsResultList[commonModel].maxRemoteUpdatedAtMs
+            originalMaxLastModifiedAtMsMap[commonModel],
+            importRecordsResultList[commonModel].maxLastModifiedAtMs
           ),
         ])
       ) as Record<CommonModel, number>;
@@ -197,7 +197,7 @@ async function doFullThenIncrementalSync({
       state: {
         phase: 'incremental',
         status: 'in progress',
-        maxRemoteUpdatedAtMsMap: getOriginalMaxRemoteUpdatedAtMsMap(),
+        maxLastModifiedAtMsMap: getOriginalMaxLastModifiedAtMsMap(),
       },
     });
 
@@ -210,7 +210,7 @@ async function doFullThenIncrementalSync({
               syncId: sync.id,
               connectionId: sync.connectionId,
               commonModel,
-              updatedAfterMs: getOriginalMaxRemoteUpdatedAtMsMap()[commonModel],
+              updatedAfterMs: getOriginalMaxLastModifiedAtMsMap()[commonModel],
             }),
           ];
           return entry;
@@ -218,14 +218,14 @@ async function doFullThenIncrementalSync({
       )
     ) as Record<CommonModel, ImportRecordsResult>;
 
-    const newMaxRemoteUpdatedAtMsMap = computeUpdatedMaxRemoteUpdatedAtMsMap(importRecordsResultList);
+    const newMaxLastModifiedAtMsMap = computeUpdatedMaxLastModifiedAtMsMap(importRecordsResultList);
 
     await updateSyncState({
       syncId: sync.id,
       state: {
         phase: 'incremental',
         status: 'in progress',
-        maxRemoteUpdatedAtMsMap: newMaxRemoteUpdatedAtMsMap,
+        maxLastModifiedAtMsMap: newMaxLastModifiedAtMsMap,
       },
     });
 
@@ -236,7 +236,7 @@ async function doFullThenIncrementalSync({
       state: {
         phase: 'incremental',
         status: 'done',
-        maxRemoteUpdatedAtMsMap: newMaxRemoteUpdatedAtMsMap,
+        maxLastModifiedAtMsMap: newMaxLastModifiedAtMsMap,
       },
     });
 


### PR DESCRIPTION
https://github.com/supaglue-labs/supaglue/issues/489

this actually pulls in deleted objects from hubspot. we cannot use search api, since it doesn't allow filtering on archived. so we have to pull in all the deleted objects all the time (we're hoping that people don't archive that many objects usually). down the road, we might consider using webhook instead