### PR TITLE
feat: create connection by passing in creds manually

### DIFF
--- a/apps/api/routes/mgmt/v1/customer/connection/index.ts
+++ b/apps/api/routes/mgmt/v1/customer/connection/index.ts
@@ -1,4 +1,5 @@
 import { getDependencyContainer } from '@/dependency_container';
+import { Client as HubspotClient } from '@hubspot/api-client';
 import { getCustomerIdPk } from '@supaglue/core/lib';
 import {
   DeleteConnectionPathParams,
@@ -8,12 +9,14 @@ import {
   GetConnectionRequest,
   GetConnectionResponse,
   GetConnectionsPathParams,
+  GetConnectionsRequest,
   GetConnectionsResponse,
 } from '@supaglue/schemas/mgmt';
 import { snakecaseKeys } from '@supaglue/utils/snakecase';
 import { Request, Response, Router } from 'express';
+import * as jsforce from 'jsforce';
 
-const { connectionService, connectionAndSyncService } = getDependencyContainer();
+const { connectionService, connectionAndSyncService, integrationService } = getDependencyContainer();
 
 export default function init(app: Router): void {
   const connectionRouter = Router({ mergeParams: true });
@@ -21,7 +24,7 @@ export default function init(app: Router): void {
   connectionRouter.get(
     '/',
     async (
-      req: Request<GetConnectionsPathParams, GetConnectionsResponse, GetConnectionsResponse>,
+      req: Request<GetConnectionsPathParams, GetConnectionsResponse, GetConnectionsRequest>,
       res: Response<GetConnectionsResponse>
     ) => {
       const customerId = getCustomerIdPk(req.supaglueApplication.id, req.params.customer_id);
@@ -30,7 +33,90 @@ export default function init(app: Router): void {
     }
   );
 
-  // NOTE: There is no POST /connections since creating a connection is done upon a successful oauth flow
+  // TODO: remove this after migrations from self-hosted to Cloud are finished
+  // We don't want to support creating connections with passed-in credentials forever.
+  connectionRouter.post('/', async (req: Request, res: Response) => {
+    // Get integration first to get category and provider_name
+    const integration = await integrationService.getByIdAndApplicationId(
+      req.body.integration_id,
+      req.supaglueApplication.id
+    );
+
+    if (integration.category !== 'crm') {
+      throw new Error(`Unable to backfill category ${integration.category}`);
+    }
+
+    if (integration.providerName === 'hubspot') {
+      const hubspotClient = new HubspotClient();
+      const token = await hubspotClient.oauth.tokensApi.createToken(
+        'refresh_token',
+        undefined,
+        undefined,
+        integration.config.oauth.credentials.oauthClientId,
+        integration.config.oauth.credentials.oauthClientSecret,
+        req.body.credentials.refresh_token
+      );
+      const expiresAt = new Date(Date.now() + token.expiresIn * 1000).toISOString();
+
+      const { hubId } = await hubspotClient.oauth.accessTokensApi.getAccessToken(token.accessToken);
+      const remoteId = hubId.toString();
+
+      const connection = await connectionAndSyncService.create({
+        // TODO: don't denormalize this?
+        category: integration.category,
+        providerName: integration.providerName,
+        applicationId: req.supaglueApplication.id,
+        customerId: req.params.customer_id,
+        integrationId: req.body.integration_id,
+        credentials: {
+          type: req.body.credentials.type,
+          accessToken: token.accessToken,
+          refreshToken: req.body.credentials.refresh_token,
+          expiresAt,
+        },
+        remoteId,
+        instanceUrl: `https:app.hubspot.com/contacts/${remoteId}`,
+      });
+      return res.status(200).send(snakecaseKeys(connection));
+    }
+
+    // salesforce
+    if (integration.providerName === 'salesforce') {
+      const salesforceClient = new jsforce.Connection({
+        oauth2: new jsforce.OAuth2({
+          loginUrl: req.body.credentials.loginUrl ?? 'https://login.salesforce.com',
+          clientId: integration.config.oauth.credentials.oauthClientId,
+          clientSecret: integration.config.oauth.credentials.oauthClientSecret,
+        }),
+        instanceUrl: req.body.credentials.instance_url,
+        refreshToken: req.body.credentials.refresh_token,
+        maxRequest: 10,
+      });
+      const { access_token } = await salesforceClient.oauth2.refreshToken(req.body.credentials.refreshToken);
+
+      const connection = await connectionAndSyncService.create({
+        // TODO: don't denormalize this?
+        category: integration.category,
+        providerName: integration.providerName,
+        applicationId: req.supaglueApplication.id,
+        customerId: req.params.customer_id,
+        integrationId: req.body.integration_id,
+        credentials: {
+          type: req.body.credentials.type,
+          accessToken: access_token,
+          refreshToken: req.body.credentials.refresh_token,
+          instanceUrl: req.body.credentials.instance_url,
+          // salesforce does not specify expiresAt
+          expiresAt: null,
+        },
+        remoteId: req.body.credentials.instance_url,
+        instanceUrl: req.body.credentials.instance_url,
+      });
+      return res.status(200).send(snakecaseKeys(connection));
+    }
+
+    return res.status(200).send(null);
+  });
 
   connectionRouter.get(
     '/:connection_id',

--- a/openapi/mgmt/openapi.bundle.json
+++ b/openapi/mgmt/openapi.bundle.json
@@ -551,6 +551,42 @@
           }
         }
       },
+      "post": {
+        "operationId": "createConnection",
+        "summary": "Create connection",
+        "tags": [
+          "Connections"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Connection created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connection"
+                }
+              }
+            }
+          }
+        }
+      },
       "parameters": [
         {
           "name": "customer_id",

--- a/openapi/mgmt/paths/connections.yaml
+++ b/openapi/mgmt/paths/connections.yaml
@@ -37,6 +37,28 @@ get:
                   category: crm
                   remote_id: 1234567
                   instance_url: https://app.hubspot.com/contacts/1234567
+post:
+  operationId: createConnection
+  summary: Create connection
+  tags:
+    - Connections
+  parameters: []
+  security:
+    - ApiKeyAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: true
+  responses:
+    '200':
+      description: Connection created
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/objects/connection.yaml
 parameters:
   - name: customer_id
     in: path

--- a/packages/schemas/gen/mgmt.ts
+++ b/packages/schemas/gen/mgmt.ts
@@ -58,6 +58,8 @@ export interface paths {
      * @description Get a list of connections
      */
     get: operations["getConnections"];
+    /** Create connection */
+    post: operations["createConnection"];
     parameters: {
       path: {
         customer_id: string;
@@ -485,6 +487,24 @@ export interface operations {
       200: {
         content: {
           "application/json": (components["schemas"]["connection"])[];
+        };
+      };
+    };
+  };
+  createConnection: {
+    /** Create connection */
+    requestBody: {
+      content: {
+        "application/json": {
+          [key: string]: unknown | undefined;
+        };
+      };
+    };
+    responses: {
+      /** @description Connection created */
+      200: {
+        content: {
+          "application/json": components["schemas"]["connection"];
         };
       };
     };


### PR DESCRIPTION
We already have this in `internal`, but we need to expose this in `mgmt` for use in Cloud temporarily for migrators from self-hosted to Cloud.

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
