### PR TITLE
chore: manual endpoint for fixing temporal syncs

### DIFF
--- a/apps/api/routes/internal/v1/index.ts
+++ b/apps/api/routes/internal/v1/index.ts
@@ -1,6 +1,8 @@
+import { getDependencyContainer } from '@/dependency_container';
 import { internalMiddleware } from '@/middleware/internal';
 import { internalApplicationMiddleware } from '@/middleware/internal_application';
 import { orgHeaderMiddleware } from '@/middleware/org';
+import { snakecaseKeys } from '@supaglue/utils/snakecase';
 import { Router } from 'express';
 import apiKey from './api_key';
 import application from './application';
@@ -11,10 +13,18 @@ import syncHistory from './sync_history';
 import syncInfo from './sync_info';
 import webhook from './webhook';
 
+const { connectionAndSyncService } = getDependencyContainer();
+
 export default function init(app: Router): void {
   // application routes should not require application header
   const v1ApplicationRouter = Router();
   v1ApplicationRouter.use(internalMiddleware);
+
+  v1ApplicationRouter.post('/_manually_fix_syncs', async (req, res) => {
+    const result = await connectionAndSyncService.manuallyFixTemporalSyncs();
+    return res.status(200).send(snakecaseKeys(result));
+  });
+
   v1ApplicationRouter.use(orgHeaderMiddleware);
 
   application(v1ApplicationRouter);

--- a/apps/api/routes/mgmt/v1/index.ts
+++ b/apps/api/routes/mgmt/v1/index.ts
@@ -15,8 +15,8 @@ export default function init(app: Router): void {
   const v1Router = Router();
 
   v1Router.use(apiKeyHeaderMiddleware);
-  v1Router.post('/_manually_clean_up_orphaned_temporal_syncs', async (req, res) => {
-    const result = await connectionAndSyncService.manuallyCleanUpOrphanedTemporalSyncs();
+  v1Router.post('/_manually_fix_temporal_syncs', async (req, res) => {
+    const result = await connectionAndSyncService.manuallyFixTemporalSyncs();
     return res.status(200).send(snakecaseKeys(result));
   });
 

--- a/apps/api/routes/mgmt/v1/index.ts
+++ b/apps/api/routes/mgmt/v1/index.ts
@@ -15,7 +15,7 @@ export default function init(app: Router): void {
   const v1Router = Router();
 
   v1Router.use(apiKeyHeaderMiddleware);
-  v1Router.post('/_manually_fix_temporal_syncs', async (req, res) => {
+  v1Router.post('/_manually_fix_syncs', async (req, res) => {
     const result = await connectionAndSyncService.manuallyFixTemporalSyncs();
     return res.status(200).send(snakecaseKeys(result));
   });

--- a/apps/api/routes/mgmt/v1/index.ts
+++ b/apps/api/routes/mgmt/v1/index.ts
@@ -1,7 +1,5 @@
-import { getDependencyContainer } from '@/dependency_container';
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
 import { openapiMiddleware } from '@/middleware/openapi';
-import { snakecaseKeys } from '@supaglue/utils/snakecase';
 import { Router } from 'express';
 import customer from './customer';
 import integration from './integration';
@@ -9,17 +7,10 @@ import syncHistory from './sync_history';
 import syncInfo from './sync_info';
 import webhook from './webhook';
 
-const { connectionAndSyncService } = getDependencyContainer();
-
 export default function init(app: Router): void {
   const v1Router = Router();
 
   v1Router.use(apiKeyHeaderMiddleware);
-  v1Router.post('/_manually_fix_syncs', async (req, res) => {
-    const result = await connectionAndSyncService.manuallyFixTemporalSyncs();
-    return res.status(200).send(snakecaseKeys(result));
-  });
-
   v1Router.use(openapiMiddleware('mgmt'));
 
   customer(v1Router);


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

The previous PR would delete orphaned WFs/schedules in Temporal.
This PR improves the endpoint to also spin up new Temporal schedules if somehow it was manually deleted by someone (even though the sync exists in Postgres).

Also moved endpoint to /internal

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
