### PR TITLE
fix: make sure to run populateAssociations for previous records even if watermark moved

### DIFF
--- a/packages/sync-workflows/workflows/run_sync.ts
+++ b/packages/sync-workflows/workflows/run_sync.ts
@@ -245,14 +245,15 @@ async function doFullThenIncrementalSync({
 
     const newMaxLastModifiedAtMsMap = computeUpdatedMaxLastModifiedAtMsMap(importRecordsResultList);
 
-    await updateSyncState({
-      syncId: sync.id,
-      state: {
-        phase: 'incremental',
-        status: 'in progress',
-        maxLastModifiedAtMsMap: newMaxLastModifiedAtMsMap,
-      },
-    });
+    // TODO: Bring this back when we fix https://github.com/supaglue-labs/supaglue/issues/644
+    // await updateSyncState({
+    //   syncId: sync.id,
+    //   state: {
+    //     phase: 'incremental',
+    //     status: 'in progress',
+    //     maxLastModifiedAtMsMap: newMaxLastModifiedAtMsMap,
+    //   },
+    // });
 
     await populateAssociations({
       connectionId: sync.connectionId,


### PR DESCRIPTION
This is a temporary "fix" to not advance watermarks after importRecords, so that if importRecords succeeds and populateAssociations fails, we will still populate all associations.

[Describe your change here]

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
