### PR TITLE
chore: for devxp, add a quick way to generate a partial embed link

### DIFF
--- a/apps/api/routes/oauth.ts
+++ b/apps/api/routes/oauth.ts
@@ -9,7 +9,6 @@ const { integrationService, connectionAndSyncService } = getDependencyContainer(
 
 const SERVER_URL = process.env.SUPAGLUE_SERVER_URL ?? 'http://localhost:8080';
 const REDIRECT_URI = `${SERVER_URL}/oauth/callback`;
-const RETURN_URL = process.env.SUPAGLUE_OAUTH_RETURN_URL ?? 'http://localhost:3000';
 
 export default function init(app: Router): void {
   const publicOauthRouter = Router();
@@ -32,6 +31,10 @@ export default function init(app: Router): void {
 
       if (!providerName) {
         throw new Error('Missing providerName');
+      }
+
+      if (!returnUrl) {
+        throw new Error('Missing returnUrl');
       }
 
       const integration = await integrationService.getByProviderNameAndApplicationId(providerName, applicationId);
@@ -68,7 +71,7 @@ export default function init(app: Router): void {
         redirect_uri: REDIRECT_URI,
         scope: oauthScopes.join(' '),
         state: JSON.stringify({
-          returnUrl: returnUrl ?? RETURN_URL,
+          returnUrl,
           applicationId,
           customerId,
           providerName,

--- a/apps/mgmt-ui/src/hooks/useNextLambdaEnv.ts
+++ b/apps/mgmt-ui/src/hooks/useNextLambdaEnv.ts
@@ -1,0 +1,17 @@
+import useSWR from 'swr';
+import { fetcher } from '.';
+
+export function useNextLambdaEnv() {
+  const { data, error, isLoading, ...rest } = useSWR(`/api/internal/env`, fetcher<{ API_HOST: string }>);
+
+  if (!data?.API_HOST) {
+    throw new Error('API_HOST is not defined');
+  }
+
+  return {
+    nextLambdaEnv: data,
+    isLoading,
+    error,
+    ...rest,
+  };
+}

--- a/apps/mgmt-ui/src/pages/api/index.ts
+++ b/apps/mgmt-ui/src/pages/api/index.ts
@@ -1,4 +1,4 @@
-export const API_HOST = process.env.SUPAGLUE_API_HOST;
+export const API_HOST = process.env.SUPAGLUE_API_HOST!;
 export const APPLICATION_ID = 'a4398523-03a2-42dd-9681-c91e3e2efaf4';
 export const ORGANIZATION_ID = 'e7070cc8-36e7-43e2-81fc-ad57713cf2d3';
 export const SG_INTERNAL_TOKEN = process.env.SUPAGLUE_INTERNAL_TOKEN!;

--- a/apps/mgmt-ui/src/pages/api/internal/env.ts
+++ b/apps/mgmt-ui/src/pages/api/internal/env.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { API_HOST } from '..';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<{ API_HOST: string }>) {
+  return res.status(200).json({
+    API_HOST,
+  });
+}

--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/index.tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/index.tsx
@@ -2,6 +2,7 @@ import { createCustomer } from '@/client';
 import MetricCard from '@/components/customers/MetricCard';
 import { NewCustomer } from '@/components/customers/NewCustomer';
 import Spinner from '@/components/Spinner';
+import { useNotification } from '@/context/notification';
 import { useActiveApplicationId } from '@/hooks/useActiveApplicationId';
 import { useCustomers } from '@/hooks/useCustomers';
 import Header from '@/layout/Header';
@@ -9,8 +10,9 @@ import { authOptions } from '@/pages/api/auth/[...nextauth]';
 import providerToIcon from '@/utils/providerToIcon';
 import { getAuth } from '@clerk/nextjs/server';
 import { Link, PeopleAltOutlined } from '@mui/icons-material';
-import { Box, Grid, Stack } from '@mui/material';
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import LinkIcon from '@mui/icons-material/Link';
+import { Box, Grid, IconButton, Stack } from '@mui/material';
+import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { ConnectionSafeAny } from '@supaglue/types/connection';
 import { type GetServerSideProps } from 'next';
 import { Session } from 'next-auth';
@@ -49,6 +51,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
 };
 
 export default function Home() {
+  const { addNotification } = useNotification();
   const { customers = [], isLoading, mutate } = useCustomers();
   const [mobileOpen, setMobileOpen] = useState(false);
   const applicationId = useActiveApplicationId();
@@ -67,6 +70,18 @@ export default function Home() {
     setMobileOpen(!mobileOpen);
   };
 
+  const handleEmebedLinkClick = async (params: GridRenderCellParams) => {
+    addNotification({ message: 'Copied to clipboard', severity: 'success' });
+
+    // NOTE: assumes one connection per customer
+    // TODO: data-drive `returnURL`
+    await navigator.clipboard.writeText(
+      `https://api.supaglue.io/oauth/connect?applicationId=${applicationId}&customerId=${encodeURIComponent(
+        params.id
+      )}&providerName={{providerName}}&returnUrl={{returnUrl}}`
+    );
+  };
+
   const columns: GridColDef[] = [
     { field: 'id', headerName: 'ID', width: 300 },
     { field: 'name', headerName: 'Name', width: 250 },
@@ -74,9 +89,21 @@ export default function Home() {
     {
       field: 'connections',
       headerName: 'Connections',
-      width: 300,
+      width: 150,
       renderCell: (params) => {
         return params.value.map((connection: ConnectionSafeAny) => providerToIcon(connection.providerName));
+      },
+    },
+    {
+      field: 'link',
+      headerName: 'Embed Link',
+      width: 100,
+      renderCell: (params) => {
+        return (
+          <IconButton onClick={() => handleEmebedLinkClick(params)}>
+            <LinkIcon />
+          </IconButton>
+        );
       },
     },
   ];

--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/index.tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/index.tsx
@@ -5,6 +5,7 @@ import Spinner from '@/components/Spinner';
 import { useNotification } from '@/context/notification';
 import { useActiveApplicationId } from '@/hooks/useActiveApplicationId';
 import { useCustomers } from '@/hooks/useCustomers';
+import { useNextLambdaEnv } from '@/hooks/useNextLambdaEnv';
 import Header from '@/layout/Header';
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 import providerToIcon from '@/utils/providerToIcon';
@@ -51,6 +52,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
 };
 
 export default function Home() {
+  const { nextLambdaEnv } = useNextLambdaEnv();
   const { addNotification } = useNotification();
   const { customers = [], isLoading, mutate } = useCustomers();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -73,12 +75,10 @@ export default function Home() {
   const handleEmebedLinkClick = async (params: GridRenderCellParams) => {
     addNotification({ message: 'Copied to clipboard', severity: 'success' });
 
-    // NOTE: assumes one connection per customer
-    // TODO: data-drive `returnURL`
     await navigator.clipboard.writeText(
-      `https://api.supaglue.io/oauth/connect?applicationId=${applicationId}&customerId=${encodeURIComponent(
+      `${nextLambdaEnv.API_HOST}/oauth/connect?applicationId=${applicationId}&customerId=${encodeURIComponent(
         params.id
-      )}&providerName={{providerName}}&returnUrl={{returnUrl}}`
+      )}&providerName={{REPLACE_ME}}&returnUrl={{REPLACE_ME}}`
     );
   };
 

--- a/docs/docs/guides/embedded-links.mdx
+++ b/docs/docs/guides/embedded-links.mdx
@@ -21,7 +21,7 @@ An embedded link takes the following form:
 | `{APPLICATION_ID}` | The unique identifier for your Supaglue application                                      | Yes      |
 | `{CUSTOMER_ID}`    | The unique identifier for a customer in your application                                 | Yes      |
 | `{PROVIDER_NAME}`  | The name of the third-party provider (e.g. `salesforce`, `hubspot`, etc.)                | Yes      |
-| `{RETURN_URL}`     | The URL to return to once the OAuth connection is complete, note: this can be uriEncoded | No       |
+| `{RETURN_URL}`     | The URL to return to once the OAuth connection is complete, note: this can be uriEncoded | Yes      |
 
 To obtain a `{PROVIDER_NAME}`, use the [Supaglue API](references/api/crm) to create new integrations for your customers to have available for them to connect to.
 


### PR DESCRIPTION
- quick-fix: add a button to generate a partial embed link
- make `returnUrl` required in embed link

Example: `https://api.supaglue.io/oauth/connect?applicationId=a4398523-03a2-42dd-9681-c91e3e2efaf4&customerId=external-customer-hubspot&providerName={{providerName}}&returnUrl={{returnUrl}}`

![Screenshot 2023-04-30 at 8 25 20 PM](https://user-images.githubusercontent.com/471516/235400843-2a2fba3c-d864-4b37-8917-7a2b6028d9ea.png)

![Screenshot 2023-04-30 at 8 25 22 PM](https://user-images.githubusercontent.com/471516/235400931-b667d4b3-02a3-4dc9-b4b3-ebd299ef514c.png)

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
