### PR TITLE
fix: validate sync period ms. fix swr refetch (#684)

### DIFF
--- a/openapi/mgmt/components/schemas/objects/integration_config.yaml
+++ b/openapi/mgmt/components/schemas/objects/integration_config.yaml
@@ -31,6 +31,7 @@ properties:
     properties:
       period_ms:
         type: integer
+        minimum: 60000
         example: 60000
     required:
       - period_ms

--- a/openapi/mgmt/openapi.bundle.json
+++ b/openapi/mgmt/openapi.bundle.json
@@ -1460,6 +1460,7 @@
             "properties": {
               "period_ms": {
                 "type": "integer",
+                "minimum": 60000,
                 "example": 60000
               }
             },


### PR DESCRIPTION
Merge from `main`

- Don't allow sync period ms below 1 minute

Separately, when adding validation, I noticed sometimes the sync period shown changed non-deterministically

- Update react hook to always set values when integration is fetched
- Fix `mutate` to not have potentially contain duplicated entry for the case of updates
- Use `optimisticData` for revalidation so value is the latest one saved

[Describe your change here]

[Describe test plan here]

[Add any special deployment instructions here]

<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

Fixes: #### <!-- Replace this with the GitHub task ID this PR addresses -->

[Describe your change here]

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
