### PR TITLE
chore: add missed generated openapi bundles

### DIFF
--- a/openapi/crm/openapi.bundle.json
+++ b/openapi/crm/openapi.bundle.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.7.10",
+    "version": "0.7.11",
     "title": "Supaglue CRM API",
     "contact": {
       "name": "Supaglue",

--- a/openapi/mgmt/openapi.bundle.json
+++ b/openapi/mgmt/openapi.bundle.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "version": "0.7.10",
+    "version": "0.7.11",
     "title": "Supaglue Management API",
     "contact": {
       "name": "Supaglue",


### PR DESCRIPTION
Someone missed these in a pr.

They were generated via:

```
yarn generate
```