### PR TITLE
feat: write to postgres destination

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "express": ">=5.0.0-beta.1",
     "express-openapi-validator": "^5.0.2",
     "express-prom-bundle": "^6.6.0",
+    "kysely": "^0.24.2",
     "pino-http": "^8.3.3",
     "prom-client": "^14.2.0",
     "simple-oauth2": "^5.0.0",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,6 @@
     "express": ">=5.0.0-beta.1",
     "express-openapi-validator": "^5.0.2",
     "express-prom-bundle": "^6.6.0",
-    "kysely": "^0.24.2",
     "pino-http": "^8.3.3",
     "prom-client": "^14.2.0",
     "simple-oauth2": "^5.0.0",

--- a/apps/api/routes/internal/v1/index.ts
+++ b/apps/api/routes/internal/v1/index.ts
@@ -3,7 +3,6 @@ import { internalMiddleware } from '@/middleware/internal';
 import { internalApplicationMiddleware } from '@/middleware/internal_application';
 import { orgHeaderMiddleware } from '@/middleware/org';
 import { fromConnectionModelToConnectionUnsafe } from '@supaglue/core/mappers';
-import { COMMON_MODEL_DB_TABLES } from '@supaglue/db';
 import { snakecaseKeys } from '@supaglue/utils/snakecase';
 import { Router } from 'express';
 import apiKey from './api_key';
@@ -26,21 +25,6 @@ export default function init(app: Router): void {
   v1ApplicationRouter.post('/_manually_fix_syncs', async (req, res) => {
     const result = await connectionAndSyncService.manuallyFixTemporalSyncs();
     return res.status(200).send(snakecaseKeys(result));
-  });
-
-  // TODO: Remove when we're done calling this so we can bring back
-  // https://github.com/supaglue-labs/supaglue/pull/634
-  v1ApplicationRouter.post('/_backfill_last_modified_at', async (req, res) => {
-    for (const table of Object.values(COMMON_MODEL_DB_TABLES)) {
-      await prisma.$executeRawUnsafe(`
-UPDATE ${table}
-SET last_modified_at = GREATEST(
-  COALESCE(remote_updated_at, TIMESTAMP 'epoch'),
-  COALESCE(detected_or_remote_deleted_at, TIMESTAMP 'epoch')
-)
-WHERE last_modified_at IS NULL;
-`);
-    }
   });
 
   v1ApplicationRouter.post('/_backfill_connection_remote_id', async (req, res) => {

--- a/apps/api/services/connection_and_sync_service.ts
+++ b/apps/api/services/connection_and_sync_service.ts
@@ -19,7 +19,7 @@ import {
   runSync,
   RUN_SYNC_PREFIX,
 } from '@supaglue/sync-workflows/workflows/run_sync';
-import { CRM_COMMON_MODELS, Sync, SyncState, SyncType } from '@supaglue/types';
+import { CRM_COMMON_MODEL_TYPES, Sync, SyncState, SyncType } from '@supaglue/types';
 import type {
   ConnectionCreateParamsAny,
   ConnectionSafeAny,
@@ -441,7 +441,7 @@ export class ConnectionAndSyncService {
         throw new Error('Unexpectedly could not find connection for sync');
       }
       const { id: connectionId, applicationId, customerId, category, providerName } = connection;
-      return CRM_COMMON_MODELS.map((commonModel) => ({
+      return CRM_COMMON_MODEL_TYPES.map((commonModel) => ({
         modelName: commonModel,
         lastSyncStart,
         nextSyncStart,

--- a/apps/mgmt-ui/src/components/configuration/destination/PostgresDestinationDetailsPane.tsx
+++ b/apps/mgmt-ui/src/components/configuration/destination/PostgresDestinationDetailsPane.tsx
@@ -142,7 +142,7 @@ export default function PostgresDestinationDetailsPanel({ isLoading }: PostgresD
         <Stack className="gap-2">
           <Typography variant="subtitle1">Schema</Typography>
           <TextField
-            value={database}
+            value={schema}
             size="small"
             label="Schema"
             variant="outlined"

--- a/apps/sync-worker/dependency_container.ts
+++ b/apps/sync-worker/dependency_container.ts
@@ -1,15 +1,6 @@
 import { getCoreDependencyContainer } from '@supaglue/core';
-import {
-  AccountService,
-  ConnectionService,
-  ContactService,
-  EventService,
-  IntegrationService,
-  LeadService,
-  OpportunityService,
-  RemoteService,
-  SyncHistoryService,
-} from '@supaglue/core/services';
+import { ConnectionService, IntegrationService, RemoteService, SyncHistoryService } from '@supaglue/core/services';
+import { DestinationService } from '@supaglue/core/services/destination_service';
 import type { PrismaClient } from '@supaglue/db';
 import { Client, Connection } from '@temporalio/client';
 import fs from 'fs';
@@ -19,34 +10,20 @@ type DependencyContainer = {
   prisma: PrismaClient;
   temporalClient: Client;
   connectionService: ConnectionService;
-  contactService: ContactService;
   remoteService: RemoteService;
-  accountService: AccountService;
-  leadService: LeadService;
-  eventService: EventService;
-  opportunityService: OpportunityService;
   syncService: SyncService;
   syncHistoryService: SyncHistoryService;
   integrationService: IntegrationService;
   applicationService: ApplicationService;
+  destinationService: DestinationService;
 };
 
 // global
 let dependencyContainer: DependencyContainer | undefined = undefined;
 
 function createDependencyContainer(): DependencyContainer {
-  const {
-    prisma,
-    connectionService,
-    contactService,
-    remoteService,
-    accountService,
-    leadService,
-    eventService,
-    opportunityService,
-    syncHistoryService,
-    integrationService,
-  } = getCoreDependencyContainer();
+  const { prisma, connectionService, remoteService, syncHistoryService, integrationService } =
+    getCoreDependencyContainer();
 
   const TEMPORAL_ADDRESS =
     process.env.SUPAGLUE_TEMPORAL_HOST && process.env.SUPAGLUE_TEMPORAL_PORT
@@ -72,21 +49,18 @@ function createDependencyContainer(): DependencyContainer {
 
   const syncService = new SyncService(prisma, temporalClient, connectionService, integrationService);
   const applicationService = new ApplicationService(prisma);
+  const destinationService = new DestinationService(prisma);
 
   return {
     prisma,
     temporalClient,
     applicationService,
     connectionService,
-    contactService,
     remoteService,
-    accountService,
-    leadService,
-    eventService,
-    opportunityService,
     syncService,
     syncHistoryService,
     integrationService,
+    destinationService,
   };
 }
 

--- a/openapi/crm/components/schemas/objects/addresses.yaml
+++ b/openapi/crm/components/schemas/objects/addresses.yaml
@@ -26,11 +26,11 @@ items:
       type: string
       nullable: true
       example: CA
-    street1:
+    street_1:
       type: string
       nullable: true
       example: 525 Brannan
-    street2:
+    street_2:
       type: string
       nullable: true
       example: ~
@@ -40,12 +40,13 @@ items:
     - country
     - postal_code
     - state
-    - street1
+    - street_1
+    - street_2
 example:
   - address_type: shipping
     city: San Francisco
     country: US
     postal_code: '94107'
     state: CA
-    street1: 525 Brannan
-    street2: ~
+    street_1: 525 Brannan
+    street_2: ~

--- a/openapi/crm/openapi.bundle.json
+++ b/openapi/crm/openapi.bundle.json
@@ -1968,12 +1968,12 @@
               "nullable": true,
               "example": "CA"
             },
-            "street1": {
+            "street_1": {
               "type": "string",
               "nullable": true,
               "example": "525 Brannan"
             },
-            "street2": {
+            "street_2": {
               "type": "string",
               "nullable": true,
               "example": null
@@ -1985,7 +1985,8 @@
             "country",
             "postal_code",
             "state",
-            "street1"
+            "street_1",
+            "street_2"
           ]
         },
         "example": [
@@ -1995,8 +1996,8 @@
             "country": "US",
             "postal_code": "94107",
             "state": "CA",
-            "street1": "525 Brannan",
-            "street2": null
+            "street_1": "525 Brannan",
+            "street_2": null
           }
         ]
       },

--- a/packages/core/destination_writers/base.ts
+++ b/packages/core/destination_writers/base.ts
@@ -1,4 +1,4 @@
-import { ConnectionSafeAny } from '@supaglue/types';
+import { ConnectionSafeAny, CRMCommonModelType } from '@supaglue/types';
 import type { Readable } from 'stream';
 
 export type WriteCommonModelsResult = {
@@ -7,66 +7,18 @@ export type WriteCommonModelsResult = {
 };
 
 export interface DestinationWriter {
-  writeAccounts(
+  writeObjects(
     connection: ConnectionSafeAny,
-    stream: Readable,
-    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
-  ): Promise<WriteCommonModelsResult>;
-  writeContacts(
-    connection: ConnectionSafeAny,
-    stream: Readable,
-    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
-  ): Promise<WriteCommonModelsResult>;
-  writeLeads(
-    connection: ConnectionSafeAny,
-    stream: Readable,
-    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
-  ): Promise<WriteCommonModelsResult>;
-  writeOpportunities(
-    connection: ConnectionSafeAny,
-    stream: Readable,
-    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
-  ): Promise<WriteCommonModelsResult>;
-  writeUsers(
-    connection: ConnectionSafeAny,
-    stream: Readable,
-    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
-  ): Promise<WriteCommonModelsResult>;
-  writeEvents(
-    connection: ConnectionSafeAny,
+    commonModelType: CRMCommonModelType,
     stream: Readable,
     onUpsertBatchCompletion: (offset: number, numRecords: number) => void
   ): Promise<WriteCommonModelsResult>;
 }
 
 export abstract class BaseDestinationWriter implements DestinationWriter {
-  abstract writeAccounts(
+  abstract writeObjects(
     connection: ConnectionSafeAny,
-    stream: Readable,
-    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
-  ): Promise<WriteCommonModelsResult>;
-  abstract writeContacts(
-    connection: ConnectionSafeAny,
-    stream: Readable,
-    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
-  ): Promise<WriteCommonModelsResult>;
-  abstract writeLeads(
-    connection: ConnectionSafeAny,
-    stream: Readable,
-    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
-  ): Promise<WriteCommonModelsResult>;
-  abstract writeOpportunities(
-    connection: ConnectionSafeAny,
-    stream: Readable,
-    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
-  ): Promise<WriteCommonModelsResult>;
-  abstract writeUsers(
-    connection: ConnectionSafeAny,
-    stream: Readable,
-    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
-  ): Promise<WriteCommonModelsResult>;
-  abstract writeEvents(
-    connection: ConnectionSafeAny,
+    commonModelType: CRMCommonModelType,
     stream: Readable,
     onUpsertBatchCompletion: (offset: number, numRecords: number) => void
   ): Promise<WriteCommonModelsResult>;

--- a/packages/core/destination_writers/base.ts
+++ b/packages/core/destination_writers/base.ts
@@ -1,0 +1,73 @@
+import { ConnectionSafeAny } from '@supaglue/types';
+import type { Readable } from 'stream';
+
+export type WriteCommonModelsResult = {
+  maxLastModifiedAt: Date | null;
+  numRecords: number;
+};
+
+export interface DestinationWriter {
+  writeAccounts(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+  writeContacts(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+  writeLeads(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+  writeOpportunities(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+  writeUsers(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+  writeEvents(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+}
+
+export abstract class BaseDestinationWriter implements DestinationWriter {
+  abstract writeAccounts(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+  abstract writeContacts(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+  abstract writeLeads(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+  abstract writeOpportunities(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+  abstract writeUsers(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+  abstract writeEvents(
+    connection: ConnectionSafeAny,
+    stream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult>;
+}

--- a/packages/core/destination_writers/postgres.ts
+++ b/packages/core/destination_writers/postgres.ts
@@ -1,0 +1,389 @@
+import { ConnectionSafeAny, CRMCommonModel, PostgresDestination } from '@supaglue/types';
+import { stringify } from 'csv-stringify';
+import { Pool, PoolClient } from 'pg';
+import { from as copyFrom } from 'pg-copy-streams';
+import { Readable, Transform } from 'stream';
+import { pipeline } from 'stream/promises';
+import { keysOfSnakecasedAccountWithTenant } from '../keys/account';
+import { keysOfSnakecasedContactWithTenant } from '../keys/contact';
+import { keysOfSnakecasedEventWithTenant } from '../keys/event';
+import { keysOfSnakecasedLeadWithTenant } from '../keys/lead';
+import { keysOfSnakecasedOpportunityWithTenant } from '../keys/opportunity';
+import { keysOfSnakecasedUserWithTenant } from '../keys/user';
+import { logger } from '../lib';
+import {
+  toSnakecasedKeysAccount,
+  toSnakecasedKeysContact,
+  toSnakecasedKeysLead,
+  toSnakecasedKeysOpportunity,
+  toSnakecasedKeysUser,
+} from '../mappers';
+import { toSnakecasedKeysEvent } from '../mappers/event';
+import { BaseDestinationWriter, WriteCommonModelsResult } from './base';
+
+const destinationIdToPool: Record<string, Pool> = {};
+
+export class PostgresDestinationWriter extends BaseDestinationWriter {
+  readonly #destination: PostgresDestination;
+
+  public constructor(destination: PostgresDestination) {
+    super();
+    this.#destination = destination;
+  }
+
+  async #getClient(): Promise<PoolClient> {
+    const existingPool = destinationIdToPool[this.#destination.id];
+    if (existingPool) {
+      return await existingPool.connect();
+    }
+
+    const pool = new Pool(this.#destination.config);
+    destinationIdToPool[this.#destination.id] = pool;
+    return await pool.connect();
+  }
+
+  async #writeObjects<T>(
+    commonModel: CRMCommonModel,
+    snakecasedKeysMapper: (object: T) => Record<string, unknown>,
+    { id: connectionId, providerName, customerId }: ConnectionSafeAny,
+    inputStream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult> {
+    const childLogger = logger.child({ connectionId, providerName, customerId, commonModel });
+
+    const schema = 'synced'; // TODO: replace with setting from PostgresDestination when it's available
+    const table = tableNamesByCommonModel[commonModel];
+    const qualifiedTable = `${schema}.${table}`;
+    const tempTable = `temp_${table}`;
+
+    const client = await this.#getClient();
+
+    try {
+      // Create tables if necessary
+      // TODO: We should only need to do this once at the beginning
+      await client.query(schemaSetupSqlByCommonModel[commonModel](schema));
+
+      // Create a temporary table
+      // TODO: on the first run, we should be able to directly write into the table and skip the temp table
+      // TODO: In the future, we may want to create a permanent table with background reaper so that we can resume in the case of failure during the COPY stage.
+      await client.query(`CREATE TEMP TABLE IF NOT EXISTS ${tempTable} (LIKE ${qualifiedTable})`);
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS ${tempTable}_provider_name_customer_id_remote_id_idx ON ${tempTable} (provider_name, customer_id, remote_id)`
+      );
+
+      const columns = columnsByCommonModel[commonModel];
+      const columnsWithoutPK = columns.filter((c) => c !== 'provider_name' && c !== 'customer_id' && c !== 'remote_id');
+
+      // Output
+      const stream = client.query(
+        copyFrom(`COPY ${tempTable} (${columns.join(',')}) FROM STDIN WITH (DELIMITER ',', FORMAT CSV)`)
+      );
+
+      // Input
+      const stringifier = stringify({
+        columns,
+        cast: {
+          boolean: (value: boolean) => value.toString(),
+          object: (value: object) => JSON.stringify(value),
+          date: (value: Date) => value.toISOString(),
+        },
+        quoted: true,
+      });
+
+      // Keep track of stuff
+      let tempTableRowCount = 0;
+      let maxLastModifiedAt: Date | null = null;
+
+      childLogger.info('Importing common model objects into temp table [IN PROGRESS]');
+      await pipeline(
+        inputStream,
+        new Transform({
+          objectMode: true,
+          transform: (chunk, encoding, callback) => {
+            try {
+              const mappedRecord = {
+                provider_name: providerName,
+                customer_id: customerId,
+                ...snakecasedKeysMapper(chunk),
+              };
+
+              ++tempTableRowCount;
+
+              // Update the max lastModifiedAt
+              const { lastModifiedAt } = chunk;
+              if (lastModifiedAt && (!maxLastModifiedAt || lastModifiedAt > maxLastModifiedAt)) {
+                maxLastModifiedAt = lastModifiedAt;
+              }
+
+              callback(null, mappedRecord);
+            } catch (e: any) {
+              return callback(e);
+            }
+          },
+        }),
+        stringifier,
+        stream
+      );
+      childLogger.info('Importing common model objects into temp table [COMPLETED]');
+
+      // Copy from temp table
+      childLogger.info({ offset: null }, 'Copying from temp table to main table [IN PROGRESS]');
+      const columnsToUpdateStr = columnsWithoutPK.join(',');
+      const excludedColumnsToUpdateStr = columnsWithoutPK.map((column) => `EXCLUDED.${column}`).join(',');
+
+      // Paginate
+      const batchSize = 10000;
+      for (let offset = 0; offset < tempTableRowCount; offset += batchSize) {
+        childLogger.info({ offset }, 'Copying from temp table to main table [IN PROGRESS]');
+        // IMPORTANT: we need to use DISTINCT ON because we may have multiple records with the same remote_id
+        // For example, hubspot will return the same record twice when querying for `archived: true` if
+        // the record was archived, restored, and archived again.
+        // TODO: This may have performance implications. We should look into this later.
+        // https://github.com/supaglue-labs/supaglue/issues/497
+        await client.query(`INSERT INTO ${qualifiedTable}
+SELECT DISTINCT ON (remote_id) * FROM (SELECT * FROM ${tempTable} ORDER BY remote_id OFFSET ${offset} limit ${batchSize}) AS batch
+ON CONFLICT (provider_name, customer_id, remote_id)
+DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
+        childLogger.info({ offset }, 'Copying from temp table to main table [COMPLETED]');
+        onUpsertBatchCompletion(offset, tempTableRowCount);
+      }
+
+      childLogger.info('Copying from temp table to main table [COMPLETED]');
+
+      return {
+        maxLastModifiedAt,
+        numRecords: tempTableRowCount, // TODO: not quite accurate (because there can be duplicates) but good enough
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  public override async writeAccounts(
+    connection: ConnectionSafeAny,
+    inputStream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult> {
+    return await this.#writeObjects(
+      'account',
+      toSnakecasedKeysAccount,
+      connection,
+      inputStream,
+      onUpsertBatchCompletion
+    );
+  }
+
+  public override async writeContacts(
+    connection: ConnectionSafeAny,
+    inputStream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult> {
+    return await this.#writeObjects(
+      'contact',
+      toSnakecasedKeysContact,
+      connection,
+      inputStream,
+      onUpsertBatchCompletion
+    );
+  }
+
+  public override async writeLeads(
+    connection: ConnectionSafeAny,
+    inputStream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult> {
+    return await this.#writeObjects('lead', toSnakecasedKeysLead, connection, inputStream, onUpsertBatchCompletion);
+  }
+
+  public override async writeOpportunities(
+    connection: ConnectionSafeAny,
+    inputStream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult> {
+    return await this.#writeObjects(
+      'opportunity',
+      toSnakecasedKeysOpportunity,
+      connection,
+      inputStream,
+      onUpsertBatchCompletion
+    );
+  }
+
+  public override async writeUsers(
+    connection: ConnectionSafeAny,
+    inputStream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult> {
+    return await this.#writeObjects('user', toSnakecasedKeysUser, connection, inputStream, onUpsertBatchCompletion);
+  }
+
+  public override async writeEvents(
+    connection: ConnectionSafeAny,
+    inputStream: Readable,
+    onUpsertBatchCompletion: (offset: number, numRecords: number) => void
+  ): Promise<WriteCommonModelsResult> {
+    return await this.#writeObjects('event', toSnakecasedKeysEvent, connection, inputStream, onUpsertBatchCompletion);
+  }
+}
+
+const tableNamesByCommonModel: Record<CRMCommonModel, string> = {
+  account: 'crm_accounts',
+  contact: 'crm_contacts',
+  lead: 'crm_leads',
+  opportunity: 'crm_opportunities',
+  user: 'crm_users',
+  event: 'crm_events',
+};
+
+const columnsByCommonModel: Record<CRMCommonModel, string[]> = {
+  account: keysOfSnakecasedAccountWithTenant,
+  contact: keysOfSnakecasedContactWithTenant,
+  lead: keysOfSnakecasedLeadWithTenant,
+  opportunity: keysOfSnakecasedOpportunityWithTenant,
+  user: keysOfSnakecasedUserWithTenant,
+  event: keysOfSnakecasedEventWithTenant,
+};
+
+const schemaSetupSqlByCommonModel: Record<CRMCommonModel, (schema: string) => string> = {
+  account: (schema: string) => `-- CreateTable
+CREATE TABLE IF NOT EXISTS "${schema}"."crm_accounts" (
+  "provider_name" TEXT NOT NULL,
+  "customer_id" TEXT NOT NULL,
+  "remote_id" TEXT NOT NULL,
+  "name" TEXT,
+  "description" TEXT,
+  "industry" TEXT,
+  "website" TEXT,
+  "number_of_employees" INTEGER,
+  "addresses" JSONB,
+  "phone_numbers" JSONB,
+  "lifecycle_stage" TEXT,
+  "last_activity_at" TIMESTAMP(3),
+  "remote_data" JSONB,
+  "remote_created_at" TIMESTAMP(3),
+  "remote_updated_at" TIMESTAMP(3),
+  "remote_was_deleted" BOOLEAN NOT NULL,
+  "remote_deleted_at" TIMESTAMP(3),
+  "detected_or_remote_deleted_at" TIMESTAMP(3),
+  "last_modified_at" TIMESTAMP(3) NOT NULL,
+  "owner_id" TEXT,
+
+  CONSTRAINT "crm_accounts_pkey" PRIMARY KEY ("provider_name", "customer_id", "remote_id")
+);`,
+  contact: (schema: string) => `-- CreateTable
+CREATE TABLE IF NOT EXISTS "${schema}"."crm_contacts" (
+  "provider_name" TEXT NOT NULL,
+  "customer_id" TEXT NOT NULL,
+  "remote_id" TEXT NOT NULL,
+  "first_name" TEXT,
+  "last_name" TEXT,
+  "addresses" JSONB NOT NULL,
+  "email_addresses" JSONB NOT NULL,
+  "phone_numbers" JSONB NOT NULL,
+  "last_activity_at" TIMESTAMP(3),
+  "lifecycle_stage" TEXT,
+  "remote_data" JSONB,
+  "remote_created_at" TIMESTAMP(3),
+  "remote_updated_at" TIMESTAMP(3),
+  "remote_was_deleted" BOOLEAN NOT NULL,
+  "remote_deleted_at" TIMESTAMP(3),
+  "detected_or_remote_deleted_at" TIMESTAMP(3),
+  "last_modified_at" TIMESTAMP(3) NOT NULL,
+  "account_id" TEXT,
+  "owner_id" TEXT,
+
+  CONSTRAINT "crm_contacts_pkey" PRIMARY KEY ("provider_name", "customer_id", "remote_id")
+);`,
+  lead: (schema: string) => `-- CreateTable
+CREATE TABLE IF NOT EXISTS "${schema}"."crm_leads" (
+  "provider_name" TEXT NOT NULL,
+  "customer_id" TEXT NOT NULL,
+  "remote_id" TEXT NOT NULL,
+  "lead_source" TEXT,
+  "title" TEXT,
+  "company" TEXT,
+  "first_name" TEXT,
+  "last_name" TEXT,
+  "addresses" JSONB,
+  "phone_numbers" JSONB,
+  "email_addresses" JSONB,
+  "remote_data" JSONB,
+  "remote_created_at" TIMESTAMP(3),
+  "remote_updated_at" TIMESTAMP(3),
+  "remote_was_deleted" BOOLEAN NOT NULL,
+  "remote_deleted_at" TIMESTAMP(3),
+  "detected_or_remote_deleted_at" TIMESTAMP(3),
+  "last_modified_at" TIMESTAMP(3) NOT NULL,
+  "converted_date" TIMESTAMP(3),
+  "converted_account_id" TEXT,
+  "converted_contact_id" TEXT,
+  "owner_id" TEXT,
+
+  CONSTRAINT "crm_leads_pkey" PRIMARY KEY ("provider_name", "customer_id", "remote_id")
+);`,
+  opportunity: (schema: string) => `-- CreateTable
+CREATE TABLE IF NOT EXISTS "${schema}"."crm_opportunities" (
+  "provider_name" TEXT NOT NULL,
+  "customer_id" TEXT NOT NULL,
+  "remote_id" TEXT NOT NULL,
+  "name" TEXT,
+  "description" TEXT,
+  "amount" INTEGER,
+  "stage" TEXT,
+  "status" TEXT,
+  "last_activity_at" TIMESTAMP(3),
+  "pipeline" TEXT,
+  "close_date" TIMESTAMP(3),
+  "remote_created_at" TIMESTAMP(3),
+  "remote_updated_at" TIMESTAMP(3),
+  "remote_was_deleted" BOOLEAN NOT NULL,
+  "remote_deleted_at" TIMESTAMP(3),
+  "detected_or_remote_deleted_at" TIMESTAMP(3),
+  "last_modified_at" TIMESTAMP(3) NOT NULL,
+  "account_id" TEXT,
+  "owner_id" TEXT,
+
+  CONSTRAINT "crm_opportunities_pkey" PRIMARY KEY ("provider_name", "customer_id", "remote_id")
+);`,
+  user: (schema: string) => `-- CreateTable
+CREATE TABLE IF NOT EXISTS "${schema}"."crm_users" (
+    "provider_name" TEXT NOT NULL,
+    "customer_id" TEXT NOT NULL,
+    "remote_id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT,
+    "is_active" BOOLEAN,
+    "remote_created_at" TIMESTAMP(3),
+    "remote_updated_at" TIMESTAMP(3),
+    "remote_was_deleted" BOOLEAN NOT NULL,
+    "remote_deleted_at" TIMESTAMP(3),
+    "detected_or_remote_deleted_at" TIMESTAMP(3),
+    "last_modified_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "crm_users_pkey" PRIMARY KEY ("provider_name", "customer_id", "remote_id")
+);`,
+  event: (schema: string) => `-- CreateTable
+CREATE TABLE IF NOT EXISTS "${schema}"."crm_events" (
+  "provider_name" TEXT NOT NULL,
+  "customer_id" TEXT NOT NULL,
+  "remote_id" TEXT NOT NULL,
+  "type" TEXT,
+  "subject" TEXT,
+  "content" TEXT,
+  "start_time" TIMESTAMP(3),
+  "end_time" TIMESTAMP(3),
+  "remote_created_at" TIMESTAMP(3),
+  "remote_updated_at" TIMESTAMP(3),
+  "remote_was_deleted" BOOLEAN NOT NULL,
+  "remote_deleted_at" TIMESTAMP(3),
+  "detected_or_remote_deleted_at" TIMESTAMP(3),
+  "last_modified_at" TIMESTAMP(3) NOT NULL,
+  "account_id" TEXT,
+  "contact_id" TEXT,
+  "lead_id" TEXT,
+  "opportunity_id" TEXT,
+  "owner_id" TEXT,
+
+  CONSTRAINT "crm_events_pkey" PRIMARY KEY ("provider_name", "customer_id", "remote_id")
+);`,
+};

--- a/packages/core/destination_writers/postgres.ts
+++ b/packages/core/destination_writers/postgres.ts
@@ -50,7 +50,7 @@ export class PostgresDestinationWriter extends BaseDestinationWriter {
   ): Promise<WriteCommonModelsResult> {
     const childLogger = logger.child({ connectionId, providerName, customerId, commonModelType });
 
-    const schema = 'synced'; // TODO: replace with setting from PostgresDestination when it's available
+    const { schema } = this.#destination.config;
     const table = tableNamesByCommonModelType[commonModelType];
     const qualifiedTable = `${schema}.${table}`;
     const tempTable = `temp_${table}`;

--- a/packages/core/keys/account.ts
+++ b/packages/core/keys/account.ts
@@ -1,0 +1,24 @@
+import { SnakecasedKeysAccountWithTenant } from '@supaglue/types';
+import { arrayOfAllKeys } from './util';
+
+export const keysOfSnakecasedAccountWithTenant = arrayOfAllKeys<SnakecasedKeysAccountWithTenant>()([
+  'provider_name',
+  'customer_id',
+  'remote_id',
+  'remote_created_at',
+  'remote_updated_at',
+  'remote_was_deleted',
+  'remote_deleted_at',
+  'detected_or_remote_deleted_at',
+  'last_modified_at',
+  'name',
+  'description',
+  'industry',
+  'website',
+  'number_of_employees',
+  'addresses',
+  'phone_numbers',
+  'last_activity_at',
+  'lifecycle_stage',
+  'owner_id',
+]);

--- a/packages/core/keys/contact.ts
+++ b/packages/core/keys/contact.ts
@@ -1,0 +1,23 @@
+import { SnakecasedKeysContactWithTenant } from '@supaglue/types';
+import { arrayOfAllKeys } from './util';
+
+export const keysOfSnakecasedContactWithTenant = arrayOfAllKeys<SnakecasedKeysContactWithTenant>()([
+  'provider_name',
+  'customer_id',
+  'remote_id',
+  'remote_created_at',
+  'remote_updated_at',
+  'remote_was_deleted',
+  'remote_deleted_at',
+  'detected_or_remote_deleted_at',
+  'last_modified_at',
+  'first_name',
+  'last_name',
+  'addresses',
+  'email_addresses',
+  'phone_numbers',
+  'lifecycle_stage',
+  'account_id',
+  'owner_id',
+  'last_activity_at',
+]);

--- a/packages/core/keys/event.ts
+++ b/packages/core/keys/event.ts
@@ -1,0 +1,24 @@
+import { SnakecasedKeysEventWithTenant } from '@supaglue/types';
+import { arrayOfAllKeys } from './util';
+
+export const keysOfSnakecasedEventWithTenant = arrayOfAllKeys<SnakecasedKeysEventWithTenant>()([
+  'provider_name',
+  'customer_id',
+  'remote_id',
+  'remote_created_at',
+  'remote_updated_at',
+  'remote_was_deleted',
+  'remote_deleted_at',
+  'detected_or_remote_deleted_at',
+  'last_modified_at',
+  'type',
+  'subject',
+  'content',
+  'start_time',
+  'end_time',
+  'owner_id',
+  'account_id',
+  'contact_id',
+  'lead_id',
+  'opportunity_id',
+]);

--- a/packages/core/keys/lead.ts
+++ b/packages/core/keys/lead.ts
@@ -1,0 +1,26 @@
+import { SnakecasedKeysLeadWithTenant } from '@supaglue/types';
+import { arrayOfAllKeys } from './util';
+
+export const keysOfSnakecasedLeadWithTenant = arrayOfAllKeys<SnakecasedKeysLeadWithTenant>()([
+  'provider_name',
+  'customer_id',
+  'remote_id',
+  'remote_created_at',
+  'remote_updated_at',
+  'remote_was_deleted',
+  'remote_deleted_at',
+  'detected_or_remote_deleted_at',
+  'last_modified_at',
+  'lead_source',
+  'title',
+  'company',
+  'first_name',
+  'last_name',
+  'addresses',
+  'email_addresses',
+  'phone_numbers',
+  'converted_date',
+  'converted_contact_id',
+  'converted_account_id',
+  'owner_id',
+]);

--- a/packages/core/keys/opportunity.ts
+++ b/packages/core/keys/opportunity.ts
@@ -1,0 +1,24 @@
+import { SnakecasedKeysOpportunityWithTenant } from '@supaglue/types';
+import { arrayOfAllKeys } from './util';
+
+export const keysOfSnakecasedOpportunityWithTenant = arrayOfAllKeys<SnakecasedKeysOpportunityWithTenant>()([
+  'provider_name',
+  'customer_id',
+  'remote_id',
+  'remote_created_at',
+  'remote_updated_at',
+  'remote_was_deleted',
+  'remote_deleted_at',
+  'detected_or_remote_deleted_at',
+  'last_modified_at',
+  'name',
+  'description',
+  'amount',
+  'stage',
+  'status',
+  'close_date',
+  'pipeline',
+  'account_id',
+  'owner_id',
+  'last_activity_at',
+]);

--- a/packages/core/keys/user.ts
+++ b/packages/core/keys/user.ts
@@ -1,0 +1,17 @@
+import { SnakecasedKeysUserWithTenant } from '@supaglue/types';
+import { arrayOfAllKeys } from './util';
+
+export const keysOfSnakecasedUserWithTenant = arrayOfAllKeys<SnakecasedKeysUserWithTenant>()([
+  'provider_name',
+  'customer_id',
+  'remote_id',
+  'remote_created_at',
+  'remote_updated_at',
+  'remote_was_deleted',
+  'remote_deleted_at',
+  'detected_or_remote_deleted_at',
+  'last_modified_at',
+  'name',
+  'email',
+  'is_active',
+]);

--- a/packages/core/keys/util.ts
+++ b/packages/core/keys/util.ts
@@ -1,0 +1,14 @@
+/**
+ * This type is used to ensure that all properties of a type are present in an array.
+ */
+type EnsureAllProperties<T, U extends T[]> = [T] extends [U[number]] ? unknown : 'Invalid';
+
+/**
+ * This function is used to ensure that all properties of a type are present in an array.
+ * It will also remove duplicates.
+ */
+export function arrayOfAllKeys<M>(): <T extends keyof M = keyof M, U extends T[] = T[]>(
+  array: U & EnsureAllProperties<T, U>
+) => U {
+  return (array) => [...new Set(array)] as typeof array;
+}

--- a/packages/core/mappers/account.ts
+++ b/packages/core/mappers/account.ts
@@ -1,8 +1,8 @@
-import { Account } from '@supaglue/types';
+import { Account, SnakecasedKeysAccount } from '@supaglue/types';
 import { toSnakecasedKeysAddress } from './address';
 import { toSnakecasedKeysPhoneNumber } from './phone_number';
 
-export const toSnakecasedKeysAccount = (account: Account) => {
+export const toSnakecasedKeysAccount = (account: Account): SnakecasedKeysAccount => {
   return {
     owner_id: account.ownerId,
     last_modified_at: account.lastModifiedAt,
@@ -19,5 +19,7 @@ export const toSnakecasedKeysAccount = (account: Account) => {
     remote_created_at: account.remoteCreatedAt,
     remote_updated_at: account.remoteUpdatedAt,
     remote_was_deleted: account.remoteWasDeleted,
+    remote_deleted_at: account.remoteDeletedAt,
+    detected_or_remote_deleted_at: account.detectedOrRemoteDeletedAt,
   };
 };

--- a/packages/core/mappers/address.ts
+++ b/packages/core/mappers/address.ts
@@ -1,9 +1,10 @@
 import { Address } from '@supaglue/types';
+import { SnakecasedKeysAddress } from '@supaglue/types/crm/common/address';
 
-export const toSnakecasedKeysAddress = (address: Address) => {
+export const toSnakecasedKeysAddress = (address: Address): SnakecasedKeysAddress => {
   return {
-    street1: address.street1,
-    street2: address.street2,
+    street_1: address.street1,
+    street_2: address.street2,
     city: address.city,
     state: address.state,
     postal_code: address.postalCode,

--- a/packages/core/mappers/contact.ts
+++ b/packages/core/mappers/contact.ts
@@ -1,9 +1,9 @@
-import { Contact } from '@supaglue/types';
+import { Contact, SnakecasedKeysContact } from '@supaglue/types';
 import { toSnakecasedKeysAddress } from './address';
 import { toSnakecasedKeysEmailAddress } from './email_address';
 import { toSnakecasedKeysPhoneNumber } from './phone_number';
 
-export const toSnakecasedKeysContact = (contact: Contact) => {
+export const toSnakecasedKeysContact = (contact: Contact): SnakecasedKeysContact => {
   return {
     owner_id: contact.ownerId,
     account_id: contact.accountId,
@@ -19,5 +19,7 @@ export const toSnakecasedKeysContact = (contact: Contact) => {
     remote_created_at: contact.remoteCreatedAt,
     remote_updated_at: contact.remoteUpdatedAt,
     remote_was_deleted: contact.remoteWasDeleted,
+    remote_deleted_at: contact.remoteDeletedAt,
+    detected_or_remote_deleted_at: contact.detectedOrRemoteDeletedAt,
   };
 };

--- a/packages/core/mappers/email_address.ts
+++ b/packages/core/mappers/email_address.ts
@@ -1,6 +1,7 @@
 import { EmailAddress } from '@supaglue/types';
+import { SnakedcasedKeysEmailAddress } from '@supaglue/types/crm/common/email_address';
 
-export const toSnakecasedKeysEmailAddress = (emailAddress: EmailAddress) => {
+export const toSnakecasedKeysEmailAddress = (emailAddress: EmailAddress): SnakedcasedKeysEmailAddress => {
   return {
     email_address: emailAddress.emailAddress,
     email_address_type: emailAddress.emailAddressType,

--- a/packages/core/mappers/event.ts
+++ b/packages/core/mappers/event.ts
@@ -1,6 +1,6 @@
-import { Event } from '@supaglue/types';
+import { Event, SnakecasedKeysEvent } from '@supaglue/types';
 
-export const toSnakecasedKeysEvent = (event: Event) => {
+export const toSnakecasedKeysEvent = (event: Event): SnakecasedKeysEvent => {
   return {
     owner_id: event.ownerId,
     account_id: event.accountId,
@@ -17,5 +17,7 @@ export const toSnakecasedKeysEvent = (event: Event) => {
     remote_created_at: event.remoteCreatedAt,
     remote_updated_at: event.remoteUpdatedAt,
     remote_was_deleted: event.remoteWasDeleted,
+    remote_deleted_at: event.remoteDeletedAt,
+    detected_or_remote_deleted_at: event.detectedOrRemoteDeletedAt,
   };
 };

--- a/packages/core/mappers/lead.ts
+++ b/packages/core/mappers/lead.ts
@@ -1,9 +1,9 @@
-import { Lead } from '@supaglue/types';
+import { Lead, SnakecasedKeysLead } from '@supaglue/types';
 import { toSnakecasedKeysAddress } from './address';
 import { toSnakecasedKeysEmailAddress } from './email_address';
 import { toSnakecasedKeysPhoneNumber } from './phone_number';
 
-export const toSnakecasedKeysLead = (lead: Lead) => {
+export const toSnakecasedKeysLead = (lead: Lead): SnakecasedKeysLead => {
   return {
     owner_id: lead.ownerId,
     last_modified_at: lead.lastModifiedAt,
@@ -22,5 +22,7 @@ export const toSnakecasedKeysLead = (lead: Lead) => {
     remote_was_deleted: lead.remoteWasDeleted,
     converted_contact_id: lead.convertedContactId,
     converted_account_id: lead.convertedAccountId,
+    remote_deleted_at: lead.remoteDeletedAt,
+    detected_or_remote_deleted_at: lead.detectedOrRemoteDeletedAt,
   };
 };

--- a/packages/core/mappers/opportunity.ts
+++ b/packages/core/mappers/opportunity.ts
@@ -1,6 +1,6 @@
-import { Opportunity } from '@supaglue/types';
+import { Opportunity, SnakecasedKeysOpportunity } from '@supaglue/types';
 
-export const toSnakecasedKeysOpportunity = (opportunity: Opportunity) => {
+export const toSnakecasedKeysOpportunity = (opportunity: Opportunity): SnakecasedKeysOpportunity => {
   return {
     owner_id: opportunity.ownerId,
     account_id: opportunity.accountId,
@@ -17,5 +17,7 @@ export const toSnakecasedKeysOpportunity = (opportunity: Opportunity) => {
     remote_created_at: opportunity.remoteCreatedAt,
     remote_updated_at: opportunity.remoteUpdatedAt,
     remote_was_deleted: opportunity.remoteWasDeleted,
+    remote_deleted_at: opportunity.remoteDeletedAt,
+    detected_or_remote_deleted_at: opportunity.detectedOrRemoteDeletedAt,
   };
 };

--- a/packages/core/mappers/phone_number.ts
+++ b/packages/core/mappers/phone_number.ts
@@ -1,6 +1,7 @@
 import { PhoneNumber } from '@supaglue/types';
+import { SnakecasedKeysPhoneNumber } from '@supaglue/types/crm/common/phone_number';
 
-export const toSnakecasedKeysPhoneNumber = (phoneNumber: PhoneNumber) => {
+export const toSnakecasedKeysPhoneNumber = (phoneNumber: PhoneNumber): SnakecasedKeysPhoneNumber => {
   return {
     phone_number: phoneNumber.phoneNumber,
     phone_number_type: phoneNumber.phoneNumberType,

--- a/packages/core/mappers/user.ts
+++ b/packages/core/mappers/user.ts
@@ -1,6 +1,6 @@
-import { User } from '@supaglue/types';
+import { SnakecasedKeysUser, User } from '@supaglue/types';
 
-export const toSnakecasedKeysUser = (user: User) => {
+export const toSnakecasedKeysUser = (user: User): SnakecasedKeysUser => {
   return {
     last_modified_at: user.lastModifiedAt,
     remote_id: user.remoteId,
@@ -10,5 +10,7 @@ export const toSnakecasedKeysUser = (user: User) => {
     remote_created_at: user.remoteCreatedAt,
     remote_updated_at: user.remoteUpdatedAt,
     remote_was_deleted: user.remoteWasDeleted,
+    remote_deleted_at: user.remoteDeletedAt,
+    detected_or_remote_deleted_at: user.detectedOrRemoteDeletedAt,
   };
 };

--- a/packages/core/services/common_models/account_service.ts
+++ b/packages/core/services/common_models/account_service.ts
@@ -1,4 +1,5 @@
 import type { Account, AccountCreateParams, AccountUpdateParams } from '@supaglue/types';
+import { Readable } from 'stream';
 import { CommonModelBaseService } from './base_service';
 
 export class AccountService extends CommonModelBaseService {
@@ -14,5 +15,10 @@ export class AccountService extends CommonModelBaseService {
   public async update(customerId: string, connectionId: string, updateParams: AccountUpdateParams): Promise<Account> {
     const remoteClient = await this.remoteService.getCrmRemoteClient(connectionId);
     return await remoteClient.updateAccount(updateParams);
+  }
+
+  public async exportAccounts(connectionId: string, customerId: string, accountsStream: Readable): Promise<void> {
+    const schema = 'api'; // TODO: replace with setting from PostgresDestination
+    const table = 'asdf';
   }
 }

--- a/packages/core/services/destination_service.ts
+++ b/packages/core/services/destination_service.ts
@@ -1,5 +1,7 @@
 import type { PrismaClient } from '@supaglue/db';
 import type { Destination, DestinationCreateParams, DestinationUpdateParams } from '@supaglue/types';
+import { DestinationWriter } from '../destination_writers/base';
+import { PostgresDestinationWriter } from '../destination_writers/postgres';
 import { fromDestinationModel } from '../mappers/destination';
 
 export class DestinationService {
@@ -44,5 +46,22 @@ export class DestinationService {
       },
     });
     return fromDestinationModel(model);
+  }
+
+  public async getWriterByApplicationId(applicationId: string): Promise<DestinationWriter> {
+    const destinations = await this.getDestinationsByApplicationId(applicationId);
+    if (destinations.length === 0) {
+      throw new Error('No destinations found');
+    }
+    if (destinations.length > 1) {
+      throw new Error('Multiple destinations found');
+    }
+    const destination = destinations[0];
+    switch (destination.type) {
+      case 's3':
+        throw new Error('S3 destination not implemented');
+      case 'postgres':
+        return new PostgresDestinationWriter(destination);
+    }
   }
 }

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -3,22 +3,4 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 export * from '@prisma/client';
-export { schemaPrefix };
 export default prisma;
-
-const databaseUrl = new URL(process.env.SUPAGLUE_DATABASE_URL!);
-const schema = databaseUrl.searchParams.get('schema');
-
-let schemaPrefix = '';
-if (schema) {
-  schemaPrefix = `${schema}.`;
-}
-
-export const COMMON_MODEL_DB_TABLES = {
-  contacts: `${schemaPrefix}crm_contacts`,
-  accounts: `${schemaPrefix}crm_accounts`,
-  leads: `${schemaPrefix}crm_leads`,
-  opportunities: `${schemaPrefix}crm_opportunities`,
-  users: `${schemaPrefix}crm_users`,
-  events: `${schemaPrefix}crm_events`,
-};

--- a/packages/schemas/gen/crm.ts
+++ b/packages/schemas/gen/crm.ts
@@ -522,8 +522,8 @@ export interface components {
      *     "country": "US",
      *     "postal_code": "94107",
      *     "state": "CA",
-     *     "street1": "525 Brannan",
-     *     "street2": null
+     *     "street_1": "525 Brannan",
+     *     "street_2": null
      *   }
      * ]
      */
@@ -539,9 +539,9 @@ export interface components {
         /** @example CA */
         state: string | null;
         /** @example 525 Brannan */
-        street1: string | null;
+        street_1: string | null;
         /** @example null */
-        street2?: string | null;
+        street_2: string | null;
       })[];
     /**
      * @example [

--- a/packages/sync-workflows/activities/import_records.ts
+++ b/packages/sync-workflows/activities/import_records.ts
@@ -1,13 +1,8 @@
-import {
-  AccountService,
-  ConnectionService,
-  ContactService,
-  EventService,
-  LeadService,
-  OpportunityService,
-  RemoteService,
-} from '@supaglue/core/services';
+import { ConnectionService, RemoteService } from '@supaglue/core/services';
+import { DestinationService } from '@supaglue/core/services/destination_service';
 import { CommonModel } from '@supaglue/types';
+import { Context } from '@temporalio/activity';
+import { pipeline, Readable, Transform } from 'stream';
 import { logEvent } from '../lib/analytics';
 
 export type ImportRecordsArgs = {
@@ -23,13 +18,9 @@ export type ImportRecordsResult = {
 };
 
 export function createImportRecords(
-  accountService: AccountService,
   connectionService: ConnectionService,
-  contactService: ContactService,
   remoteService: RemoteService,
-  opportunityService: OpportunityService,
-  leadService: LeadService,
-  eventService: EventService
+  destinationService: DestinationService
 ) {
   return async function importRecords({
     syncId,
@@ -39,6 +30,7 @@ export function createImportRecords(
   }: ImportRecordsArgs): Promise<ImportRecordsResult> {
     const connection = await connectionService.getSafeById(connectionId);
     const client = await remoteService.getCrmRemoteClient(connectionId);
+    const writer = await destinationService.getWriterByApplicationId(connection.applicationId);
 
     const result = {
       maxLastModifiedAt: null as Date | null,
@@ -52,26 +44,32 @@ export function createImportRecords(
     switch (commonModel) {
       case 'account': {
         const readable = await client.listAccounts(updatedAfter);
+        await writer.writeAccounts(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
       case 'contact': {
         const readable = await client.listContacts(updatedAfter);
+        await writer.writeContacts(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
       case 'opportunity': {
         const readable = await client.listOpportunities(updatedAfter);
+        await writer.writeOpportunities(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
       case 'lead': {
         const readable = await client.listLeads(updatedAfter);
+        await writer.writeLeads(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
       case 'user': {
         const readable = await client.listUsers(updatedAfter);
+        await writer.writeUsers(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
       case 'event': {
         const readable = await client.listEvents(updatedAfter);
+        await writer.writeEvents(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
     }
@@ -88,4 +86,31 @@ export function createImportRecords(
       numRecordsSynced: result.numRecords,
     };
   };
+}
+
+function toHeartbeatingStream(stream: Readable) {
+  // TODO: While this ensures rescheduling of this activity if the process dies,
+  // it does not ensure that we stop the stream processing.
+  // We need to include a timeout here to clean up the pipeline when we
+  // exceed the heartbeat timeout.
+  return pipeline(
+    stream,
+    new Transform({
+      objectMode: true,
+      transform: (chunk, encoding, callback) => {
+        Context.current().heartbeat();
+        try {
+          callback(null, chunk);
+        } catch (e: any) {
+          return callback(e);
+        }
+      },
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    () => {}
+  );
+}
+
+function onUpsertBatchCompletion(offset: number, numRecords: number) {
+  Context.current().heartbeat();
 }

--- a/packages/sync-workflows/activities/import_records.ts
+++ b/packages/sync-workflows/activities/import_records.ts
@@ -44,32 +44,32 @@ export function createImportRecords(
     switch (commonModel) {
       case 'account': {
         const readable = await client.listAccounts(updatedAfter);
-        await writer.writeAccounts(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
+        await writer.writeObjects(connection, 'account', toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
       case 'contact': {
         const readable = await client.listContacts(updatedAfter);
-        await writer.writeContacts(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
+        await writer.writeObjects(connection, 'contact', toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
       case 'opportunity': {
         const readable = await client.listOpportunities(updatedAfter);
-        await writer.writeOpportunities(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
+        await writer.writeObjects(connection, 'opportunity', toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
       case 'lead': {
         const readable = await client.listLeads(updatedAfter);
-        await writer.writeLeads(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
+        await writer.writeObjects(connection, 'lead', toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
       case 'user': {
         const readable = await client.listUsers(updatedAfter);
-        await writer.writeUsers(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
+        await writer.writeObjects(connection, 'user', toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
       case 'event': {
         const readable = await client.listEvents(updatedAfter);
-        await writer.writeEvents(connection, toHeartbeatingStream(readable), onUpsertBatchCompletion);
+        await writer.writeObjects(connection, 'event', toHeartbeatingStream(readable), onUpsertBatchCompletion);
         break;
       }
     }

--- a/packages/sync-workflows/activities/index.ts
+++ b/packages/sync-workflows/activities/index.ts
@@ -1,14 +1,5 @@
-import type {
-  AccountService,
-  ConnectionService,
-  ContactService,
-  EventService,
-  IntegrationService,
-  LeadService,
-  OpportunityService,
-  RemoteService,
-  SyncHistoryService,
-} from '@supaglue/core/services';
+import type { ConnectionService, IntegrationService, RemoteService, SyncHistoryService } from '@supaglue/core/services';
+import { DestinationService } from '@supaglue/core/services/destination_service';
 import type { ApplicationService, SyncService } from 'sync-worker/services';
 import { createDoProcessSyncChanges } from './do_process_sync_changes';
 import { createGetSync } from './get_sync';
@@ -19,43 +10,27 @@ import { createMaybeSendSyncFinishWebhook } from './maybe_send_sync_finish_webho
 import { createUpdateSyncState } from './update_sync_state';
 
 export const createActivities = ({
-  accountService,
   connectionService,
-  contactService,
   remoteService,
-  opportunityService,
-  leadService,
-  eventService,
   syncService,
   syncHistoryService,
   integrationService,
   applicationService,
+  destinationService,
 }: {
-  accountService: AccountService;
   connectionService: ConnectionService;
-  contactService: ContactService;
   remoteService: RemoteService;
-  opportunityService: OpportunityService;
-  leadService: LeadService;
-  eventService: EventService;
   syncService: SyncService;
   syncHistoryService: SyncHistoryService;
   integrationService: IntegrationService;
   applicationService: ApplicationService;
+  destinationService: DestinationService;
 }) => {
   return {
     getSync: createGetSync(syncService),
     doProcessSyncChanges: createDoProcessSyncChanges(syncService),
     updateSyncState: createUpdateSyncState(syncService),
-    importRecords: createImportRecords(
-      accountService,
-      connectionService,
-      contactService,
-      remoteService,
-      opportunityService,
-      leadService,
-      eventService
-    ),
+    importRecords: createImportRecords(connectionService, remoteService, destinationService),
     logSyncStart: createLogSyncStart({ syncHistoryService }),
     logSyncFinish: createLogSyncFinish({ syncHistoryService }),
     maybeSendSyncFinishWebhook: createMaybeSendSyncFinishWebhook({

--- a/packages/sync-workflows/workflows/run_sync.ts
+++ b/packages/sync-workflows/workflows/run_sync.ts
@@ -1,5 +1,5 @@
 import { CommonModel } from '@supaglue/types/common';
-import { CRM_COMMON_MODELS } from '@supaglue/types/crm';
+import { CRM_COMMON_MODEL_TYPES } from '@supaglue/types/crm';
 import { FullThenIncrementalSync, ReverseThenForwardSync } from '@supaglue/types/sync';
 import { ActivityFailure, ApplicationFailure, proxyActivities, uuid4 } from '@temporalio/workflow';
 // Only import the activity types
@@ -39,14 +39,14 @@ export type RunSyncArgs = {
 
 export async function runSync({ syncId, connectionId }: RunSyncArgs): Promise<void> {
   const historyIdsMap = Object.fromEntries(
-    CRM_COMMON_MODELS.map((commonModel) => {
+    CRM_COMMON_MODEL_TYPES.map((commonModel) => {
       const entry: [CommonModel, string] = [commonModel, uuid4()];
       return entry;
     })
   ) as Record<CommonModel, string>;
 
   await Promise.all(
-    CRM_COMMON_MODELS.map(async (commonModel) => {
+    CRM_COMMON_MODEL_TYPES.map(async (commonModel) => {
       await logSyncStart({ syncId, historyId: historyIdsMap[commonModel], commonModel });
     })
   );
@@ -68,7 +68,7 @@ export async function runSync({ syncId, connectionId }: RunSyncArgs): Promise<vo
   } catch (err: any) {
     const errorMessage = getErrorMessage(err);
     await Promise.all(
-      CRM_COMMON_MODELS.map(async (commonModel) => {
+      CRM_COMMON_MODEL_TYPES.map(async (commonModel) => {
         await logSyncFinish({
           syncId,
           connectionId,
@@ -96,7 +96,7 @@ export async function runSync({ syncId, connectionId }: RunSyncArgs): Promise<vo
   }
 
   await Promise.all(
-    CRM_COMMON_MODELS.map(async (commonModel) => {
+    CRM_COMMON_MODEL_TYPES.map(async (commonModel) => {
       await logSyncFinish({ syncId, connectionId, historyId: historyIdsMap[commonModel], status: 'SUCCESS' });
       await maybeSendSyncFinishWebhook({
         historyId: historyIdsMap[commonModel],
@@ -128,7 +128,7 @@ async function doFullThenIncrementalSync({
 
     const importRecordsResultList = Object.fromEntries(
       await Promise.all(
-        CRM_COMMON_MODELS.map(async (commonModel) => {
+        CRM_COMMON_MODEL_TYPES.map(async (commonModel) => {
           const entry: [CommonModel, ImportRecordsResult] = [
             commonModel,
             await importRecords({ syncId: sync.id, connectionId: sync.connectionId, commonModel }),
@@ -166,7 +166,7 @@ async function doFullThenIncrementalSync({
     });
 
     return Object.fromEntries(
-      CRM_COMMON_MODELS.map((commonModel) => [commonModel, importRecordsResultList[commonModel].numRecordsSynced])
+      CRM_COMMON_MODEL_TYPES.map((commonModel) => [commonModel, importRecordsResultList[commonModel].numRecordsSynced])
     ) as Record<CommonModel, number>;
   }
 
@@ -196,7 +196,7 @@ async function doFullThenIncrementalSync({
       const originalMaxLastModifiedAtMsMap = getOriginalMaxLastModifiedAtMsMap();
 
       return Object.fromEntries(
-        CRM_COMMON_MODELS.map((commonModel) => [
+        CRM_COMMON_MODEL_TYPES.map((commonModel) => [
           commonModel,
           Math.max(
             originalMaxLastModifiedAtMsMap[commonModel],
@@ -217,7 +217,7 @@ async function doFullThenIncrementalSync({
 
     const importRecordsResultList = Object.fromEntries(
       await Promise.all(
-        CRM_COMMON_MODELS.map(async (commonModel) => {
+        CRM_COMMON_MODEL_TYPES.map(async (commonModel) => {
           const entry: [CommonModel, ImportRecordsResult] = [
             commonModel,
             await importRecords({
@@ -254,7 +254,7 @@ async function doFullThenIncrementalSync({
     });
 
     return Object.fromEntries(
-      CRM_COMMON_MODELS.map((commonModel) => [commonModel, importRecordsResultList[commonModel].numRecordsSynced])
+      CRM_COMMON_MODEL_TYPES.map((commonModel) => [commonModel, importRecordsResultList[commonModel].numRecordsSynced])
     ) as Record<CommonModel, number>;
   }
 

--- a/packages/types/base.ts
+++ b/packages/types/base.ts
@@ -1,6 +1,6 @@
 export type Address = {
   street1: string | null;
-  street2?: string | null;
+  street2: string | null;
   city: string | null;
   state: string | null;
   postalCode: string | null;

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -1,4 +1,4 @@
-import type { CRMCommonModel } from './crm';
+import type { CRMCommonModelType } from './crm';
 
 export type ListParams = GetParams &
   PaginationParams & {
@@ -39,4 +39,4 @@ export type PaginatedResult<T> = {
 };
 
 export type IntegrationCategory = 'crm';
-export type CommonModel = CRMCommonModel;
+export type CommonModel = CRMCommonModelType;

--- a/packages/types/crm/account.ts
+++ b/packages/types/crm/account.ts
@@ -1,5 +1,13 @@
 import type { Address, BaseCrmModel, CustomFields, LifecycleStage, PhoneNumber } from '..';
 import { Filter } from '../filter';
+import { SnakecasedKeys } from '../snakecased_keys';
+
+export type SnakecasedKeysAccount = SnakecasedKeys<Account>;
+
+export type SnakecasedKeysAccountWithTenant = SnakecasedKeysAccount & {
+  provider_name: string;
+  customer_id: string;
+};
 
 export type Account = BaseCrmModel & {
   name: string | null;

--- a/packages/types/crm/common/address.ts
+++ b/packages/types/crm/common/address.ts
@@ -1,0 +1,4 @@
+import { Address } from '../..';
+import { SnakecasedKeys } from '../../snakecased_keys';
+
+export type SnakecasedKeysAddress = SnakecasedKeys<Address>;

--- a/packages/types/crm/common/email_address.ts
+++ b/packages/types/crm/common/email_address.ts
@@ -1,0 +1,4 @@
+import { EmailAddress } from '../..';
+import { SnakecasedKeys } from '../../snakecased_keys';
+
+export type SnakedcasedKeysEmailAddress = SnakecasedKeys<EmailAddress>;

--- a/packages/types/crm/common/phone_number.ts
+++ b/packages/types/crm/common/phone_number.ts
@@ -1,0 +1,4 @@
+import { PhoneNumber } from '../..';
+import { SnakecasedKeys } from '../../snakecased_keys';
+
+export type SnakecasedKeysPhoneNumber = SnakecasedKeys<PhoneNumber>;

--- a/packages/types/crm/contact.ts
+++ b/packages/types/crm/contact.ts
@@ -1,5 +1,13 @@
 import type { Address, BaseCrmModel, CustomFields, EmailAddress, LifecycleStage, PhoneNumber } from '..';
 import { Filter } from '../filter';
+import { SnakecasedKeys } from '../snakecased_keys';
+
+export type SnakecasedKeysContact = SnakecasedKeys<Contact>;
+
+export type SnakecasedKeysContactWithTenant = SnakecasedKeysContact & {
+  provider_name: string;
+  customer_id: string;
+};
 
 export type Contact = BaseCrmModel & {
   firstName: string | null;

--- a/packages/types/crm/event.ts
+++ b/packages/types/crm/event.ts
@@ -1,5 +1,13 @@
 import { CustomFields } from '..';
+import { SnakecasedKeys } from '../snakecased_keys';
 import { BaseCrmModel } from './base';
+
+export type SnakecasedKeysEvent = SnakecasedKeys<Event>;
+
+export type SnakecasedKeysEventWithTenant = SnakecasedKeysEvent & {
+  provider_name: string;
+  customer_id: string;
+};
 
 export type Event = BaseCrmModel & {
   type: string | null;

--- a/packages/types/crm/index.ts
+++ b/packages/types/crm/index.ts
@@ -10,8 +10,8 @@ export const SUPPORTED_CRM_CONNECTIONS = [
 
 export type CRMProviderName = (typeof SUPPORTED_CRM_CONNECTIONS)[number];
 
-export const CRM_COMMON_MODELS = ['account', 'contact', 'lead', 'opportunity', 'user', 'event'] as const;
-export type CRMCommonModel = (typeof CRM_COMMON_MODELS)[number];
+export const CRM_COMMON_MODEL_TYPES = ['account', 'contact', 'lead', 'opportunity', 'user', 'event'] as const;
+export type CRMCommonModelType = (typeof CRM_COMMON_MODEL_TYPES)[number];
 
 export type CustomFields = Record<string, any>;
 

--- a/packages/types/crm/lead.ts
+++ b/packages/types/crm/lead.ts
@@ -1,4 +1,12 @@
 import type { Address, BaseCrmModel, CustomFields, EmailAddress, PhoneNumber } from '..';
+import { SnakecasedKeys } from '../snakecased_keys';
+
+export type SnakecasedKeysLead = SnakecasedKeys<Lead>;
+
+export type SnakecasedKeysLeadWithTenant = SnakecasedKeysLead & {
+  provider_name: string;
+  customer_id: string;
+};
 
 export type Lead = BaseCrmModel & {
   leadSource: string | null;

--- a/packages/types/crm/opportunity.ts
+++ b/packages/types/crm/opportunity.ts
@@ -1,7 +1,15 @@
 import { BaseCrmModel, CustomFields } from '.';
+import { SnakecasedKeys } from '../snakecased_keys';
 
 export const OPPORTUNITY_STATUSES = ['OPEN', 'WON', 'LOST'] as const;
 export type OpportunityStatus = (typeof OPPORTUNITY_STATUSES)[number];
+
+export type SnakecasedKeysOpportunity = SnakecasedKeys<Opportunity>;
+
+export type SnakecasedKeysOpportunityWithTenant = SnakecasedKeysOpportunity & {
+  provider_name: string;
+  customer_id: string;
+};
 
 export type Opportunity = BaseCrmModel & {
   name: string | null;

--- a/packages/types/crm/user.ts
+++ b/packages/types/crm/user.ts
@@ -1,4 +1,12 @@
 import { BaseCrmModel } from '..';
+import { SnakecasedKeys } from '../snakecased_keys';
+
+export type SnakecasedKeysUser = SnakecasedKeys<User>;
+
+export type SnakecasedKeysUserWithTenant = SnakecasedKeysUser & {
+  provider_name: string;
+  customer_id: string;
+};
 
 export type User = BaseCrmModel & {
   name: string | null;

--- a/packages/types/snakecased_keys.ts
+++ b/packages/types/snakecased_keys.ts
@@ -1,0 +1,11 @@
+type CamelToSnake<T extends string> = T extends `${infer Head}${infer Tail}`
+  ? `${Head extends Uppercase<Head> ? `_${Lowercase<Head>}` : Head}${CamelToSnake<Tail>}`
+  : T;
+
+export type SnakecasedKeys<T> = {
+  [K in keyof T as CamelToSnake<K & string>]: T[K] extends Record<string, unknown>
+    ? SnakecasedKeys<T[K]>
+    : T[K] extends Array<infer U>
+    ? Array<U extends Record<string, unknown> ? SnakecasedKeys<U> : U>
+    : T[K];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6177,7 +6177,6 @@ __metadata:
     express: ">=5.0.0-beta.1"
     express-openapi-validator: ^5.0.2
     express-prom-bundle: ^6.6.0
-    kysely: ^0.24.2
     pino-http: ^8.3.3
     prom-client: ^14.2.0
     simple-oauth2: ^5.0.0
@@ -12009,13 +12008,6 @@ __metadata:
   version: 2.0.6
   resolution: "klona@npm:2.0.6"
   checksum: ac9ee3732e42b96feb67faae4d27cf49494e8a3bf3fa7115ce242fe04786788e0aff4741a07a45a2462e2079aa983d73d38519c85d65b70ef11447bbc3c58ce7
-  languageName: node
-  linkType: hard
-
-"kysely@npm:^0.24.2":
-  version: 0.24.2
-  resolution: "kysely@npm:0.24.2"
-  checksum: b45a820c098f60440d6d601aae227cdbb58503a94a71dda928095b0f2cf7205a0b173a0940a36c89b4ff99c95174f223c0ff018c3845c1575fa779a6e297ca93
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6177,6 +6177,7 @@ __metadata:
     express: ">=5.0.0-beta.1"
     express-openapi-validator: ^5.0.2
     express-prom-bundle: ^6.6.0
+    kysely: ^0.24.2
     pino-http: ^8.3.3
     prom-client: ^14.2.0
     simple-oauth2: ^5.0.0
@@ -12008,6 +12009,13 @@ __metadata:
   version: 2.0.6
   resolution: "klona@npm:2.0.6"
   checksum: ac9ee3732e42b96feb67faae4d27cf49494e8a3bf3fa7115ce242fe04786788e0aff4741a07a45a2462e2079aa983d73d38519c85d65b70ef11447bbc3c58ce7
+  languageName: node
+  linkType: hard
+
+"kysely@npm:^0.24.2":
+  version: 0.24.2
+  resolution: "kysely@npm:0.24.2"
+  checksum: b45a820c098f60440d6d601aae227cdbb58503a94a71dda928095b0f2cf7205a0b173a0940a36c89b4ff99c95174f223c0ff018c3845c1575fa779a6e297ca93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Write records to postgres destination. Currently, it uses a hard-coded postgres schema. When https://github.com/supaglue-labs/supaglue/pull/681 lands, we can pull schema from the config instead.

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
