### PR TITLE
feat: add force sync feature and endpoint

### DIFF
--- a/apps/api/routes/mgmt/v1/force_sync.ts
+++ b/apps/api/routes/mgmt/v1/force_sync.ts
@@ -1,0 +1,36 @@
+import { getDependencyContainer } from '@/dependency_container';
+import {
+  CreateForceSyncPathParams,
+  CreateForceSyncQueryParams,
+  CreateForceSyncRequest,
+  CreateForceSyncResponse,
+} from '@supaglue/schemas/mgmt';
+import { Request, Response, Router } from 'express';
+
+const { connectionAndSyncService } = getDependencyContainer();
+
+export default function init(app: Router) {
+  app.post(
+    '/force-sync',
+    async (
+      req: Request<
+        CreateForceSyncPathParams,
+        CreateForceSyncResponse,
+        CreateForceSyncRequest,
+        CreateForceSyncQueryParams
+      >,
+      res: Response<CreateForceSyncResponse>
+    ) => {
+      await connectionAndSyncService.setForceSyncFlag(
+        {
+          applicationId: req.supaglueApplication.id,
+          externalCustomerId: req.query.customer_id,
+          providerName: req.query.provider_name,
+        },
+        true
+      );
+
+      return res.status(200).send({ success: true });
+    }
+  );
+}

--- a/apps/api/routes/mgmt/v1/index.ts
+++ b/apps/api/routes/mgmt/v1/index.ts
@@ -2,6 +2,7 @@ import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
 import { openapiMiddleware } from '@/middleware/openapi';
 import { Router } from 'express';
 import customer from './customer';
+import forceSync from './force_sync';
 import integration from './integration';
 import syncHistory from './sync_history';
 import syncInfo from './sync_info';
@@ -18,6 +19,7 @@ export default function init(app: Router): void {
   webhook(v1Router);
   syncInfo(v1Router);
   syncHistory(v1Router);
+  forceSync(v1Router);
 
   app.use('/v1', v1Router);
 }

--- a/apps/api/services/connection_and_sync_service.ts
+++ b/apps/api/services/connection_and_sync_service.ts
@@ -19,7 +19,7 @@ import {
   runSync,
   RUN_SYNC_PREFIX,
 } from '@supaglue/sync-workflows/workflows/run_sync';
-import { CRM_COMMON_MODELS, Sync, SyncState, SyncType } from '@supaglue/types';
+import { CRM_COMMON_MODELS, Sync, SyncIdentifier, SyncState, SyncType } from '@supaglue/types';
 import type {
   ConnectionCreateParamsAny,
   ConnectionSafeAny,
@@ -431,6 +431,29 @@ export class ConnectionAndSyncService {
       },
     });
     return models.map(fromSyncModel);
+  }
+
+  public async setForceSyncFlag(
+    { applicationId, externalCustomerId, providerName }: SyncIdentifier,
+    flag: boolean
+  ): Promise<Sync> {
+    const customerId = getCustomerIdPk(applicationId, externalCustomerId);
+    const connection = await this.#connectionService.getSafeByCustomerIdAndApplicationIdAndProviderName({
+      applicationId,
+      customerId,
+      providerName,
+    });
+
+    const model = await this.#prisma.sync.update({
+      data: {
+        resync: flag,
+      },
+      where: {
+        connectionId: connection.id,
+      },
+    });
+
+    return fromSyncModel(model);
   }
 
   public async getSyncInfoList({

--- a/apps/api/services/connection_and_sync_service.ts
+++ b/apps/api/services/connection_and_sync_service.ts
@@ -446,7 +446,7 @@ export class ConnectionAndSyncService {
 
     const model = await this.#prisma.sync.update({
       data: {
-        resync: flag,
+        forceSyncFlag: flag,
       },
       where: {
         connectionId: connection.id,

--- a/apps/sync-worker/services/sync_service.ts
+++ b/apps/sync-worker/services/sync_service.ts
@@ -21,6 +21,7 @@ function fromSyncModel(model: SyncModel): Sync {
     type,
     ...otherStrategyProps,
     state: model.state as SyncState,
+    resync: model.resync,
   } as Sync;
 }
 
@@ -48,6 +49,19 @@ export class SyncService {
         id,
       },
     });
+    return fromSyncModel(model);
+  }
+
+  public async setForceSyncFlag({ syncId }: { syncId: string }, flag: boolean): Promise<Sync> {
+    const model = await this.#prisma.sync.update({
+      data: {
+        resync: flag,
+      },
+      where: {
+        id: syncId,
+      },
+    });
+
     return fromSyncModel(model);
   }
 

--- a/apps/sync-worker/services/sync_service.ts
+++ b/apps/sync-worker/services/sync_service.ts
@@ -21,7 +21,7 @@ function fromSyncModel(model: SyncModel): Sync {
     type,
     ...otherStrategyProps,
     state: model.state as SyncState,
-    resync: model.resync,
+    forceSyncFlag: model.forceSyncFlag,
   } as Sync;
 }
 
@@ -55,7 +55,7 @@ export class SyncService {
   public async setForceSyncFlag({ syncId }: { syncId: string }, flag: boolean): Promise<Sync> {
     const model = await this.#prisma.sync.update({
       data: {
-        resync: flag,
+        forceSyncFlag: flag,
       },
       where: {
         id: syncId,

--- a/openapi/crm/openapi.bundle.json
+++ b/openapi/crm/openapi.bundle.json
@@ -2555,10 +2555,6 @@
       "description": "The `User` Common Model is used to represent a \"user\" that can login to CRMs."
     },
     {
-      "name": "Sync",
-      "description": "Get information and history for the sync process."
-    },
-    {
       "name": "Passthrough",
       "description": "Passthrough operations to underlying providers."
     }

--- a/openapi/crm/openapi.yaml
+++ b/openapi/crm/openapi.yaml
@@ -68,8 +68,6 @@ tags:
     description: The `Opportunity` Common Model is used to represent a "deal opportunity" in CRMs.
   - name: Users
     description: The `User` Common Model is used to represent a "user" that can login to CRMs.
-  - name: Sync
-    description: Get information and history for the sync process.
   - name: Passthrough
     description: Passthrough operations to underlying providers.
 components:

--- a/openapi/mgmt/components/schemas/force_sync.yaml
+++ b/openapi/mgmt/components/schemas/force_sync.yaml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  success:
+    type: boolean
+    example: true
+required:
+  - success

--- a/openapi/mgmt/openapi.bundle.json
+++ b/openapi/mgmt/openapi.bundle.json
@@ -942,6 +942,62 @@
           }
         }
       }
+    },
+    "/force-sync": {
+      "post": {
+        "operationId": "createForceSync",
+        "tags": [
+          "Sync"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "summary": "Force a full sync",
+        "description": "Force a full sync",
+        "parameters": [
+          {
+            "name": "customer_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "example": "my-customer-1"
+            },
+            "description": "The customer ID that uniquely identifies the customer in your application",
+            "required": true
+          },
+          {
+            "name": "provider_name",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "example": "salesforce"
+            },
+            "description": "The provider name",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Force a full sync",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/force_sync"
+                },
+                "examples": {
+                  "Example": {
+                    "value": {
+                      "success": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "tags": [],
@@ -1382,6 +1438,18 @@
           "provider_name",
           "category",
           "connection_id"
+        ]
+      },
+      "force_sync": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          }
+        },
+        "required": [
+          "success"
         ]
       },
       "webhook-payload": {

--- a/openapi/mgmt/openapi.yaml
+++ b/openapi/mgmt/openapi.yaml
@@ -43,6 +43,8 @@ paths:
     $ref: paths/sync_history.yaml
   '/sync-info':
     $ref: paths/sync_info.yaml
+  '/force-sync':
+    $ref: paths/force_sync.yaml
 tags: []
 components:
   securitySchemes:
@@ -71,6 +73,8 @@ components:
       $ref: ./components/schemas/sync_info.yaml
     sync_history:
       $ref: ./components/schemas/sync_history.yaml
+    force_sync:
+      $ref: ./components/schemas/force_sync.yaml
     webhook-payload:
       $ref: './components/schemas/webhook-payload.yaml'
   parameters:

--- a/openapi/mgmt/paths/force_sync.yaml
+++ b/openapi/mgmt/paths/force_sync.yaml
@@ -1,0 +1,35 @@
+post:
+  operationId: createForceSync
+  tags:
+    - Sync
+  security:
+    - ApiKeyAuth: []
+  summary: Force a full sync
+  description: >-
+    Force a full sync
+  parameters:
+    - name: customer_id
+      in: query
+      schema:
+        type: string
+        example: my-customer-1 
+      description: The customer ID that uniquely identifies the customer in your application
+      required: true
+    - name: provider_name
+      in: query
+      schema:
+        type: string
+        example: salesforce
+      description: The provider name
+      required: true
+  responses:
+    '200':
+      description: Force a full sync
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/force_sync.yaml
+          examples:
+            Example:
+              value:
+                success: true

--- a/packages/db/prisma/migrations/20230503003026_sync_resync/migration.sql
+++ b/packages/db/prisma/migrations/20230503003026_sync_resync/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "syncs" ADD COLUMN     "resync" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "syncs" ADD COLUMN "force_sync_flag" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/migrations/20230503003026_sync_resync/migration.sql
+++ b/packages/db/prisma/migrations/20230503003026_sync_resync/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "syncs" ADD COLUMN     "resync" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -309,7 +309,7 @@ model CrmEvent {
 model Sync {
   id              String        @id @default(uuid())
   state           Json
-  resync          Boolean       @default(false)
+  forceSyncFlag   Boolean       @default(false)
   strategy        Json
   connectionId    String        @unique @map("connection_id")
   connection      Connection    @relation(fields: [connectionId], references: [id])

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -309,6 +309,7 @@ model CrmEvent {
 model Sync {
   id              String        @id @default(uuid())
   state           Json
+  resync          Boolean       @default(false)
   strategy        Json
   connectionId    String        @unique @map("connection_id")
   connection      Connection    @relation(fields: [connectionId], references: [id])

--- a/packages/schemas/gen/mgmt.ts
+++ b/packages/schemas/gen/mgmt.ts
@@ -101,6 +101,13 @@ export interface paths {
      */
     get: operations["getSyncInfos"];
   };
+  "/force-sync": {
+    /**
+     * Force a full sync 
+     * @description Force a full sync
+     */
+    post: operations["createForceSync"];
+  };
 }
 
 export interface webhooks {
@@ -271,6 +278,10 @@ export interface components {
       connection_id: string;
       /** @enum {string} */
       status: "SUCCESS" | "IN_PROGRESS" | "FAILURE";
+    };
+    force_sync: {
+      /** @example true */
+      success: boolean;
     };
     "webhook-payload": OneOf<[{
       /** @enum {unknown} */
@@ -576,6 +587,28 @@ export interface operations {
       200: {
         content: {
           "application/json": (components["schemas"]["sync_info"])[];
+        };
+      };
+    };
+  };
+  createForceSync: {
+    /**
+     * Force a full sync 
+     * @description Force a full sync
+     */
+    parameters: {
+        /** @description The customer ID that uniquely identifies the customer in your application */
+        /** @description The provider name */
+      query: {
+        customer_id: string;
+        provider_name: string;
+      };
+    };
+    responses: {
+      /** @description Force a full sync */
+      200: {
+        content: {
+          "application/json": components["schemas"]["force_sync"];
         };
       };
     };

--- a/packages/schemas/mgmt.ts
+++ b/packages/schemas/mgmt.ts
@@ -91,3 +91,9 @@ export type GetSyncHistoryQueryParams = Required<operations['getSyncHistory']>['
 export type GetSyncHistoryRequest = never;
 export type GetSyncHistoryResponse =
   operations['getSyncHistory']['responses'][keyof operations['getSyncHistory']['responses']]['content']['application/json'];
+
+export type CreateForceSyncPathParams = never;
+export type CreateForceSyncQueryParams = Required<operations['createForceSync']>['parameters']['query'];
+export type CreateForceSyncRequest = never;
+export type CreateForceSyncResponse =
+  operations['createForceSync']['responses'][keyof operations['createForceSync']['responses']]['content']['application/json'];

--- a/packages/sync-workflows/activities/index.ts
+++ b/packages/sync-workflows/activities/index.ts
@@ -18,6 +18,7 @@ import { createLogSyncFinish } from './log_sync_finish';
 import { createLogSyncStart } from './log_sync_start';
 import { createMaybeSendSyncFinishWebhook } from './maybe_send_sync_finish_webhook';
 import { createPopulateAssociations } from './populate_associations';
+import { createSetForceSyncFlag } from './set_force_sync_flag';
 import { createUpdateSyncState } from './update_sync_state';
 
 export const createActivities = ({
@@ -50,6 +51,7 @@ export const createActivities = ({
   return {
     getSync: createGetSync(syncService),
     doProcessSyncChanges: createDoProcessSyncChanges(syncService),
+    setForceSyncFlag: createSetForceSyncFlag(syncService),
     updateSyncState: createUpdateSyncState(syncService),
     importRecords: createImportRecords(
       accountService,

--- a/packages/sync-workflows/activities/set_force_sync_flag.ts
+++ b/packages/sync-workflows/activities/set_force_sync_flag.ts
@@ -1,0 +1,16 @@
+import { Sync } from '@supaglue/types';
+import { SyncService } from 'sync-worker/services/sync_service';
+
+export type SetForceSyncFlagResult = {
+  sync: Sync;
+};
+
+export function createSetForceSyncFlag(syncService: SyncService) {
+  return async function setForceSyncFlag(
+    { syncId }: { syncId: string },
+    flag: boolean
+  ): Promise<SetForceSyncFlagResult> {
+    const sync = await syncService.setForceSyncFlag({ syncId }, flag);
+    return { sync };
+  };
+}

--- a/packages/sync-workflows/workflows/run_sync.ts
+++ b/packages/sync-workflows/workflows/run_sync.ts
@@ -336,7 +336,7 @@ const getErrorMessageStack = (err: Error): { message: string; stack: string } =>
 
 class SyncStateFSM {
   static isResetFlagSet(sync: Sync): boolean {
-    return sync.resync;
+    return sync.forceSyncFlag;
   }
 
   static setInitialState(sync: Sync): Sync {

--- a/packages/sync-workflows/workflows/run_sync.ts
+++ b/packages/sync-workflows/workflows/run_sync.ts
@@ -345,4 +345,6 @@ class SyncStateFSM {
     };
     return sync;
   }
+
+  // @todo: move other state transitions here
 }

--- a/packages/types/sync.ts
+++ b/packages/types/sync.ts
@@ -3,7 +3,7 @@ import { CommonModel } from './common';
 type BaseSync = {
   id: string;
   connectionId: string;
-  resync: boolean; // flag: whether to treat the sync as phase "created"
+  forceSyncFlag: boolean; // flag: whether to transition a sync to the phase "created"
 };
 
 export type FullThenIncrementalSync = BaseSync & {

--- a/packages/types/sync.ts
+++ b/packages/types/sync.ts
@@ -3,6 +3,7 @@ import { CommonModel } from './common';
 type BaseSync = {
   id: string;
   connectionId: string;
+  resync: boolean; // flag: whether to treat the sync as phase "created"
 };
 
 export type FullThenIncrementalSync = BaseSync & {
@@ -78,3 +79,10 @@ export type ReverseThenForwardSyncState =
   | ReverseThenForwardSyncStateForwardPhase;
 
 export type SyncState = FullThenIncrementalSyncState | ReverseThenForwardSyncState;
+
+// The triplet of customer-provided identifiers to uniquely identify a sync. @todo: this triple can also be used elsewhere to uniquel identifer Supaglue resources.
+export type SyncIdentifier = {
+  applicationId: string;
+  externalCustomerId: string;
+  providerName: string;
+};

--- a/packages/types/sync.ts
+++ b/packages/types/sync.ts
@@ -80,7 +80,7 @@ export type ReverseThenForwardSyncState =
 
 export type SyncState = FullThenIncrementalSyncState | ReverseThenForwardSyncState;
 
-// The triplet of customer-provided identifiers to uniquely identify a sync. @todo: this triple can also be used elsewhere to uniquel identifer Supaglue resources.
+// The triplet of customer-provided identifiers to uniquely identify a sync. @todo: use this elsewhere.
 export type SyncIdentifier = {
   applicationId: string;
   externalCustomerId: string;


### PR DESCRIPTION
- POST to `/mgmt/v1/force-sync?customer_id={}&provide_name={}` to schedule a forced full refresh upon the next sync cycle
- adds openapi spec and endpoints
- migration to add a `resync` flag that is consumable by sync-workers upon the start of the forced sync. consumes the flag upon start: if there's a failure, the user has to reschedule
- adds a lightweight class to help with sync state transitions

## Test Plan

- tested a forced full sync locally against a sync that moved onto the incremental phase of the "full then incremental" strategy and observed that deleted leads re-appeared after the forced sync

## Deployment instructions

[Add any special deployment instructions here]
