### PR TITLE
fix: bump keepalive timeout to 61 seconds

### DIFF
--- a/apps/api/index.ts
+++ b/apps/api/index.ts
@@ -183,6 +183,9 @@ const server = app.listen(port, (): void => {
   }
 });
 
+server.keepAliveTimeout = 61 * 1000;
+server.headersTimeout = 62 * 1000; // should be 1 second more than keepAliveTimeout, according to most sources
+
 const metricsServer = metricsApp.listen(9090, (): void => {
   logger.info('Metrics server listening on port 9090');
 });


### PR DESCRIPTION
I suspect that the 504s are for long running requests. Since we set the keepalive timeout on the ELBs to 4 seconds to keep under the node default of 5 seconds, its probable that the ELB is now timing out the request if it takes longer than the 4 seconds.

After this is deployed, I will bump the ELB idle timeout back up to the default 60 sec.