### PR TITLE
chore: allow update of temporal schedule args

### DIFF
--- a/packages/core/services/connection_service.ts
+++ b/packages/core/services/connection_service.ts
@@ -1,5 +1,10 @@
 import type { PrismaClient } from '@supaglue/db';
-import type { ConnectionCredentialsDecryptedAny, ConnectionSafeAny, ConnectionUnsafe } from '@supaglue/types';
+import type {
+  ConnectionCredentialsDecryptedAny,
+  ConnectionSafeAny,
+  ConnectionUnsafe,
+  ProviderName,
+} from '@supaglue/types';
 import type { CRMProviderName } from '@supaglue/types/crm';
 import { NotFoundError } from '../errors';
 import { decrypt, encrypt } from '../lib/crypt';
@@ -15,7 +20,7 @@ export class ConnectionService {
     this.#integrationService = integrationService;
   }
 
-  public async getUnsafeById<T extends CRMProviderName>(id: string): Promise<ConnectionUnsafe<T>> {
+  public async getUnsafeById<T extends ProviderName>(id: string): Promise<ConnectionUnsafe<T>> {
     const connection = await this.#prisma.connection.findUnique({
       where: { id },
     });


### PR DESCRIPTION
previously we would only update the period. we want to allow `manuallyUpdateTemporalSyncs` to update the args too in case there are new ones

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
