### PR TITLE
fix: idempotent index for temp teable

### DIFF
--- a/packages/core/services/common_models/base_service.ts
+++ b/packages/core/services/common_models/base_service.ts
@@ -41,7 +41,7 @@ export abstract class CommonModelBaseService {
       // so that we can resume in the case of failure during the COPY stage.
       // TODO: Maybe we don't need to include all
       await client.query(`CREATE TEMP TABLE IF NOT EXISTS ${tempTable} (LIKE ${table} INCLUDING DEFAULTS)`);
-      await client.query(`CREATE INDEX ${tempTable}_remote_id_idx ON ${tempTable} (remote_id)`);
+      await client.query(`CREATE INDEX IF NOT EXISTS ${tempTable}_remote_id_idx ON ${tempTable} (remote_id)`);
       const columns = ['id', ...columnsWithoutId];
 
       // Output


### PR DESCRIPTION
Make index idempotent (same as creating the temp table) in `upsertRemoteCommonModels`

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
