### PR TITLE
chore: increase heartbeat timeout for populate associations

### DIFF
--- a/packages/sync-workflows/workflows/run_sync.ts
+++ b/packages/sync-workflows/workflows/run_sync.ts
@@ -16,7 +16,7 @@ const { importRecords } = proxyActivities<ReturnType<typeof createActivities>>({
 
 const { populateAssociations } = proxyActivities<ReturnType<typeof createActivities>>({
   startToCloseTimeout: '120 minute',
-  heartbeatTimeout: '8 minute',
+  heartbeatTimeout: '30 minute',
   retry: {
     maximumAttempts: 3,
   },


### PR DESCRIPTION
This is because `populateAssociations` happens in 1 step per model, so if there are many records, it may time out.