### PR TITLE
chore: add provider name to webhook payload

### DIFF
--- a/openapi/mgmt/components/schemas/webhook-payload.yaml
+++ b/openapi/mgmt/components/schemas/webhook-payload.yaml
@@ -15,6 +15,12 @@ oneOf:
           customer_id:
             type: string
             example: 7bfcc74d-c98b-49de-8e8f-3dc7a17273f6
+          provider_name:
+            type: string
+            enum:
+              - hubspot
+              - salesforce
+            example: hubspot
           history_id:
             type: string
             example: 2fdbd03d-11f2-4e66-a5e6-2b731c71a12d
@@ -66,6 +72,7 @@ oneOf:
             enum:
               - hubspot
               - salesforce
+            example: hubspot
         required:
           - customer_id
           - integration_id

--- a/openapi/mgmt/openapi.bundle.json
+++ b/openapi/mgmt/openapi.bundle.json
@@ -1405,6 +1405,14 @@
                     "type": "string",
                     "example": "7bfcc74d-c98b-49de-8e8f-3dc7a17273f6"
                   },
+                  "provider_name": {
+                    "type": "string",
+                    "enum": [
+                      "hubspot",
+                      "salesforce"
+                    ],
+                    "example": "hubspot"
+                  },
                   "history_id": {
                     "type": "string",
                     "example": "2fdbd03d-11f2-4e66-a5e6-2b731c71a12d"
@@ -1474,7 +1482,8 @@
                     "enum": [
                       "hubspot",
                       "salesforce"
-                    ]
+                    ],
+                    "example": "hubspot"
                   }
                 },
                 "required": [

--- a/packages/schemas/gen/mgmt.ts
+++ b/packages/schemas/gen/mgmt.ts
@@ -273,6 +273,11 @@ export interface components {
         connection_id: string;
         /** @example 7bfcc74d-c98b-49de-8e8f-3dc7a17273f6 */
         customer_id: string;
+        /**
+         * @example hubspot 
+         * @enum {string}
+         */
+        provider_name?: "hubspot" | "salesforce";
         /** @example 2fdbd03d-11f2-4e66-a5e6-2b731c71a12d */
         history_id: string;
         /** @example 100 */
@@ -294,7 +299,10 @@ export interface components {
         integration_id: string;
         /** @enum {string} */
         category: "crm";
-        /** @enum {string} */
+        /**
+         * @example hubspot 
+         * @enum {string}
+         */
         provider_name: "hubspot" | "salesforce";
       };
     }]>;

--- a/packages/sync-workflows/activities/maybe_send_sync_finish_webhook.ts
+++ b/packages/sync-workflows/activities/maybe_send_sync_finish_webhook.ts
@@ -34,6 +34,7 @@ export function createMaybeSendSyncFinishWebhook({
       await sendWebhookPayload(config.webhook, status, {
         connectionId,
         customerId: connection.customerId,
+        providerName: connection.providerName,
         historyId,
         numRecordsSynced,
         commonModel,

--- a/packages/types/webhook.ts
+++ b/packages/types/webhook.ts
@@ -20,6 +20,7 @@ export type ConnectionWebhookPayload = ConnectionCreateParams;
 export type SyncWebhookPayload = {
   connectionId: string;
   customerId: string;
+  providerName: string;
   historyId: string;
   numRecordsSynced: number;
   commonModel: CommonModel;


### PR DESCRIPTION
Fixes: https://github.com/supaglue-labs/supaglue/issues/557

Add provider name to payload so webhook can be entirely data driven (we can remove provider from env var in typescript-syncer)

## Test Plan

Looked at doc slocally

## Deployment instructions

[Add any special deployment instructions here]
