### PR TITLE
chore: db indexes for performance

### DIFF
--- a/packages/core/services/common_models/base_service.ts
+++ b/packages/core/services/common_models/base_service.ts
@@ -41,6 +41,7 @@ export abstract class CommonModelBaseService {
       // so that we can resume in the case of failure during the COPY stage.
       // TODO: Maybe we don't need to include all
       await client.query(`CREATE TEMP TABLE IF NOT EXISTS ${tempTable} (LIKE ${table} INCLUDING DEFAULTS)`);
+      await client.query(`CREATE INDEX ${tempTable}_remote_id_idx ON ${tempTable} (remote_id)`);
       const columns = ['id', ...columnsWithoutId];
 
       // Output

--- a/packages/core/services/common_models/event_service.ts
+++ b/packages/core/services/common_models/event_service.ts
@@ -206,12 +206,17 @@ export class EventService extends CommonModelBaseService {
     );
   }
 
-  public async updateDanglingOwners(connectionId: string): Promise<void> {
+  public async updateDanglingOwners(connectionId: string, startingLastModifiedAt: Date): Promise<void> {
     const eventsTable = COMMON_MODEL_DB_TABLES['events'];
     const usersTable = COMMON_MODEL_DB_TABLES['users'];
 
     await this.prisma.crmEvent.updateMany({
       where: {
+        // Only update events for the given connection and that have been updated since the last sync (to be more efficient).
+        connectionId,
+        lastModifiedAt: {
+          gt: startingLastModifiedAt,
+        },
         remoteOwnerId: null,
         ownerId: {
           not: null,
@@ -228,6 +233,7 @@ export class EventService extends CommonModelBaseService {
       FROM ${usersTable} u
       WHERE
         c.connection_id = '${connectionId}'
+        AND c.last_modified_at > '${startingLastModifiedAt.toISOString()}'
         AND c.connection_id = u.connection_id
         AND c.owner_id IS NULL
         AND c._remote_owner_id IS NOT NULL
@@ -235,12 +241,17 @@ export class EventService extends CommonModelBaseService {
       `);
   }
 
-  public async updateDanglingAccounts(connectionId: string): Promise<void> {
+  public async updateDanglingAccounts(connectionId: string, startingLastModifiedAt: Date): Promise<void> {
     const eventsTable = COMMON_MODEL_DB_TABLES['events'];
     const accountsTable = COMMON_MODEL_DB_TABLES['accounts'];
 
     await this.prisma.crmEvent.updateMany({
       where: {
+        // Only update events for the given connection and that have been updated since the last sync (to be more efficient).
+        connectionId,
+        lastModifiedAt: {
+          gt: startingLastModifiedAt,
+        },
         remoteAccountId: null,
         accountId: {
           not: null,
@@ -257,6 +268,7 @@ export class EventService extends CommonModelBaseService {
       FROM ${accountsTable} u
       WHERE
         c.connection_id = '${connectionId}'
+        AND c.last_modified_at > '${startingLastModifiedAt.toISOString()}'
         AND c.connection_id = u.connection_id
         AND c.account_id IS NULL
         AND c._remote_account_id IS NOT NULL
@@ -264,12 +276,17 @@ export class EventService extends CommonModelBaseService {
       `);
   }
 
-  public async updateDanglingContacts(connectionId: string): Promise<void> {
+  public async updateDanglingContacts(connectionId: string, startingLastModifiedAt: Date): Promise<void> {
     const eventsTable = COMMON_MODEL_DB_TABLES['events'];
     const contactsTable = COMMON_MODEL_DB_TABLES['contacts'];
 
     await this.prisma.crmEvent.updateMany({
       where: {
+        // Only update events for the given connection and that have been updated since the last sync (to be more efficient).
+        connectionId,
+        lastModifiedAt: {
+          gt: startingLastModifiedAt,
+        },
         remoteContactId: null,
         contactId: {
           not: null,
@@ -286,6 +303,7 @@ export class EventService extends CommonModelBaseService {
       FROM ${contactsTable} u
       WHERE
         c.connection_id = '${connectionId}'
+        AND c.last_modified_at > '${startingLastModifiedAt.toISOString()}'
         AND c.connection_id = u.connection_id
         AND c.contact_id IS NULL
         AND c._remote_contact_id IS NOT NULL
@@ -293,12 +311,17 @@ export class EventService extends CommonModelBaseService {
       `);
   }
 
-  public async updateDanglingLeads(connectionId: string): Promise<void> {
+  public async updateDanglingLeads(connectionId: string, startingLastModifiedAt: Date): Promise<void> {
     const eventsTable = COMMON_MODEL_DB_TABLES['events'];
     const leadsTable = COMMON_MODEL_DB_TABLES['leads'];
 
     await this.prisma.crmEvent.updateMany({
       where: {
+        // Only update events for the given connection and that have been updated since the last sync (to be more efficient).
+        connectionId,
+        lastModifiedAt: {
+          gt: startingLastModifiedAt,
+        },
         remoteLeadId: null,
         leadId: {
           not: null,
@@ -315,6 +338,7 @@ export class EventService extends CommonModelBaseService {
       FROM ${leadsTable} u
       WHERE
         c.connection_id = '${connectionId}'
+        AND c.last_modified_at > '${startingLastModifiedAt.toISOString()}'
         AND c.connection_id = u.connection_id
         AND c.lead_id IS NULL
         AND c._remote_lead_id IS NOT NULL
@@ -322,12 +346,17 @@ export class EventService extends CommonModelBaseService {
       `);
   }
 
-  public async updateDanglingOpportunities(connectionId: string): Promise<void> {
+  public async updateDanglingOpportunities(connectionId: string, startingLastModifiedAt: Date): Promise<void> {
     const eventsTable = COMMON_MODEL_DB_TABLES['events'];
     const opportunitiesTable = COMMON_MODEL_DB_TABLES['opportunities'];
 
     await this.prisma.crmEvent.updateMany({
       where: {
+        // Only update events for the given connection and that have been updated since the last sync (to be more efficient).
+        connectionId,
+        lastModifiedAt: {
+          gt: startingLastModifiedAt,
+        },
         remoteOpportunityId: null,
         opportunityId: {
           not: null,
@@ -344,6 +373,7 @@ export class EventService extends CommonModelBaseService {
       FROM ${opportunitiesTable} u
       WHERE
         c.connection_id = '${connectionId}'
+        AND c.last_modified_at > '${startingLastModifiedAt.toISOString()}'
         AND c.connection_id = u.connection_id
         AND c.opportunity_id IS NULL
         AND c._remote_opportunity_id IS NOT NULL

--- a/packages/core/services/common_models/lead_service.ts
+++ b/packages/core/services/common_models/lead_service.ts
@@ -185,12 +185,17 @@ export class LeadService extends CommonModelBaseService {
     );
   }
 
-  public async updateDanglingAccounts(connectionId: string): Promise<void> {
+  public async updateDanglingAccounts(connectionId: string, startingLastModifiedAt: Date): Promise<void> {
     const leadsTable = COMMON_MODEL_DB_TABLES['leads'];
     const accountsTable = COMMON_MODEL_DB_TABLES['accounts'];
 
     await this.prisma.crmLead.updateMany({
       where: {
+        // Only update accounts for the given connection and that have been updated since the last sync (to be more efficient).
+        connectionId,
+        lastModifiedAt: {
+          gt: startingLastModifiedAt,
+        },
         convertedRemoteAccountId: null,
         convertedAccountId: {
           not: null,
@@ -207,6 +212,7 @@ export class LeadService extends CommonModelBaseService {
       FROM ${accountsTable} a
       WHERE
         l.connection_id = '${connectionId}'
+        AND l.last_modified_at > '${startingLastModifiedAt.toISOString()}'
         AND l.connection_id = a.connection_id
         AND l.converted_account_id IS NULL
         AND l._converted_remote_account_id IS NOT NULL
@@ -214,12 +220,17 @@ export class LeadService extends CommonModelBaseService {
       `);
   }
 
-  public async updateDanglingContacts(connectionId: string): Promise<void> {
+  public async updateDanglingContacts(connectionId: string, startingLastModifiedAt: Date): Promise<void> {
     const leadsTable = COMMON_MODEL_DB_TABLES['leads'];
     const contactsTable = COMMON_MODEL_DB_TABLES['contacts'];
 
     await this.prisma.crmLead.updateMany({
       where: {
+        // Only update contacts for the given connection and that have been updated since the last sync (to be more efficient).
+        connectionId,
+        lastModifiedAt: {
+          gt: startingLastModifiedAt,
+        },
         convertedRemoteContactId: null,
         convertedContactId: {
           not: null,
@@ -236,6 +247,7 @@ export class LeadService extends CommonModelBaseService {
       FROM ${contactsTable} c
       WHERE
         l.connection_id = '${connectionId}'
+        AND l.last_modified_at > '${startingLastModifiedAt.toISOString()}'
         AND l.connection_id = c.connection_id
         AND l.converted_contact_id IS NULL
         AND l._converted_remote_contact_id IS NOT NULL
@@ -243,12 +255,17 @@ export class LeadService extends CommonModelBaseService {
       `);
   }
 
-  public async updateDanglingOwners(connectionId: string): Promise<void> {
+  public async updateDanglingOwners(connectionId: string, startingLastModifiedAt: Date): Promise<void> {
     const leadsTable = COMMON_MODEL_DB_TABLES['leads'];
     const usersTable = COMMON_MODEL_DB_TABLES['users'];
 
     await this.prisma.crmLead.updateMany({
       where: {
+        // Only update leads for the given connection and that have been updated since the last sync (to be more efficient).
+        connectionId,
+        lastModifiedAt: {
+          gt: startingLastModifiedAt,
+        },
         remoteOwnerId: null,
         ownerId: {
           not: null,
@@ -265,6 +282,7 @@ export class LeadService extends CommonModelBaseService {
       FROM ${usersTable} u
       WHERE
         c.connection_id = '${connectionId}'
+        AND c.last_modified_at > '${startingLastModifiedAt.toISOString()}'
         AND c.connection_id = u.connection_id
         AND c.owner_id IS NULL
         AND c._remote_owner_id IS NOT NULL

--- a/packages/core/services/common_models/opportunity_service.ts
+++ b/packages/core/services/common_models/opportunity_service.ts
@@ -225,12 +225,17 @@ export class OpportunityService extends CommonModelBaseService {
     );
   }
 
-  public async updateDanglingAccounts(connectionId: string): Promise<void> {
+  public async updateDanglingAccounts(connectionId: string, startingLastModifiedAt: Date): Promise<void> {
     const opportunitiesTable = COMMON_MODEL_DB_TABLES['opportunities'];
     const accountsTable = COMMON_MODEL_DB_TABLES['accounts'];
 
     await this.prisma.crmOpportunity.updateMany({
       where: {
+        // Only update opportunities for the given connection and that have been updated since the last sync (to be more efficient).
+        connectionId,
+        lastModifiedAt: {
+          gt: startingLastModifiedAt,
+        },
         remoteAccountId: null,
         accountId: {
           not: null,
@@ -247,6 +252,7 @@ export class OpportunityService extends CommonModelBaseService {
       FROM ${accountsTable} a
       WHERE
         o.connection_id = '${connectionId}'
+        AND o.last_modified_at > '${startingLastModifiedAt.toISOString()}'
         AND o.connection_id = a.connection_id
         AND o.account_id IS NULL
         AND o._remote_account_id IS NOT NULL
@@ -254,12 +260,17 @@ export class OpportunityService extends CommonModelBaseService {
       `);
   }
 
-  public async updateDanglingOwners(connectionId: string): Promise<void> {
+  public async updateDanglingOwners(connectionId: string, startingLastModifiedAt: Date): Promise<void> {
     const opportunitiesTable = COMMON_MODEL_DB_TABLES['opportunities'];
     const usersTable = COMMON_MODEL_DB_TABLES['users'];
 
     await this.prisma.crmOpportunity.updateMany({
       where: {
+        // Only update opportunities for the given connection and that have been updated since the last sync (to be more efficient).
+        connectionId,
+        lastModifiedAt: {
+          gt: startingLastModifiedAt,
+        },
         remoteOwnerId: null,
         ownerId: {
           not: null,
@@ -276,6 +287,7 @@ export class OpportunityService extends CommonModelBaseService {
       FROM ${usersTable} u
       WHERE
         c.connection_id = '${connectionId}'
+        AND c.last_modified_at > '${startingLastModifiedAt.toISOString()}'
         AND c.connection_id = u.connection_id
         AND c.owner_id IS NULL
         AND c._remote_owner_id IS NOT NULL

--- a/packages/db/prisma/migrations/20230405163512_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20230405163512_indexes/migration.sql
@@ -1,0 +1,17 @@
+-- CreateIndex
+CREATE INDEX "crm_accounts_connection_id_last_modified_at_idx" ON "crm_accounts"("connection_id", "last_modified_at" ASC);
+
+-- CreateIndex
+CREATE INDEX "crm_contacts_connection_id_last_modified_at_idx" ON "crm_contacts"("connection_id", "last_modified_at" ASC);
+
+-- CreateIndex
+CREATE INDEX "crm_events_connection_id_last_modified_at_idx" ON "crm_events"("connection_id", "last_modified_at" ASC);
+
+-- CreateIndex
+CREATE INDEX "crm_leads_connection_id_last_modified_at_idx" ON "crm_leads"("connection_id", "last_modified_at" ASC);
+
+-- CreateIndex
+CREATE INDEX "crm_opportunities_connection_id_last_modified_at_idx" ON "crm_opportunities"("connection_id", "last_modified_at" ASC);
+
+-- CreateIndex
+CREATE INDEX "crm_users_connection_id_last_modified_at_idx" ON "crm_users"("connection_id", "last_modified_at" ASC);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -109,6 +109,7 @@ model CrmAccount {
   events                    CrmEvent[]
 
   @@unique([connectionId, remoteId])
+  @@index([connectionId, lastModifiedAt(sort: Asc)]) // for incremental syncs hitting our API // TODO: consider adding index on `remoteWasDeleted`
   @@map("crm_accounts")
 }
 
@@ -144,6 +145,7 @@ model CrmContact {
   events                    CrmEvent[]
 
   @@unique([connectionId, remoteId])
+  @@index([connectionId, lastModifiedAt(sort: Asc)]) // for incremental syncs hitting our API // TODO: consider adding index on `remoteWasDeleted`
   @@map("crm_contacts")
 }
 
@@ -183,6 +185,7 @@ model CrmLead {
   events                    CrmEvent[]
 
   @@unique([connectionId, remoteId])
+  @@index([connectionId, lastModifiedAt(sort: Asc)]) // for incremental syncs hitting our API // TODO: consider adding index on `remoteWasDeleted`
   @@map("crm_leads")
 }
 
@@ -217,6 +220,7 @@ model CrmOpportunity {
   events                    CrmEvent[]
 
   @@unique([connectionId, remoteId])
+  @@index([connectionId, lastModifiedAt(sort: Asc)]) // for incremental syncs hitting our API // TODO: consider adding index on `remoteWasDeleted`
   @@map("crm_opportunities")
 }
 
@@ -243,6 +247,7 @@ model CrmUser {
   events                    CrmEvent[]
 
   @@unique([connectionId, remoteId])
+  @@index([connectionId, lastModifiedAt(sort: Asc)]) // for incremental syncs hitting our API // TODO: consider adding index on `remoteWasDeleted`
   @@map("crm_users")
 }
 
@@ -284,6 +289,7 @@ model CrmEvent {
   owner               CrmUser?        @relation(fields: [ownerId], references: [id])
 
   @@unique([connectionId, remoteId])
+  @@index([connectionId, lastModifiedAt(sort: Asc)]) // for incremental syncs hitting our API // TODO: consider adding index on `remoteWasDeleted`
   @@map("crm_events")
 }
 

--- a/packages/sync-workflows/activities/populate_associations.ts
+++ b/packages/sync-workflows/activities/populate_associations.ts
@@ -1,8 +1,10 @@
 import { AccountService, ContactService, EventService, LeadService, OpportunityService } from '@supaglue/core/services';
+import { CommonModel } from '@supaglue/types';
 import { Context } from '@temporalio/activity';
 
 export type PopulateAssociationsArgs = {
   connectionId: string;
+  originalMaxLastModifiedAtMsMap: Record<CommonModel, number>;
 };
 
 export function createPopulateAssociations(
@@ -12,45 +14,54 @@ export function createPopulateAssociations(
   leadService: LeadService,
   eventService: EventService
 ) {
-  return async function populateAssociations({ connectionId }: PopulateAssociationsArgs) {
+  return async function populateAssociations({
+    connectionId,
+    originalMaxLastModifiedAtMsMap,
+  }: PopulateAssociationsArgs) {
     // TODO: Parallelize / optimize? Keeping serial for now to be safe. Each command should run pretty quickly anyway.
-    await contactService.updateDanglingAccounts(connectionId);
+    await contactService.updateDanglingAccounts(connectionId, new Date(originalMaxLastModifiedAtMsMap['contact']));
     Context.current().heartbeat();
 
-    await opportunityService.updateDanglingAccounts(connectionId);
+    await opportunityService.updateDanglingAccounts(
+      connectionId,
+      new Date(originalMaxLastModifiedAtMsMap['opportunity'])
+    );
     Context.current().heartbeat();
 
-    await leadService.updateDanglingAccounts(connectionId);
+    await leadService.updateDanglingAccounts(connectionId, new Date(originalMaxLastModifiedAtMsMap['lead']));
     Context.current().heartbeat();
 
-    await leadService.updateDanglingContacts(connectionId);
+    await leadService.updateDanglingContacts(connectionId, new Date(originalMaxLastModifiedAtMsMap['lead']));
     Context.current().heartbeat();
 
-    await accountService.updateDanglingOwners(connectionId);
+    await accountService.updateDanglingOwners(connectionId, new Date(originalMaxLastModifiedAtMsMap['account']));
     Context.current().heartbeat();
 
-    await contactService.updateDanglingOwners(connectionId);
+    await contactService.updateDanglingOwners(connectionId, new Date(originalMaxLastModifiedAtMsMap['contact']));
     Context.current().heartbeat();
 
-    await leadService.updateDanglingOwners(connectionId);
+    await leadService.updateDanglingOwners(connectionId, new Date(originalMaxLastModifiedAtMsMap['lead']));
     Context.current().heartbeat();
 
-    await opportunityService.updateDanglingOwners(connectionId);
+    await opportunityService.updateDanglingOwners(
+      connectionId,
+      new Date(originalMaxLastModifiedAtMsMap['opportunity'])
+    );
     Context.current().heartbeat();
 
-    await eventService.updateDanglingOwners(connectionId);
+    await eventService.updateDanglingOwners(connectionId, new Date(originalMaxLastModifiedAtMsMap['event']));
     Context.current().heartbeat();
 
-    await eventService.updateDanglingAccounts(connectionId);
+    await eventService.updateDanglingAccounts(connectionId, new Date(originalMaxLastModifiedAtMsMap['event']));
     Context.current().heartbeat();
 
-    await eventService.updateDanglingContacts(connectionId);
+    await eventService.updateDanglingContacts(connectionId, new Date(originalMaxLastModifiedAtMsMap['event']));
     Context.current().heartbeat();
 
-    await eventService.updateDanglingLeads(connectionId);
+    await eventService.updateDanglingLeads(connectionId, new Date(originalMaxLastModifiedAtMsMap['event']));
     Context.current().heartbeat();
 
-    await eventService.updateDanglingOpportunities(connectionId);
+    await eventService.updateDanglingOpportunities(connectionId, new Date(originalMaxLastModifiedAtMsMap['event']));
     Context.current().heartbeat();
   };
 }

--- a/packages/sync-workflows/workflows/run_sync.ts
+++ b/packages/sync-workflows/workflows/run_sync.ts
@@ -250,7 +250,10 @@ async function doFullThenIncrementalSync({
       },
     });
 
-    await populateAssociations({ connectionId: sync.connectionId });
+    await populateAssociations({
+      connectionId: sync.connectionId,
+      originalMaxLastModifiedAtMsMap: getOriginalMaxLastModifiedAtMsMap(),
+    });
 
     await updateSyncState({
       syncId: sync.id,

--- a/packages/sync-workflows/workflows/run_sync.ts
+++ b/packages/sync-workflows/workflows/run_sync.ts
@@ -153,7 +153,17 @@ async function doFullThenIncrementalSync({
       },
     });
 
-    await populateAssociations({ connectionId: sync.connectionId });
+    await populateAssociations({
+      connectionId: sync.connectionId,
+      originalMaxLastModifiedAtMsMap: {
+        account: 0,
+        lead: 0,
+        opportunity: 0,
+        contact: 0,
+        user: 0,
+        event: 0,
+      },
+    });
 
     await updateSyncState({
       syncId: sync.id,


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

Fixes: https://github.com/supaglue-labs/supaglue/issues/422

These are some indexes / query tweaks that in theory may help with:
1. upserting from temp table to main table
1. populating associations
1. list queries against our API sorted by `last_modified_date`

Need to generate migration, test these out, etc., consider other indexes, partitions, etc.

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
