### PR TITLE
fix: write last_modified_at on create and update calls

### DIFF
--- a/packages/core/services/common_models/user_service.ts
+++ b/packages/core/services/common_models/user_service.ts
@@ -85,10 +85,6 @@ export class UserService extends CommonModelBaseService {
       tempTable,
       columnsWithoutId,
       fromRemoteUserToDbUserParams,
-      (remoteUser) =>
-        new Date(
-          Math.max(remoteUser.remoteUpdatedAt?.getTime() || 0, remoteUser.detectedOrRemoteDeletedAt?.getTime() || 0)
-        ),
       onUpsertBatchCompletion
     );
   }


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

This fixes writing `last_modified_at` upon create and update calls. In addition, it provides a backfill endpoint so that after the fix is deployed, we can backfill `last_modified_at` in the DB so that in a subsequent release, we can apply a migration to make `last_modified_at` non-NULL.

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
