### PR TITLE
fix: validate sync period ms. fix swr refetch

### DIFF
--- a/openapi/mgmt/components/schemas/objects/integration_config.yaml
+++ b/openapi/mgmt/components/schemas/objects/integration_config.yaml
@@ -31,6 +31,7 @@ properties:
     properties:
       period_ms:
         type: integer
+        minimum: 60000
         example: 60000
     required:
       - period_ms

--- a/openapi/mgmt/openapi.bundle.json
+++ b/openapi/mgmt/openapi.bundle.json
@@ -1123,6 +1123,7 @@
             "properties": {
               "period_ms": {
                 "type": "integer",
+                "minimum": 60000,
                 "example": 60000
               }
             },


### PR DESCRIPTION
- Don't allow sync period ms below 1 minute

Separately, when adding validation, I noticed sometimes the sync period shown changed non-deterministically

- Update react hook to always set values when integration is fetched
- Fix `mutate` to not have potentially contain duplicated entry for the case of updates
- Use `optimisticData` for revalidation so value is the latest one saved

Fixes: #### <!-- Replace this with the GitHub task ID this PR addresses -->

<img width="748" alt="Screenshot 2023-04-21 at 6 07 36 PM" src="https://user-images.githubusercontent.com/471516/233625110-8e7c4d1c-24f9-4f98-8b45-d60968f72209.png">
<img width="745" alt="Screenshot 2023-04-21 at 6 07 43 PM" src="https://user-images.githubusercontent.com/471516/233625115-6f05de9e-8572-4926-a7ba-d2149ee1b33a.png">
<img width="746" alt="Screenshot 2023-04-21 at 6 07 49 PM" src="https://user-images.githubusercontent.com/471516/233625118-439224bd-c45d-401e-ae16-07b8bc66aaa1.png">


[Describe your change here]

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
