### PR TITLE
feat: pg cache invalidation, pull destination from integration, add _supaglue prefix for fields

### DIFF
--- a/apps/api/routes/crm/v2/account.ts
+++ b/apps/api/routes/crm/v2/account.ts
@@ -41,10 +41,9 @@ export default function init(app: Router): void {
       req: Request<CreateAccountPathParams, CreateAccountResponse, CreateAccountRequest>,
       res: Response<CreateAccountResponse>
     ) => {
-      const { id: connectionId } = req.customerConnection;
       const id = await crmCommonModelService.create(
         'account',
-        connectionId,
+        req.customerConnection,
         camelcaseKeysSansCustomFields(req.body.model)
       );
       return res.status(200).send({ model: { id } });
@@ -57,8 +56,7 @@ export default function init(app: Router): void {
       req: Request<UpdateAccountPathParams, UpdateAccountResponse, UpdateAccountRequest>,
       res: Response<UpdateAccountResponse>
     ) => {
-      const { id: connectionId } = req.customerConnection;
-      await crmCommonModelService.update('account', connectionId, {
+      await crmCommonModelService.update('account', req.customerConnection, {
         id: req.params.account_id,
         ...camelcaseKeysSansCustomFields(req.body.model),
       });

--- a/apps/api/routes/crm/v2/contact.ts
+++ b/apps/api/routes/crm/v2/contact.ts
@@ -42,10 +42,9 @@ export default function init(app: Router): void {
       req: Request<CreateContactPathParams, CreateContactResponse, CreateContactRequest>,
       res: Response<CreateContactResponse>
     ) => {
-      const { id: connectionId } = req.customerConnection;
       const id = await crmCommonModelService.create(
         'contact',
-        connectionId,
+        req.customerConnection,
         camelcaseKeysSansCustomFields(req.body.model)
       );
       return res.status(200).send({ model: { id } });
@@ -58,8 +57,7 @@ export default function init(app: Router): void {
       req: Request<UpdateContactPathParams, UpdateContactResponse, UpdateContactRequest>,
       res: Response<UpdateContactResponse>
     ) => {
-      const { id: connectionId } = req.customerConnection;
-      await crmCommonModelService.update('contact', connectionId, {
+      await crmCommonModelService.update('contact', req.customerConnection, {
         id: req.params.contact_id,
         ...camelcaseKeysSansCustomFields(req.body.model),
       });

--- a/apps/api/routes/crm/v2/lead.ts
+++ b/apps/api/routes/crm/v2/lead.ts
@@ -41,10 +41,9 @@ export default function init(app: Router): void {
       req: Request<CreateLeadPathParams, CreateLeadResponse, CreateLeadRequest>,
       res: Response<CreateLeadResponse>
     ) => {
-      const { id: connectionId } = req.customerConnection;
       const id = await crmCommonModelService.create(
         'lead',
-        connectionId,
+        req.customerConnection,
         camelcaseKeysSansCustomFields(req.body.model)
       );
       return res.status(200).send({ model: { id } });
@@ -57,8 +56,7 @@ export default function init(app: Router): void {
       req: Request<UpdateLeadPathParams, UpdateLeadResponse, UpdateLeadRequest>,
       res: Response<UpdateLeadResponse>
     ) => {
-      const { id: connectionId } = req.customerConnection;
-      await crmCommonModelService.update('lead', connectionId, {
+      await crmCommonModelService.update('lead', req.customerConnection, {
         id: req.params.lead_id,
         ...camelcaseKeysSansCustomFields(req.body.model),
       });

--- a/apps/api/routes/crm/v2/opportunity.ts
+++ b/apps/api/routes/crm/v2/opportunity.ts
@@ -42,8 +42,7 @@ export default function init(app: Router): void {
       req: Request<CreateOpportunityPathParams, CreateOpportunityResponse, CreateOpportunityRequest>,
       res: Response<CreateOpportunityResponse>
     ) => {
-      const { id: connectionId } = req.customerConnection;
-      const id = await crmCommonModelService.create('opportunity', connectionId, {
+      const id = await crmCommonModelService.create('opportunity', req.customerConnection, {
         ...camelcaseKeysSansCustomFields(req.body.model),
         closeDate: stringOrNullOrUndefinedToDate(req.body.model.close_date),
       });
@@ -57,8 +56,7 @@ export default function init(app: Router): void {
       req: Request<UpdateOpportunityPathParams, UpdateOpportunityResponse, UpdateOpportunityRequest>,
       res: Response<UpdateOpportunityResponse>
     ) => {
-      const { id: connectionId } = req.customerConnection;
-      await crmCommonModelService.update('opportunity', connectionId, {
+      await crmCommonModelService.update('opportunity', req.customerConnection, {
         id: req.params.opportunity_id,
         ...camelcaseKeysSansCustomFields(req.body.model),
         closeDate: stringOrNullOrUndefinedToDate(req.body.model.close_date),

--- a/apps/api/types/express.d.ts
+++ b/apps/api/types/express.d.ts
@@ -1,4 +1,4 @@
-import { Application as SupaglueApplication, ConnectionSafe } from '@supaglue/types';
+import { Application as SupaglueApplication, ConnectionSafeAny } from '@supaglue/types';
 
 declare global {
   declare namespace Express {
@@ -7,7 +7,7 @@ declare global {
     interface Request {
       customerId: string;
       supaglueApplication: SupaglueApplication;
-      customerConnection: ConnectionSafe;
+      customerConnection: ConnectionSafeAny;
       orgId: string;
       sg: Record<string, string>;
     }

--- a/packages/core/dependency_container.ts
+++ b/packages/core/dependency_container.ts
@@ -104,7 +104,7 @@ function createCoreDependencyContainer(): CoreDependencyContainer {
   const webhookService = new WebhookService({ prisma });
   const destinationService = new DestinationService(prisma);
 
-  const crmCommonModelService = new CrmCommonModelService(remoteService);
+  const crmCommonModelService = new CrmCommonModelService(remoteService, destinationService);
   const engagementCommonModelService = new EngagementCommonModelService(remoteService);
 
   // crm

--- a/packages/core/destination_writers/base.ts
+++ b/packages/core/destination_writers/base.ts
@@ -1,4 +1,5 @@
-import type { CommonModel, ConnectionSafeAny } from '@supaglue/types';
+import type { CommonModelType, ConnectionSafeAny } from '@supaglue/types';
+import { CRMCommonModelType, CRMCommonModelTypeMap } from '@supaglue/types/crm';
 import type { Readable } from 'stream';
 
 export type WriteCommonModelsResult = {
@@ -7,18 +8,39 @@ export type WriteCommonModelsResult = {
 };
 
 export interface DestinationWriter {
+  upsertObject<T extends CRMCommonModelType>(
+    connection: ConnectionSafeAny,
+    commonModelType: T,
+    object: CRMCommonModelTypeMap<T>['object']
+  ): Promise<void>;
+
   writeObjects(
     connection: ConnectionSafeAny,
-    commonModelType: CommonModel,
+    commonModelType: CommonModelType,
     stream: Readable,
     heartbeat: () => void
   ): Promise<WriteCommonModelsResult>;
 }
 
 export abstract class BaseDestinationWriter implements DestinationWriter {
+  /**
+   * This is a method used for writers that support updating objects after
+   * syncing, e.g. Postgres for "cache invalidation"
+   *
+   * TODO: Support engagement vertical as well
+   */
+  abstract upsertObject<T extends CRMCommonModelType>(
+    connection: ConnectionSafeAny,
+    commonModelType: T,
+    object: CRMCommonModelTypeMap<T>['object']
+  ): Promise<void>;
+
+  /**
+   * This is the main method used to sync objects to a destination
+   */
   abstract writeObjects(
     connection: ConnectionSafeAny,
-    commonModelType: CommonModel,
+    commonModelType: CommonModelType,
     stream: Readable,
     heartbeat: () => void
   ): Promise<WriteCommonModelsResult>;

--- a/packages/core/destination_writers/s3.ts
+++ b/packages/core/destination_writers/s3.ts
@@ -1,5 +1,6 @@
 import { DeleteObjectsCommand, paginateListObjectsV2, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import { CommonModel, ConnectionSafeAny, IntegrationCategory, ProviderName, S3Destination } from '@supaglue/types';
+import { CommonModelType, ConnectionSafeAny, IntegrationCategory, ProviderName, S3Destination } from '@supaglue/types';
+import { CRMCommonModelType, CRMCommonModelTypeMap } from '@supaglue/types/crm';
 import { Readable, Transform } from 'stream';
 import { pipeline } from 'stream/promises';
 import { BaseDestinationWriter, WriteCommonModelsResult } from './base';
@@ -23,9 +24,18 @@ export class S3DestinationWriter extends BaseDestinationWriter {
     });
   }
 
+  public override async upsertObject<T extends CRMCommonModelType>(
+    connection: ConnectionSafeAny,
+    commonModelType: T,
+    object: CRMCommonModelTypeMap<T>['object']
+  ): Promise<void> {
+    // Do nothing
+    return;
+  }
+
   public override async writeObjects(
     connection: ConnectionSafeAny,
-    commonModelType: CommonModel,
+    commonModelType: CommonModelType,
     inputStream: Readable,
     heartbeat: () => void
   ): Promise<WriteCommonModelsResult> {
@@ -84,7 +94,7 @@ export class S3DestinationWriter extends BaseDestinationWriter {
 
   getKeyPrefix(
     category: IntegrationCategory,
-    commonModelType: CommonModel,
+    commonModelType: CommonModelType,
     customerId: string,
     providerName: ProviderName
   ) {
@@ -92,7 +102,7 @@ export class S3DestinationWriter extends BaseDestinationWriter {
   }
 
   async write(
-    commonModelType: CommonModel,
+    commonModelType: CommonModelType,
     { providerName, customerId, category }: ConnectionSafeAny,
     results: Record<string, any>[]
   ): Promise<void> {
@@ -119,7 +129,7 @@ export class S3DestinationWriter extends BaseDestinationWriter {
 
   async dropExistingRecordsIfNecessary(
     category: IntegrationCategory,
-    commonModelType: CommonModel,
+    commonModelType: CommonModelType,
     customerId: string,
     providerName: ProviderName
   ) {

--- a/packages/core/destination_writers/s3.ts
+++ b/packages/core/destination_writers/s3.ts
@@ -58,8 +58,8 @@ export class S3DestinationWriter extends BaseDestinationWriter {
           try {
             numRecords++;
             const mappedRecord = {
-              provider_name: providerName,
-              customer_id: customerId,
+              _supaglue_provider_name: providerName,
+              _supaglue_customer_id: customerId,
               ...mapper(chunk),
             };
             data.push(mappedRecord);
@@ -111,8 +111,8 @@ export class S3DestinationWriter extends BaseDestinationWriter {
         .map((result) =>
           JSON.stringify({
             ...result,
-            customer_id: customerId,
-            provider_name: providerName,
+            _supaglue_customer_id: customerId,
+            _supaglue_provider_name: providerName,
           })
         )
         .join('\n');

--- a/packages/core/destination_writers/util.ts
+++ b/packages/core/destination_writers/util.ts
@@ -1,4 +1,4 @@
-import { CommonModel, IntegrationCategory } from '@supaglue/types';
+import { CommonModelType, IntegrationCategory } from '@supaglue/types';
 import { CRMCommonModelType } from '@supaglue/types/crm';
 import { EngagementCommonModelType } from '@supaglue/types/engagement';
 import {
@@ -16,7 +16,7 @@ import {
   toSnakecasedKeysSequenceV2,
 } from '../mappers/engagement';
 
-export const getSnakecasedKeysMapper = (category: IntegrationCategory, commonModelType: CommonModel) => {
+export const getSnakecasedKeysMapper = (category: IntegrationCategory, commonModelType: CommonModelType) => {
   if (category === 'crm') {
     return snakecasedKeysMapperByCommonModelType.crm[commonModelType as CRMCommonModelType];
   }

--- a/packages/core/keys/crm/account.ts
+++ b/packages/core/keys/crm/account.ts
@@ -2,8 +2,9 @@ import { SnakecasedKeysCrmAccountV2WithTenant } from '@supaglue/types/crm';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedCrmAccountV2WithTenant = arrayOfAllKeys<SnakecasedKeysCrmAccountV2WithTenant>()([
-  'provider_name',
-  'customer_id',
+  '_supaglue_application_id',
+  '_supaglue_provider_name',
+  '_supaglue_customer_id',
   'id',
   'created_at',
   'updated_at',

--- a/packages/core/keys/crm/account.ts
+++ b/packages/core/keys/crm/account.ts
@@ -2,7 +2,6 @@ import { SnakecasedKeysCrmAccountV2WithTenant } from '@supaglue/types/crm';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedCrmAccountV2WithTenant = arrayOfAllKeys<SnakecasedKeysCrmAccountV2WithTenant>()([
-  '_supaglue_application_id',
   '_supaglue_provider_name',
   '_supaglue_customer_id',
   'id',

--- a/packages/core/keys/crm/contact.ts
+++ b/packages/core/keys/crm/contact.ts
@@ -2,7 +2,6 @@ import { SnakecasedKeysCrmContactV2WithTenant } from '@supaglue/types/crm';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedCrmContactV2WithTenant = arrayOfAllKeys<SnakecasedKeysCrmContactV2WithTenant>()([
-  '_supaglue_application_id',
   '_supaglue_provider_name',
   '_supaglue_customer_id',
   'id',

--- a/packages/core/keys/crm/contact.ts
+++ b/packages/core/keys/crm/contact.ts
@@ -2,8 +2,9 @@ import { SnakecasedKeysCrmContactV2WithTenant } from '@supaglue/types/crm';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedCrmContactV2WithTenant = arrayOfAllKeys<SnakecasedKeysCrmContactV2WithTenant>()([
-  'provider_name',
-  'customer_id',
+  '_supaglue_application_id',
+  '_supaglue_provider_name',
+  '_supaglue_customer_id',
   'id',
   'created_at',
   'updated_at',

--- a/packages/core/keys/crm/lead.ts
+++ b/packages/core/keys/crm/lead.ts
@@ -2,7 +2,6 @@ import { SnakecasedKeysCrmLeadV2WithTenant } from '@supaglue/types/crm';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedLeadV2WithTenant = arrayOfAllKeys<SnakecasedKeysCrmLeadV2WithTenant>()([
-  '_supaglue_application_id',
   '_supaglue_provider_name',
   '_supaglue_customer_id',
   'id',

--- a/packages/core/keys/crm/lead.ts
+++ b/packages/core/keys/crm/lead.ts
@@ -2,8 +2,9 @@ import { SnakecasedKeysCrmLeadV2WithTenant } from '@supaglue/types/crm';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedLeadV2WithTenant = arrayOfAllKeys<SnakecasedKeysCrmLeadV2WithTenant>()([
-  'provider_name',
-  'customer_id',
+  '_supaglue_application_id',
+  '_supaglue_provider_name',
+  '_supaglue_customer_id',
   'id',
   'created_at',
   'updated_at',

--- a/packages/core/keys/crm/opportunity.ts
+++ b/packages/core/keys/crm/opportunity.ts
@@ -2,8 +2,9 @@ import { SnakecasedKeysOpportunityV2WithTenant } from '@supaglue/types/crm';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedOpportunityV2WithTenant = arrayOfAllKeys<SnakecasedKeysOpportunityV2WithTenant>()([
-  'provider_name',
-  'customer_id',
+  '_supaglue_application_id',
+  '_supaglue_provider_name',
+  '_supaglue_customer_id',
   'id',
   'created_at',
   'updated_at',

--- a/packages/core/keys/crm/opportunity.ts
+++ b/packages/core/keys/crm/opportunity.ts
@@ -2,7 +2,6 @@ import { SnakecasedKeysOpportunityV2WithTenant } from '@supaglue/types/crm';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedOpportunityV2WithTenant = arrayOfAllKeys<SnakecasedKeysOpportunityV2WithTenant>()([
-  '_supaglue_application_id',
   '_supaglue_provider_name',
   '_supaglue_customer_id',
   'id',

--- a/packages/core/keys/crm/user.ts
+++ b/packages/core/keys/crm/user.ts
@@ -2,8 +2,9 @@ import { SnakecasedKeysCrmUserV2WithTenant } from '@supaglue/types/crm';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedCrmUserV2WithTenant = arrayOfAllKeys<SnakecasedKeysCrmUserV2WithTenant>()([
-  'provider_name',
-  'customer_id',
+  '_supaglue_application_id',
+  '_supaglue_provider_name',
+  '_supaglue_customer_id',
   'id',
   'created_at',
   'updated_at',

--- a/packages/core/keys/crm/user.ts
+++ b/packages/core/keys/crm/user.ts
@@ -2,7 +2,6 @@ import { SnakecasedKeysCrmUserV2WithTenant } from '@supaglue/types/crm';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedCrmUserV2WithTenant = arrayOfAllKeys<SnakecasedKeysCrmUserV2WithTenant>()([
-  '_supaglue_application_id',
   '_supaglue_provider_name',
   '_supaglue_customer_id',
   'id',

--- a/packages/core/keys/engagement/contact.ts
+++ b/packages/core/keys/engagement/contact.ts
@@ -3,7 +3,6 @@ import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedEngagementContactV2WithTenant =
   arrayOfAllKeys<SnakecasedKeysEngagementContactV2WithTenant>()([
-    '_supaglue_application_id',
     '_supaglue_provider_name',
     '_supaglue_customer_id',
     'id',

--- a/packages/core/keys/engagement/contact.ts
+++ b/packages/core/keys/engagement/contact.ts
@@ -3,8 +3,9 @@ import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedEngagementContactV2WithTenant =
   arrayOfAllKeys<SnakecasedKeysEngagementContactV2WithTenant>()([
-    'provider_name',
-    'customer_id',
+    '_supaglue_application_id',
+    '_supaglue_provider_name',
+    '_supaglue_customer_id',
     'id',
     'created_at',
     'updated_at',

--- a/packages/core/keys/engagement/mailbox.ts
+++ b/packages/core/keys/engagement/mailbox.ts
@@ -2,7 +2,6 @@ import { SnakecasedKeysMailboxV2WithTenant } from '@supaglue/types/engagement';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedMailboxV2WithTenant = arrayOfAllKeys<SnakecasedKeysMailboxV2WithTenant>()([
-  '_supaglue_application_id',
   '_supaglue_provider_name',
   '_supaglue_customer_id',
   'id',

--- a/packages/core/keys/engagement/mailbox.ts
+++ b/packages/core/keys/engagement/mailbox.ts
@@ -2,8 +2,9 @@ import { SnakecasedKeysMailboxV2WithTenant } from '@supaglue/types/engagement';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedMailboxV2WithTenant = arrayOfAllKeys<SnakecasedKeysMailboxV2WithTenant>()([
-  'provider_name',
-  'customer_id',
+  '_supaglue_application_id',
+  '_supaglue_provider_name',
+  '_supaglue_customer_id',
   'id',
   'created_at',
   'updated_at',

--- a/packages/core/keys/engagement/sequence.ts
+++ b/packages/core/keys/engagement/sequence.ts
@@ -2,8 +2,9 @@ import { SnakecasedKeysSequenceV2WithTenant } from '@supaglue/types/engagement';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedSequenceV2WithTenant = arrayOfAllKeys<SnakecasedKeysSequenceV2WithTenant>()([
-  'provider_name',
-  'customer_id',
+  '_supaglue_application_id',
+  '_supaglue_provider_name',
+  '_supaglue_customer_id',
   'id',
   'created_at',
   'updated_at',

--- a/packages/core/keys/engagement/sequence.ts
+++ b/packages/core/keys/engagement/sequence.ts
@@ -2,7 +2,6 @@ import { SnakecasedKeysSequenceV2WithTenant } from '@supaglue/types/engagement';
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedSequenceV2WithTenant = arrayOfAllKeys<SnakecasedKeysSequenceV2WithTenant>()([
-  '_supaglue_application_id',
   '_supaglue_provider_name',
   '_supaglue_customer_id',
   'id',

--- a/packages/core/keys/engagement/sequence_state.ts
+++ b/packages/core/keys/engagement/sequence_state.ts
@@ -2,7 +2,6 @@ import { SnakecasedKeysSequenceStateV2WithTenant } from '@supaglue/types/engagem
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedSequenceStateV2WithTenant = arrayOfAllKeys<SnakecasedKeysSequenceStateV2WithTenant>()([
-  '_supaglue_application_id',
   '_supaglue_provider_name',
   '_supaglue_customer_id',
   'id',

--- a/packages/core/keys/engagement/sequence_state.ts
+++ b/packages/core/keys/engagement/sequence_state.ts
@@ -2,8 +2,9 @@ import { SnakecasedKeysSequenceStateV2WithTenant } from '@supaglue/types/engagem
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedSequenceStateV2WithTenant = arrayOfAllKeys<SnakecasedKeysSequenceStateV2WithTenant>()([
-  'provider_name',
-  'customer_id',
+  '_supaglue_application_id',
+  '_supaglue_provider_name',
+  '_supaglue_customer_id',
   'id',
   'created_at',
   'updated_at',

--- a/packages/core/keys/engagement/user.ts
+++ b/packages/core/keys/engagement/user.ts
@@ -2,7 +2,6 @@ import { SnakecasedKeysEngagementUserV2WithTenant } from '@supaglue/types/engage
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedEngagementUserV2WithTenant = arrayOfAllKeys<SnakecasedKeysEngagementUserV2WithTenant>()([
-  '_supaglue_application_id',
   '_supaglue_provider_name',
   '_supaglue_customer_id',
   'id',

--- a/packages/core/keys/engagement/user.ts
+++ b/packages/core/keys/engagement/user.ts
@@ -2,8 +2,9 @@ import { SnakecasedKeysEngagementUserV2WithTenant } from '@supaglue/types/engage
 import { arrayOfAllKeys } from '../util';
 
 export const keysOfSnakecasedEngagementUserV2WithTenant = arrayOfAllKeys<SnakecasedKeysEngagementUserV2WithTenant>()([
-  'provider_name',
-  'customer_id',
+  '_supaglue_application_id',
+  '_supaglue_provider_name',
+  '_supaglue_customer_id',
   'id',
   'created_at',
   'updated_at',

--- a/packages/core/lib/remote_id.ts
+++ b/packages/core/lib/remote_id.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@supaglue/db';
-import { CommonModel } from '@supaglue/types';
+import { CommonModelType } from '@supaglue/types';
 
-export const getRemoteId = async (prisma: PrismaClient, id: string, commonModel: CommonModel): Promise<string> => {
+export const getRemoteId = async (prisma: PrismaClient, id: string, commonModel: CommonModelType): Promise<string> => {
   let record = null;
   switch (commonModel) {
     case 'account': {

--- a/packages/core/services/common_models/crm/common_model_service.ts
+++ b/packages/core/services/common_models/crm/common_model_service.ts
@@ -1,12 +1,16 @@
+import { ConnectionSafeAny } from '@supaglue/types/connection';
 import { CRMCommonModelType, CRMCommonModelTypeMap } from '@supaglue/types/crm';
 import { CrmRemoteClient } from '../../../remotes/crm/base';
+import { DestinationService } from '../../destination_service';
 import { RemoteService } from '../../remote_service';
 
 export class CrmCommonModelService {
   readonly #remoteService: RemoteService;
+  readonly #destinationService: DestinationService;
 
-  public constructor(remoteService: RemoteService) {
+  public constructor(remoteService: RemoteService, destinationService: DestinationService) {
     this.#remoteService = remoteService;
+    this.#destinationService = destinationService;
   }
 
   public async get<T extends CRMCommonModelType>(
@@ -20,19 +24,35 @@ export class CrmCommonModelService {
 
   public async create<T extends CRMCommonModelType>(
     type: T,
-    connectionId: string,
+    connection: ConnectionSafeAny,
     params: CRMCommonModelTypeMap<T>['createParams']
   ): Promise<string> {
-    const remoteClient = (await this.#remoteService.getRemoteClient(connectionId)) as CrmRemoteClient;
-    return await remoteClient.createObject(type, params);
+    const remoteClient = (await this.#remoteService.getRemoteClient(connection.id)) as CrmRemoteClient;
+    const id = await remoteClient.createObject(type, params);
+
+    // If the associated integration has a destination, do cache invalidation
+    const writer = await this.#destinationService.getWriterByIntegrationId(connection.integrationId);
+    if (writer) {
+      const object = await remoteClient.getObject(type, id);
+      await writer.upsertObject(connection, type, object);
+    }
+
+    return id;
   }
 
   public async update<T extends CRMCommonModelType>(
     type: T,
-    connectionId: string,
+    connection: ConnectionSafeAny,
     params: CRMCommonModelTypeMap<T>['updateParams']
   ): Promise<void> {
-    const remoteClient = (await this.#remoteService.getRemoteClient(connectionId)) as CrmRemoteClient;
+    const remoteClient = (await this.#remoteService.getRemoteClient(connection.id)) as CrmRemoteClient;
     await remoteClient.updateObject(type, params);
+
+    // If the associated integration has a destination, do cache invalidation
+    const writer = await this.#destinationService.getWriterByIntegrationId(connection.integrationId);
+    if (writer) {
+      const object = await remoteClient.getObject(type, params.id);
+      await writer.upsertObject(connection, type, object);
+    }
   }
 }

--- a/packages/core/services/destination_service.ts
+++ b/packages/core/services/destination_service.ts
@@ -19,6 +19,16 @@ export class DestinationService {
     return models.map(fromDestinationModel);
   }
 
+  public async getDestinationByIntegrationId(integrationId: string): Promise<Destination | null> {
+    const model = await this.#prisma.destination.findFirst({
+      where: { integrations: { some: { id: integrationId } } },
+    });
+    if (!model) {
+      return null;
+    }
+    return fromDestinationModel(model);
+  }
+
   public async getDestinationById(id: string): Promise<Destination> {
     const model = await this.#prisma.destination.findUniqueOrThrow({
       where: { id },
@@ -51,15 +61,11 @@ export class DestinationService {
     return fromDestinationModel(model);
   }
 
-  public async getWriterByApplicationId(applicationId: string): Promise<DestinationWriter> {
-    const destinations = await this.getDestinationsByApplicationId(applicationId);
-    if (destinations.length === 0) {
-      throw new Error('No destinations found');
+  public async getWriterByIntegrationId(integrationId: string): Promise<DestinationWriter | null> {
+    const destination = await this.getDestinationByIntegrationId(integrationId);
+    if (!destination) {
+      return null;
     }
-    if (destinations.length > 1) {
-      throw new Error('Multiple destinations found');
-    }
-    const destination = destinations[0];
     switch (destination.type) {
       case 's3':
         return new S3DestinationWriter(destination);

--- a/packages/sync-workflows/activities/import_records.ts
+++ b/packages/sync-workflows/activities/import_records.ts
@@ -15,7 +15,7 @@ import {
   UserService as EngagementUserService,
 } from '@supaglue/core/services/common_models/engagement';
 import { SequenceStateService } from '@supaglue/core/services/common_models/engagement/sequence_state_service';
-import { CommonModel, IntegrationCategory } from '@supaglue/types';
+import { CommonModelType, IntegrationCategory } from '@supaglue/types';
 import { CRMCommonModelType } from '@supaglue/types/crm';
 import { EngagementCommonModelType } from '@supaglue/types/engagement';
 import { Context } from '@temporalio/activity';
@@ -25,14 +25,14 @@ import { logEvent } from '../lib/analytics';
 export type ImportRecordsArgs = {
   syncId: string;
   connectionId: string;
-  commonModel: CommonModel;
+  commonModel: CommonModelType;
   updatedAfterMs?: number;
 };
 
 export type ImportRecordsResult = {
   syncId: string;
   connectionId: string;
-  commonModel: CommonModel;
+  commonModel: CommonModelType;
   maxLastModifiedAtMs: number;
   numRecordsSynced: number;
 };

--- a/packages/sync-workflows/activities/maybe_send_sync_finish_webhook.ts
+++ b/packages/sync-workflows/activities/maybe_send_sync_finish_webhook.ts
@@ -1,6 +1,6 @@
 import { maybeSendWebhookPayload } from '@supaglue/core/lib/webhook';
 import { ConnectionService, IntegrationService } from '@supaglue/core/services';
-import { CommonModel } from '@supaglue/types/common';
+import { CommonModelType } from '@supaglue/types/common';
 import { ApplicationService } from 'sync-worker/services';
 
 export function createMaybeSendSyncFinishWebhook({
@@ -24,7 +24,7 @@ export function createMaybeSendSyncFinishWebhook({
     connectionId: string;
     status: 'SYNC_SUCCESS' | 'SYNC_ERROR';
     numRecordsSynced: number;
-    commonModel: CommonModel;
+    commonModel: CommonModelType;
     errorMessage?: string;
   }) {
     const connection = await connectionService.getSafeById(connectionId);

--- a/packages/sync-workflows/activities/sync_records_to_destination.ts
+++ b/packages/sync-workflows/activities/sync_records_to_destination.ts
@@ -2,7 +2,7 @@ import { CrmRemoteClient } from '@supaglue/core/remotes/crm/base';
 import { EngagementRemoteClient } from '@supaglue/core/remotes/engagement/base';
 import { ConnectionService, RemoteService } from '@supaglue/core/services';
 import { DestinationService } from '@supaglue/core/services/destination_service';
-import { CommonModel } from '@supaglue/types';
+import { CommonModelType } from '@supaglue/types';
 import { CRMCommonModelType } from '@supaglue/types/crm';
 import { EngagementCommonModelType } from '@supaglue/types/engagement';
 import { Context } from '@temporalio/activity';
@@ -12,14 +12,14 @@ import { logEvent } from '../lib/analytics';
 export type SyncRecordsToDestinationArgs = {
   syncId: string;
   connectionId: string;
-  commonModel: CommonModel;
+  commonModel: CommonModelType;
   updatedAfterMs?: number;
 };
 
 export type SyncRecordsToDestinationResult = {
   syncId: string;
   connectionId: string;
-  commonModel: CommonModel;
+  commonModel: CommonModelType;
   maxLastModifiedAtMs: number;
   numRecordsSynced: number;
 };
@@ -48,7 +48,10 @@ export function createSyncRecordsToDestination(
 
     const client = await remoteService.getRemoteClient(connectionId);
 
-    const writer = await destinationService.getWriterByApplicationId(connection.applicationId);
+    const writer = await destinationService.getWriterByIntegrationId(connection.integrationId);
+    if (!writer) {
+      throw new Error(`No destination found for integration ${connection.integrationId}`);
+    }
 
     let readable: Readable;
     // TODO: Have better type-safety

--- a/packages/sync-workflows/lib/analytics.ts
+++ b/packages/sync-workflows/lib/analytics.ts
@@ -1,6 +1,6 @@
 import { distinctId } from '@supaglue/core/lib/distinct_identifier';
 import { getSystemProperties, posthogClient } from '@supaglue/core/lib/posthog';
-import { CommonModel, ProviderName } from '@supaglue/types';
+import { CommonModelType, ProviderName } from '@supaglue/types';
 
 export const logEvent = ({
   eventName,
@@ -12,7 +12,7 @@ export const logEvent = ({
 }: {
   eventName: string;
   providerName: ProviderName;
-  modelName: CommonModel;
+  modelName: CommonModelType;
   syncId: string;
   numRecordsSynced?: number;
   isSuccess?: boolean;

--- a/packages/sync-workflows/workflows/run_managed_sync.ts
+++ b/packages/sync-workflows/workflows/run_managed_sync.ts
@@ -1,4 +1,4 @@
-import { CommonModel, IntegrationCategory } from '@supaglue/types/common';
+import { CommonModelType, IntegrationCategory } from '@supaglue/types/common';
 import { CRMCommonModelType, CRM_COMMON_MODEL_TYPES } from '@supaglue/types/crm';
 import {
   CRMNumRecordsSyncedMap,
@@ -52,10 +52,10 @@ export type RunManagedSyncArgs = {
 export async function runManagedSync({ syncId, connectionId, category }: RunManagedSyncArgs): Promise<void> {
   const historyIdsMap = Object.fromEntries(
     getCommonModels(category).map((commonModel) => {
-      const entry: [CommonModel, string] = [commonModel, uuid4()];
+      const entry: [CommonModelType, string] = [commonModel, uuid4()];
       return entry;
     })
-  ) as Record<CommonModel, string>;
+  ) as Record<CommonModelType, string>;
 
   await Promise.all(
     getCommonModels(category).map(async (commonModel) => {
@@ -147,14 +147,14 @@ async function doFullOnlySync({
   const importRecordsResultList = Object.fromEntries(
     await Promise.all(
       getCommonModels(category).map(async (commonModel) => {
-        const entry: [CommonModel, ImportRecordsResult] = [
+        const entry: [CommonModelType, ImportRecordsResult] = [
           commonModel,
           await syncRecordsToDestination({ syncId: sync.id, connectionId: sync.connectionId, commonModel }),
         ];
         return entry;
       })
     )
-  ) as Record<CommonModel, ImportRecordsResult>;
+  ) as Record<CommonModelType, ImportRecordsResult>;
 
   await updateSyncState({
     syncId: sync.id,
@@ -174,7 +174,7 @@ async function doFullOnlySync({
 
   return Object.fromEntries(
     getCommonModels(category).map((commonModel) => [commonModel, importRecordsResultList[commonModel].numRecordsSynced])
-  ) as Record<CommonModel, number>;
+  ) as Record<CommonModelType, number>;
 }
 
 async function doFullThenIncrementalSync({
@@ -197,14 +197,14 @@ async function doFullThenIncrementalSync({
     const importRecordsResultList = Object.fromEntries(
       await Promise.all(
         getCommonModels(category).map(async (commonModel) => {
-          const entry: [CommonModel, ImportRecordsResult] = [
+          const entry: [CommonModelType, ImportRecordsResult] = [
             commonModel,
             await syncRecordsToDestination({ syncId: sync.id, connectionId: sync.connectionId, commonModel }),
           ];
           return entry;
         })
       )
-    ) as Record<CommonModel, ImportRecordsResult>;
+    ) as Record<CommonModelType, ImportRecordsResult>;
 
     const newMaxLastModifiedAtMsMap =
       category === 'crm'
@@ -246,7 +246,7 @@ async function doFullThenIncrementalSync({
         commonModel,
         importRecordsResultList[commonModel].numRecordsSynced,
       ])
-    ) as Record<CommonModel, number>;
+    ) as Record<CommonModelType, number>;
   }
 
   async function doIncrementalPhase(): Promise<NumRecordsSyncedMap> {
@@ -288,8 +288,8 @@ async function doFullThenIncrementalSync({
         getCommonModels(category).map((commonModel) => [
           commonModel,
           Math.max(
-            (originalMaxLastModifiedAtMsMap as Record<CommonModel, number>)[commonModel],
-            (importRecordsResultList as Record<CommonModel, ImportRecordsResult>)[commonModel].maxLastModifiedAtMs
+            (originalMaxLastModifiedAtMsMap as Record<CommonModelType, number>)[commonModel],
+            (importRecordsResultList as Record<CommonModelType, ImportRecordsResult>)[commonModel].maxLastModifiedAtMs
           ),
         ])
       ) as NumRecordsSyncedMap;
@@ -307,19 +307,19 @@ async function doFullThenIncrementalSync({
     const importRecordsResultList = Object.fromEntries(
       await Promise.all(
         getCommonModels(category).map(async (commonModel) => {
-          const entry: [CommonModel, ImportRecordsResult] = [
+          const entry: [CommonModelType, ImportRecordsResult] = [
             commonModel,
             await syncRecordsToDestination({
               syncId: sync.id,
               connectionId: sync.connectionId,
               commonModel,
-              updatedAfterMs: (getOriginalMaxLastModifiedAtMsMap() as Record<CommonModel, number>)[commonModel],
+              updatedAfterMs: (getOriginalMaxLastModifiedAtMsMap() as Record<CommonModelType, number>)[commonModel],
             }),
           ];
           return entry;
         })
       )
-    ) as Record<CommonModel, ImportRecordsResult>;
+    ) as Record<CommonModelType, ImportRecordsResult>;
 
     const newMaxLastModifiedAtMsMap = computeUpdatedMaxLastModifiedAtMsMap(importRecordsResultList);
 
@@ -345,7 +345,7 @@ async function doFullThenIncrementalSync({
     return Object.fromEntries(
       getCommonModels(category).map((commonModel) => [
         commonModel,
-        (importRecordsResultList as Record<CommonModel, ImportRecordsResult>)[commonModel].numRecordsSynced,
+        (importRecordsResultList as Record<CommonModelType, ImportRecordsResult>)[commonModel].numRecordsSynced,
       ])
     ) as NumRecordsSyncedMap;
   }
@@ -380,7 +380,7 @@ async function doReverseThenForwardSync({
 }: {
   sync: ReverseThenForwardSync;
   category: IntegrationCategory;
-}): Promise<Record<CommonModel, number>> {
+}): Promise<Record<CommonModelType, number>> {
   throw ApplicationFailure.nonRetryable('reverse then forward sync not currently supported');
 }
 

--- a/packages/sync-workflows/workflows/run_sync.ts
+++ b/packages/sync-workflows/workflows/run_sync.ts
@@ -1,4 +1,4 @@
-import { CommonModel, IntegrationCategory } from '@supaglue/types/common';
+import { CommonModelType, IntegrationCategory } from '@supaglue/types/common';
 import { CRMCommonModelType, CRM_COMMON_MODEL_TYPES } from '@supaglue/types/crm';
 import {
   CRMNumRecordsSyncedMap,
@@ -51,10 +51,10 @@ export type RunSyncArgs = {
 export async function runSync({ syncId, connectionId, category }: RunSyncArgs): Promise<void> {
   const historyIdsMap = Object.fromEntries(
     getCommonModels(category).map((commonModel) => {
-      const entry: [CommonModel, string] = [commonModel, uuid4()];
+      const entry: [CommonModelType, string] = [commonModel, uuid4()];
       return entry;
     })
-  ) as Record<CommonModel, string>;
+  ) as Record<CommonModelType, string>;
 
   await Promise.all(
     getCommonModels(category).map(async (commonModel) => {
@@ -145,14 +145,14 @@ async function doFullThenIncrementalSync({
     const importRecordsResultList = Object.fromEntries(
       await Promise.all(
         getCommonModels(category).map(async (commonModel) => {
-          const entry: [CommonModel, ImportRecordsResult] = [
+          const entry: [CommonModelType, ImportRecordsResult] = [
             commonModel,
             await importRecords({ syncId: sync.id, connectionId: sync.connectionId, commonModel }),
           ];
           return entry;
         })
       )
-    ) as Record<CommonModel, ImportRecordsResult>;
+    ) as Record<CommonModelType, ImportRecordsResult>;
 
     const newMaxLastModifiedAtMsMap =
       category === 'crm'
@@ -194,7 +194,7 @@ async function doFullThenIncrementalSync({
         commonModel,
         importRecordsResultList[commonModel].numRecordsSynced,
       ])
-    ) as Record<CommonModel, number>;
+    ) as Record<CommonModelType, number>;
   }
 
   async function doIncrementalPhase(): Promise<NumRecordsSyncedMap> {
@@ -236,8 +236,8 @@ async function doFullThenIncrementalSync({
         getCommonModels(category).map((commonModel) => [
           commonModel,
           Math.max(
-            (originalMaxLastModifiedAtMsMap as Record<CommonModel, number>)[commonModel],
-            (importRecordsResultList as Record<CommonModel, ImportRecordsResult>)[commonModel].maxLastModifiedAtMs
+            (originalMaxLastModifiedAtMsMap as Record<CommonModelType, number>)[commonModel],
+            (importRecordsResultList as Record<CommonModelType, ImportRecordsResult>)[commonModel].maxLastModifiedAtMs
           ),
         ])
       ) as NumRecordsSyncedMap;
@@ -255,19 +255,19 @@ async function doFullThenIncrementalSync({
     const importRecordsResultList = Object.fromEntries(
       await Promise.all(
         getCommonModels(category).map(async (commonModel) => {
-          const entry: [CommonModel, ImportRecordsResult] = [
+          const entry: [CommonModelType, ImportRecordsResult] = [
             commonModel,
             await importRecords({
               syncId: sync.id,
               connectionId: sync.connectionId,
               commonModel,
-              updatedAfterMs: (getOriginalMaxLastModifiedAtMsMap() as Record<CommonModel, number>)[commonModel],
+              updatedAfterMs: (getOriginalMaxLastModifiedAtMsMap() as Record<CommonModelType, number>)[commonModel],
             }),
           ];
           return entry;
         })
       )
-    ) as Record<CommonModel, ImportRecordsResult>;
+    ) as Record<CommonModelType, ImportRecordsResult>;
 
     const newMaxLastModifiedAtMsMap = computeUpdatedMaxLastModifiedAtMsMap(importRecordsResultList);
 
@@ -293,7 +293,7 @@ async function doFullThenIncrementalSync({
     return Object.fromEntries(
       getCommonModels(category).map((commonModel) => [
         commonModel,
-        (importRecordsResultList as Record<CommonModel, ImportRecordsResult>)[commonModel].numRecordsSynced,
+        (importRecordsResultList as Record<CommonModelType, ImportRecordsResult>)[commonModel].numRecordsSynced,
       ])
     ) as NumRecordsSyncedMap;
   }
@@ -328,7 +328,7 @@ async function doReverseThenForwardSync({
 }: {
   sync: ReverseThenForwardSync;
   category: IntegrationCategory;
-}): Promise<Record<CommonModel, number>> {
+}): Promise<Record<CommonModelType, number>> {
   throw ApplicationFailure.nonRetryable('reverse then forward sync not currently supported');
 }
 

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -47,4 +47,4 @@ export type PaginatedResult<T> = {
 };
 
 export type IntegrationCategory = 'crm' | 'engagement';
-export type CommonModel = CRMCommonModelType | EngagementCommonModelType;
+export type CommonModelType = CRMCommonModelType | EngagementCommonModelType;

--- a/packages/types/crm/base.ts
+++ b/packages/types/crm/base.ts
@@ -1,6 +1,7 @@
 export type SnakecasedCrmTenantFields = {
-  provider_name: string;
-  customer_id: string;
+  _supaglue_application_id: string;
+  _supaglue_provider_name: string;
+  _supaglue_customer_id: string;
 };
 
 export type BaseCrmModel = {

--- a/packages/types/crm/base.ts
+++ b/packages/types/crm/base.ts
@@ -1,5 +1,4 @@
 export type SnakecasedCrmTenantFields = {
-  _supaglue_application_id: string;
   _supaglue_provider_name: string;
   _supaglue_customer_id: string;
 };

--- a/packages/types/engagement/base.ts
+++ b/packages/types/engagement/base.ts
@@ -1,6 +1,7 @@
 export type SnakecasedEngagementTenantFields = {
-  provider_name: string;
-  customer_id: string;
+  _supaglue_application_id: string;
+  _supaglue_provider_name: string;
+  _supaglue_customer_id: string;
 };
 
 export type BaseEngagementModel = {

--- a/packages/types/engagement/base.ts
+++ b/packages/types/engagement/base.ts
@@ -1,5 +1,4 @@
 export type SnakecasedEngagementTenantFields = {
-  _supaglue_application_id: string;
   _supaglue_provider_name: string;
   _supaglue_customer_id: string;
 };

--- a/packages/types/webhook.ts
+++ b/packages/types/webhook.ts
@@ -1,4 +1,4 @@
-import { CommonModel } from './common';
+import { CommonModelType } from './common';
 import { ConnectionCreateParamsAny } from './connection';
 
 export type HttpRequestType = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
@@ -23,7 +23,7 @@ export type SyncWebhookPayload = {
   providerName: string;
   historyId: string;
   numRecordsSynced: number;
-  commonModel: CommonModel;
+  commonModel: CommonModelType;
   errorMessage?: string;
 };
 


### PR DESCRIPTION
- "cache invalidation" in postgres for managed syncs
- write to destination specified in Integration; don't grab a random destination from all configured destinations in an application
- add `_supaglue` prefix to DB fields if it is metadata

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
