### PR TITLE
fix: salesforce refresh

### DIFF
--- a/apps/api/routes/oauth.ts
+++ b/apps/api/routes/oauth.ts
@@ -184,6 +184,7 @@ export default function init(app: Router): void {
           refreshToken: tokenWrapper.token['refresh_token'] as string,
           instanceUrl: tokenWrapper.token['instance_url'] as string,
           expiresAt: tokenWrapper.token['expires_at'] as string,
+          loginUrl,
         },
         remoteId,
       };

--- a/packages/core/remotes/crm/salesforce/index.ts
+++ b/packages/core/remotes/crm/salesforce/index.ts
@@ -298,7 +298,9 @@ class SalesforceClient extends AbstractCrmRemoteClient {
     const interval = 1000; // TODO: make configurable
 
     while (startTime + timeout > Date.now()) {
-      const { state } = await poll();
+      const pollResponse = await poll();
+      logger.info(`poll response: `, pollResponse);
+      const { state } = pollResponse;
       switch (state) {
         case 'Open':
           throw new Error('job has not been started');
@@ -333,7 +335,10 @@ class SalesforceClient extends AbstractCrmRemoteClient {
   }
 
   async #getBulk2QueryJobResults(soql: string): Promise<Readable> {
-    const { id } = await this.#submitBulk2QueryJob(soql);
+    const response = await this.#submitBulk2QueryJob(soql);
+    // TODO: Delete this
+    logger.info(`bulk job submission response: `, response);
+    const { id } = response;
 
     await this.#pollBulk2QueryJob(id);
 
@@ -347,6 +352,8 @@ class SalesforceClient extends AbstractCrmRemoteClient {
       let locator: string | undefined = undefined;
       do {
         const response = await this.#getBulk2QueryJobResponse(id, locator);
+        // TODO: Delete this
+        logger.info(`get bulk job response: `, response);
         const readable = getBulk2QueryJobResultsFromResponse(response);
         locator = getBulk2QueryJobNextLocatorFromResponse(response);
 

--- a/packages/core/remotes/crm/salesforce/index.ts
+++ b/packages/core/remotes/crm/salesforce/index.ts
@@ -267,6 +267,8 @@ class SalesforceClient extends AbstractCrmRemoteClient {
           await this.#refreshAccessToken();
         } catch (e: any) {
           logger.error(e);
+          // The error name in jsforce is generated at https://github.com/jsforce/jsforce/blob/master/lib/oauth2.js#L197
+          // TODO(624): Move off of jsforce
           if (e.name === 'ERROR_HTTP_429') {
             throw e;
           }

--- a/packages/core/remotes/crm/salesforce/index.ts
+++ b/packages/core/remotes/crm/salesforce/index.ts
@@ -317,8 +317,7 @@ class SalesforceClient extends AbstractCrmRemoteClient {
     const interval = 1000; // TODO: make configurable
 
     while (startTime + timeout > Date.now()) {
-      const pollResponse = await poll();
-      const { state } = pollResponse;
+      const { state } = await poll();
       switch (state) {
         case 'Open':
           throw new Error('job has not been started');
@@ -367,7 +366,6 @@ class SalesforceClient extends AbstractCrmRemoteClient {
       let locator: string | undefined = undefined;
       do {
         const response = await this.#getBulk2QueryJobResponse(id, locator);
-        // TODO: Delete this
         const readable = getBulk2QueryJobResultsFromResponse(response);
         locator = getBulk2QueryJobNextLocatorFromResponse(response);
 

--- a/packages/types/connection.ts
+++ b/packages/types/connection.ts
@@ -2,12 +2,15 @@ import type { CRMProviderName } from './crm';
 
 export type ConnectionStatus = 'available' | 'added' | 'authorized' | 'callable';
 
+// TODO: Bifurcate salesforce vs hubspot
 export type ConnectionCredentialsDecrypted = {
   type: string;
   accessToken: string;
   refreshToken: string;
   expiresAt: string | null; // null means unknown expiry time
+  // Needed for salesforce only
   instanceUrl: string;
+  loginUrl?: string;
 };
 
 type BaseConnectionCreateParams = {

--- a/packages/types/connection.ts
+++ b/packages/types/connection.ts
@@ -2,7 +2,7 @@ import type { CRMProviderName } from './crm';
 
 export type ConnectionStatus = 'available' | 'added' | 'authorized' | 'callable';
 
-// TODO: Bifurcate salesforce vs hubspot
+// TODO(625): Bifurcate salesforce vs hubspot
 export type ConnectionCredentialsDecrypted = {
   type: string;
   accessToken: string;

--- a/scripts/build_and_push.sh
+++ b/scripts/build_and_push.sh
@@ -14,15 +14,14 @@ WORKSPACE_PATH=$(yarn workspaces list --json | jq -r "select(.name == \"${WORKSP
 # fetch the posthog api key from 1password and pass it as an arg
 # to the docker build
 
-# eval "$(op signin supaglue)"
+eval "$(op signin supaglue)"
 
-POSTHOG_API_KEY=phc_thv3N2dFQcJDh2vPz6FtGE9oKDiBSdYp5oKS1Cu9U8j
+POSTHOG_API_KEY=$(op get item dl4y3dryfib2huqpultgp7wlcq --fields credential)
 
 ADDITIONAL_ARGS="--build-arg POSTHOG_API_KEY=${POSTHOG_API_KEY}"
 
 # read version from package.json
-# VERSION=$(jq -r .version "${WORKSPACE_PATH}/package.json")
-VERSION=ryan-test
+VERSION=$(jq -r .version "${WORKSPACE_PATH}/package.json")
 
 depot build --project 2bljgst1rr \
   --platform linux/amd64,linux/arm64 \

--- a/scripts/build_and_push.sh
+++ b/scripts/build_and_push.sh
@@ -14,14 +14,15 @@ WORKSPACE_PATH=$(yarn workspaces list --json | jq -r "select(.name == \"${WORKSP
 # fetch the posthog api key from 1password and pass it as an arg
 # to the docker build
 
-eval "$(op signin supaglue)"
+# eval "$(op signin supaglue)"
 
-POSTHOG_API_KEY=$(op get item dl4y3dryfib2huqpultgp7wlcq --fields credential)
+POSTHOG_API_KEY=phc_thv3N2dFQcJDh2vPz6FtGE9oKDiBSdYp5oKS1Cu9U8j
 
 ADDITIONAL_ARGS="--build-arg POSTHOG_API_KEY=${POSTHOG_API_KEY}"
 
 # read version from package.json
-VERSION=$(jq -r .version "${WORKSPACE_PATH}/package.json")
+# VERSION=$(jq -r .version "${WORKSPACE_PATH}/package.json")
+VERSION=ryan-test
 
 depot build --project 2bljgst1rr \
   --platform linux/amd64,linux/arm64 \


### PR DESCRIPTION
This fixes a few issues:
- the main issue: persist connection loginUrl so we can use the correct url when refreshing access tokens
- don't infinitely retry when refreshing a token fails
- introduce a timeout when fetching (this is unrelated, but good to do anyway) 