### PR TITLE
feat: hubspot stage and pipeline names

### DIFF
--- a/packages/core/remotes/crm/hubspot/mappers.ts
+++ b/packages/core/remotes/crm/hubspot/mappers.ts
@@ -16,6 +16,8 @@ import {
   RemoteOpportunityCreateParams,
   RemoteUser,
 } from '@supaglue/types';
+import { PipelineStageMapping } from '.';
+import { BadRequestError } from '../../../errors';
 
 export const fromHubSpotCompanyToRemoteAccount = ({
   id,
@@ -158,15 +160,10 @@ export const fromHubSpotContactToRemoteContact = ({
   };
 };
 
-export const fromHubSpotDealToRemoteOpportunity = ({
-  id,
-  properties,
-  createdAt,
-  updatedAt,
-  associations,
-  archived,
-  archivedAt,
-}: HubSpotDeal): RemoteOpportunity => {
+export const fromHubSpotDealToRemoteOpportunity = (
+  { id, properties, createdAt, updatedAt, associations, archived, archivedAt }: HubSpotDeal,
+  pipelineStageMapping: PipelineStageMapping
+): RemoteOpportunity => {
   let status: OpportunityStatus = 'OPEN';
   if (properties.hs_is_closed_won) {
     status = 'WON';
@@ -177,6 +174,18 @@ export const fromHubSpotDealToRemoteOpportunity = ({
   if (associations?.companies?.results?.length) {
     remoteAccountId = associations.companies.results[0].id ?? null;
   }
+
+  let pipeline = properties.pipeline ?? null;
+  let stage = properties.dealstage ?? null;
+
+  if (pipeline && pipelineStageMapping[pipeline]) {
+    const pipelineId = pipeline;
+    pipeline = pipelineStageMapping[pipeline].label;
+    if (stage && pipelineStageMapping[pipelineId].stageIdsToLabels[stage]) {
+      stage = pipelineStageMapping[pipelineId].stageIdsToLabels[stage];
+    }
+  }
+
   return {
     remoteId: id,
     name: properties.dealname ?? null,
@@ -184,11 +193,11 @@ export const fromHubSpotDealToRemoteOpportunity = ({
     remoteOwnerId: properties.hubspot_owner_id ?? null,
     lastActivityAt: properties.notes_last_updated ? new Date(properties.notes_last_updated) : null,
     status,
-    pipeline: properties.pipeline ?? null,
+    pipeline,
     remoteAccountId,
     amount: properties.amount ? parseInt(properties.amount) : null,
     closeDate: properties.closedate ? new Date(properties.closedate) : null,
-    stage: properties.dealstage,
+    stage,
     remoteCreatedAt: createdAt,
     remoteUpdatedAt: updatedAt,
     remoteWasDeleted: !!archived,
@@ -252,14 +261,58 @@ export const toHubspotAccountCreateParams = (params: RemoteAccountCreateParams):
 
 export const toHubspotAccountUpdateParams = toHubspotAccountCreateParams;
 
-export const toHubspotOpportunityCreateParams = (params: RemoteOpportunityCreateParams): Record<string, string> => {
+const getPipelineId = (
+  pipelineNameOrId: string | null | undefined,
+  pipelineStageMapping: PipelineStageMapping
+): string | null => {
+  if (!pipelineNameOrId) {
+    return null;
+  }
+  if (pipelineStageMapping[pipelineNameOrId]) {
+    return pipelineNameOrId;
+  }
+  const entry = Object.entries(pipelineStageMapping).find(([, { label }]) => label === pipelineNameOrId);
+  if (entry) {
+    return entry[0];
+  }
+  throw new BadRequestError(`Pipeline not found: ${pipelineNameOrId}`);
+};
+
+const getStageId = (
+  pipelineId: string | null,
+  stageNameOrId: string | undefined | null,
+  pipelineStageMapping: PipelineStageMapping
+): string | null => {
+  if (!pipelineId || !stageNameOrId) {
+    return null;
+  }
+  if (!pipelineStageMapping[pipelineId]) {
+    throw new BadRequestError(`Pipeline not found: ${pipelineId}`);
+  }
+  const stageMapping = pipelineStageMapping[pipelineId].stageIdsToLabels;
+  if (stageMapping[stageNameOrId]) {
+    return stageNameOrId;
+  }
+  const entry = Object.entries(stageMapping).find(([, label]) => label === stageNameOrId);
+  if (entry) {
+    return entry[0];
+  }
+  throw new BadRequestError(`Stage not found: ${stageNameOrId}`);
+};
+
+export const toHubspotOpportunityCreateParams = (
+  params: RemoteOpportunityCreateParams,
+  pipelineStageMapping: PipelineStageMapping
+): Record<string, string> => {
+  const pipelineId = getPipelineId(params.pipeline, pipelineStageMapping);
+  const stageId = getStageId(pipelineId, params.stage, pipelineStageMapping);
   const out = {
     amount: nullToEmptyString(params.amount?.toString()),
     closedate: nullToEmptyString(params.closeDate?.toISOString()),
     dealname: nullToEmptyString(params.name),
     description: nullToEmptyString(params.description),
-    dealstage: nullToEmptyString(params.stage),
-    pipeline: nullToEmptyString(params.pipeline),
+    dealstage: nullToEmptyString(stageId),
+    pipeline: nullToEmptyString(pipelineId),
     hubspot_owner_id: nullToEmptyString(params.ownerId),
     ...params.customFields,
   };


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

Fixes: #743

Changes:
- We will return the name of the pipeline and stage in the `pipeline` and `stage` fields for Hubspot instead of their ids (i.e. `Sales Pipeline` instead of `default`)
- For Create/Update, we accept either the ID or the name (we will do the lookup)

## Test Plan

Tested locally -- see screenshots below:

![Screenshot 2023-04-27 at 2 33 01 PM](https://user-images.githubusercontent.com/1498449/234996838-296b65cb-418b-410b-a3a2-7842da4597b9.png)
![Screenshot 2023-04-27 at 2 33 37 PM](https://user-images.githubusercontent.com/1498449/234996849-cf49674f-b381-41cb-8dde-309a948686ba.png)
![Screenshot 2023-04-27 at 2 33 55 PM](https://user-images.githubusercontent.com/1498449/234996860-66996dda-981f-453c-9924-0602af059b43.png)
![image](https://user-images.githubusercontent.com/1498449/234997118-63bbb89a-cd65-4320-a6af-a5eec8cef4b9.png)

## Deployment instructions

[Add any special deployment instructions here]
