### PR TITLE
BREAKING CHANGE: rename RunSyncs to RunSync now that we have a Sync object

### DIFF
--- a/apps/api/services/sync_service.ts
+++ b/apps/api/services/sync_service.ts
@@ -13,7 +13,7 @@ import { CommonModel } from '@supaglue/core/types/common';
 import { SyncInfo, SyncInfoFilter } from '@supaglue/core/types/sync_info';
 import { PrismaClient, Sync as SyncModel } from '@supaglue/db';
 import { SYNC_TASK_QUEUE } from '@supaglue/sync-workflows/constants';
-import { getRunSyncsScheduleId, getRunSyncsWorkflowId, runSyncs } from '@supaglue/sync-workflows/workflows/run_syncs';
+import { getRunSyncScheduleId, getRunSyncWorkflowId, runSync } from '@supaglue/sync-workflows/workflows/run_sync';
 import { Client, ScheduleAlreadyRunning } from '@temporalio/client';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -95,7 +95,7 @@ export class SyncService {
   async #createSyncsSchedule(syncId: string, connection: ConnectionSafe, syncPeriodMs: number): Promise<void> {
     try {
       await this.#temporalClient.schedule.create({
-        scheduleId: getRunSyncsScheduleId(syncId),
+        scheduleId: getRunSyncScheduleId(syncId),
         spec: {
           intervals: [
             {
@@ -107,8 +107,8 @@ export class SyncService {
         },
         action: {
           type: 'startWorkflow',
-          workflowType: runSyncs,
-          workflowId: getRunSyncsWorkflowId(syncId),
+          workflowType: runSync,
+          workflowId: getRunSyncWorkflowId(syncId),
           taskQueue: SYNC_TASK_QUEUE,
           args: [{ syncId, connectionId: connection.id }],
           searchAttributes: {
@@ -151,7 +151,7 @@ export class SyncService {
     { id: connectionId, applicationId, customerId, category, providerName }: ConnectionSafe,
     commonModel: CommonModel
   ): Promise<SyncInfo> {
-    const scheduleId = getRunSyncsScheduleId(connectionId);
+    const scheduleId = getRunSyncScheduleId(connectionId);
     const handle = this.#temporalClient.schedule.getHandle(scheduleId);
     const description = await handle.describe();
 

--- a/packages/sync-workflows/workflows/index.ts
+++ b/packages/sync-workflows/workflows/index.ts
@@ -1,1 +1,1 @@
-export { runSyncs } from './run_syncs';
+export { runSync } from './run_sync';

--- a/packages/sync-workflows/workflows/run_sync.ts
+++ b/packages/sync-workflows/workflows/run_sync.ts
@@ -3,8 +3,8 @@ import { CRM_COMMON_MODELS } from '@supaglue/core/types/crm';
 import { FullThenIncrementalSync, ReverseThenForwardSync } from '@supaglue/core/types/sync';
 import { ApplicationFailure, proxyActivities } from '@temporalio/workflow';
 // Only import the activity types
-import type { createActivities } from '../activities';
 import { ImportRecordsResult } from '../activities/import_records';
+import type { createActivities } from '../activities/index';
 
 const { importRecords, populateAssociations } = proxyActivities<ReturnType<typeof createActivities>>({
   startToCloseTimeout: '120 minute',
@@ -17,15 +17,15 @@ const { getSync, updateSyncState, logSyncStart, logSyncFinish, maybeSendSyncFini
   startToCloseTimeout: '30 second',
 });
 
-export const getRunSyncsScheduleId = (syncId: string): string => `run-syncs-${syncId}`;
-export const getRunSyncsWorkflowId = (syncId: string): string => `run-syncs-${syncId}`;
+export const getRunSyncScheduleId = (syncId: string): string => `run-sync-${syncId}`;
+export const getRunSyncWorkflowId = (syncId: string): string => `run-sync-${syncId}`;
 
-export type RunSyncsArgs = {
+export type RunSyncArgs = {
   syncId: string;
   connectionId: string;
 };
 
-export async function runSyncs({ syncId, connectionId }: RunSyncsArgs): Promise<void> {
+export async function runSync({ syncId, connectionId }: RunSyncArgs): Promise<void> {
   // TODO: Re-do the sync logs now that a single "Sync" is for all common models together.
   const historyIdsMap = Object.fromEntries(
     await Promise.all(


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

Fixes: #### <!-- Replace this with the GitHub task ID this PR addresses -->

Renaming `RunSyncs` workflow to `RunSync` now that we have a `Sync` object to avoid confusion. A `Sync` coordinates all the individual record imports for account, contact, opportunity, etc.

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
