### PR TITLE
feat(mgmt): add pagination to sync history

### DIFF
--- a/apps/api/routes/internal/v1/sync_history.ts
+++ b/apps/api/routes/internal/v1/sync_history.ts
@@ -18,7 +18,7 @@ export default function init(app: Router) {
       req: Request<GetSyncHistoryPathParams, GetSyncHistoryResponse, GetSyncHistoryRequest, GetSyncHistoryQueryParams>,
       res: Response<GetSyncHistoryResponse>
     ) => {
-      const { next, previous, results } = await syncHistoryService.list({
+      const { next, previous, results, totalCount } = await syncHistoryService.list({
         applicationId: req.supaglueApplication.id,
         paginationParams: toPaginationInternalParams({ page_size: req.query?.page_size, cursor: req.query?.cursor }),
         model: req.query?.model,
@@ -33,7 +33,7 @@ export default function init(app: Router) {
           endTimestamp: result.endTimestamp?.toISOString() ?? null,
         })
       );
-      return res.status(200).send({ next, previous, results: snakeCaseResults });
+      return res.status(200).send({ next, previous, results: snakeCaseResults, total_count: totalCount });
     }
   );
 }

--- a/apps/api/routes/internal/v2/sync_history.ts
+++ b/apps/api/routes/internal/v2/sync_history.ts
@@ -18,7 +18,7 @@ export default function init(app: Router) {
       req: Request<GetSyncHistoryPathParams, GetSyncHistoryResponse, GetSyncHistoryRequest, GetSyncHistoryQueryParams>,
       res: Response<GetSyncHistoryResponse>
     ) => {
-      const { next, previous, results } = await syncHistoryService.list({
+      const { next, previous, results, totalCount } = await syncHistoryService.list({
         applicationId: req.supaglueApplication.id,
         paginationParams: toPaginationInternalParams({ page_size: req.query?.page_size, cursor: req.query?.cursor }),
         model: req.query?.model,
@@ -33,7 +33,7 @@ export default function init(app: Router) {
           endTimestamp: result.endTimestamp?.toISOString() ?? null,
         })
       );
-      return res.status(200).send({ next, previous, results: snakeCaseResults });
+      return res.status(200).send({ next, previous, results: snakeCaseResults, total_count: totalCount });
     }
   );
 }

--- a/apps/mgmt-ui/src/components/logs/LogsTable.tsx
+++ b/apps/mgmt-ui/src/components/logs/LogsTable.tsx
@@ -1,43 +1,71 @@
 import { datetimeStringFromISOString } from '@/utils/datetime';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { SyncHistory } from '@supaglue/types';
+import { useState } from 'react';
 
 const columns: GridColDef[] = [
-  { field: 'customerId', headerName: 'Customer Id', width: 200 },
-  { field: 'providerName', headerName: 'Provider', width: 120 },
-  { field: 'modelName', headerName: 'Model', width: 120 },
-  { field: 'status', headerName: 'Status', width: 120 },
+  { field: 'customerId', headerName: 'Customer Id', width: 200, sortable: false },
+  { field: 'providerName', headerName: 'Provider', width: 120, sortable: false },
+  { field: 'modelName', headerName: 'Model', width: 120, sortable: false },
+  { field: 'status', headerName: 'Status', width: 120, sortable: false },
   {
     field: 'startTimestamp',
     headerName: 'Start Time',
     width: 180,
     valueFormatter: ({ value }) => (value ? datetimeStringFromISOString(value) : '-'),
+    sortable: false,
   },
   {
     field: 'endTimestamp',
     headerName: 'End Time',
     width: 180,
     valueFormatter: ({ value }) => (value ? datetimeStringFromISOString(value) : '-'),
+    sortable: false,
   },
   {
     field: 'errorMessage',
     headerName: 'Error Message',
     width: 240,
+    sortable: false,
   },
 ];
 
 export type LogsTableProps = {
+  isLoading: boolean;
+  rowCount: number;
   data: SyncHistory[];
+  handleNextPage: () => void;
+  handlePreviousPage: () => void;
 };
 
 export default function LogsTable(props: LogsTableProps) {
-  const { data } = props;
+  const { data, rowCount, handleNextPage, handlePreviousPage, isLoading } = props;
+  const [paginationModel, setPaginationModel] = useState({
+    page: 0,
+    pageSize: 100,
+  });
 
   return (
     <div style={{ height: 750, width: '100%' }}>
       <DataGrid
+        density="compact"
+        pageSizeOptions={[100]}
+        disableColumnFilter
+        disableColumnMenu
+        loading={isLoading}
+        rowCount={rowCount}
         rows={data ?? []}
         columns={columns}
+        paginationMode="server"
+        paginationModel={paginationModel}
+        onPaginationModelChange={(newPaginationModel) => {
+          setPaginationModel(newPaginationModel);
+          if (newPaginationModel.page > paginationModel.page) {
+            handleNextPage();
+          } else {
+            handlePreviousPage();
+          }
+        }}
         initialState={{
           sorting: {
             sortModel: [{ field: 'startTimestamp', sort: 'desc' }],

--- a/apps/mgmt-ui/src/hooks/useSWRWithApplication.ts
+++ b/apps/mgmt-ui/src/hooks/useSWRWithApplication.ts
@@ -11,6 +11,9 @@ export function useSWRWithApplication<T>(path: string) {
       path,
       applicationId,
     },
-    fetcherWithApplication<T>
+    fetcherWithApplication<T>,
+    {
+      keepPreviousData: true,
+    }
   );
 }

--- a/apps/mgmt-ui/src/hooks/useSyncHistory.ts
+++ b/apps/mgmt-ui/src/hooks/useSyncHistory.ts
@@ -2,8 +2,12 @@ import { PaginatedResult, SyncHistory } from '@supaglue/types';
 import { camelcaseKeys } from '@supaglue/utils/camelcase';
 import { useSWRWithApplication } from './useSWRWithApplication';
 
-export function useSyncHistory() {
-  const { data, isLoading, error } = useSWRWithApplication('/api/internal/sync-history');
+export function useSyncHistory(cursor?: string) {
+  const queryParams = new URLSearchParams();
+  queryParams.append('page_size', '100');
+  cursor && queryParams.append('cursor', cursor);
+
+  const { data, isLoading, error } = useSWRWithApplication(`/api/internal/sync-history?${queryParams}`);
 
   return {
     syncHistories: data ? (camelcaseKeys(data) as PaginatedResult<SyncHistory>) : undefined,

--- a/apps/mgmt-ui/src/pages/api/internal/sync-history/index.ts
+++ b/apps/mgmt-ui/src/pages/api/internal/sync-history/index.ts
@@ -4,8 +4,11 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { API_HOST } from '../..';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<GetSyncHistoryResponse | null>) {
-  // TODO: Implement real pagination
-  const result = await fetch(`${API_HOST}/internal/v1/sync-history?page_size=1000`, {
+  const queryParams = new URLSearchParams();
+  req.query?.page_size && queryParams.append('page_size', req.query.page_size as string);
+  req.query?.cursor && queryParams.append('cursor', req.query.cursor as string);
+
+  const result = await fetch(`${API_HOST}/internal/v1/sync-history?${queryParams}`, {
     method: 'GET',
     headers: getApplicationIdScopedHeaders(req),
   });

--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/sync_logs/index.tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/sync_logs/index.tsx
@@ -1,5 +1,4 @@
 import LogsTable from '@/components/logs/LogsTable';
-import Spinner from '@/components/Spinner';
 import { useSyncHistory } from '@/hooks/useSyncHistory';
 import Header from '@/layout/Header';
 import { getServerSideProps } from '@/pages/applications/[applicationId]';
@@ -10,11 +9,24 @@ import { useState } from 'react';
 export { getServerSideProps };
 
 export default function Home() {
-  const { syncHistories, isLoading } = useSyncHistory();
+  const [currentCursor, setCurrentCursor] = useState<string | undefined>(undefined);
+  const { syncHistories, isLoading } = useSyncHistory(currentCursor);
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
+  };
+
+  const handleNextPage = () => {
+    if (syncHistories?.next) {
+      setCurrentCursor(syncHistories.next);
+    }
+  };
+
+  const handlePreviousPage = () => {
+    if (syncHistories?.previous) {
+      setCurrentCursor(syncHistories.previous);
+    }
   };
 
   return (
@@ -29,7 +41,13 @@ export default function Home() {
       <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
         <Header title="Sync Logs" onDrawerToggle={handleDrawerToggle} />
         <Box component="main" sx={{ flex: 1, py: 6, px: 4, bgcolor: '#eaeff1' }}>
-          {isLoading ? <Spinner /> : <LogsTable data={syncHistories?.results ?? []} />}
+          <LogsTable
+            handleNextPage={handleNextPage}
+            handlePreviousPage={handlePreviousPage}
+            rowCount={syncHistories?.totalCount || 0}
+            data={syncHistories?.results ?? []}
+            isLoading={isLoading}
+          />
         </Box>
       </Box>
     </>

--- a/openapi/common/components/schemas/pagination.yaml
+++ b/openapi/common/components/schemas/pagination.yaml
@@ -8,3 +8,6 @@ properties:
     type: string
     nullable: true
     example: eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9
+  total_count:
+    type: number
+    example: 100

--- a/openapi/v1/crm/openapi.bundle.json
+++ b/openapi/v1/crm/openapi.bundle.json
@@ -3266,6 +3266,10 @@
             "type": "string",
             "nullable": true,
             "example": "eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9"
+          },
+          "total_count": {
+            "type": "number",
+            "example": 100
           }
         }
       },

--- a/openapi/v1/engagement/openapi.bundle.json
+++ b/openapi/v1/engagement/openapi.bundle.json
@@ -1698,6 +1698,10 @@
             "type": "string",
             "nullable": true,
             "example": "eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9"
+          },
+          "total_count": {
+            "type": "number",
+            "example": 100
           }
         }
       },

--- a/openapi/v1/mgmt/openapi.bundle.json
+++ b/openapi/v1/mgmt/openapi.bundle.json
@@ -1049,6 +1049,10 @@
                           "type": "string",
                           "nullable": true,
                           "example": "eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9"
+                        },
+                        "total_count": {
+                          "type": "number",
+                          "example": 100
                         }
                       }
                     },

--- a/openapi/v2/crm/openapi.bundle.json
+++ b/openapi/v2/crm/openapi.bundle.json
@@ -2560,6 +2560,10 @@
             "type": "string",
             "nullable": true,
             "example": "eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9"
+          },
+          "total_count": {
+            "type": "number",
+            "example": 100
           }
         }
       },

--- a/openapi/v2/engagement/openapi.bundle.json
+++ b/openapi/v2/engagement/openapi.bundle.json
@@ -1637,6 +1637,10 @@
             "type": "string",
             "nullable": true,
             "example": "eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9"
+          },
+          "total_count": {
+            "type": "number",
+            "example": 100
           }
         }
       },

--- a/openapi/v2/mgmt/openapi.bundle.json
+++ b/openapi/v2/mgmt/openapi.bundle.json
@@ -1046,6 +1046,10 @@
                           "type": "string",
                           "nullable": true,
                           "example": "eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9"
+                        },
+                        "total_count": {
+                          "type": "number",
+                          "example": 100
                         }
                       }
                     },

--- a/packages/core/lib/pagination.ts
+++ b/packages/core/lib/pagination.ts
@@ -58,7 +58,7 @@ export const decodeCursor = (encoded?: string): Cursor | undefined => {
 const MAX_PAGE_SIZE = 1000;
 
 export const toPaginationInternalParams = (paginationParams: PaginationParams): PaginationInternalParams => {
-  const page_size = paginationParams.page_size ? parseInt(paginationParams.page_size) : MAX_PAGE_SIZE;
+  const page_size = paginationParams.page_size ? parseInt(paginationParams.page_size, 10) : MAX_PAGE_SIZE;
   if (isNaN(page_size)) {
     throw new BadRequestError('Unable to parse page_size');
   }

--- a/packages/schemas/gen/v1/crm.ts
+++ b/packages/schemas/gen/v1/crm.ts
@@ -571,6 +571,8 @@ export interface components {
       next?: string | null;
       /** @example eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9 */
       previous?: string | null;
+      /** @example 100 */
+      total_count?: number;
     };
     /** @description Custom properties to be inserted that are not covered by the common model. Object keys must match exactly to the corresponding provider API. */
     custom_fields: {

--- a/packages/schemas/gen/v1/engagement.ts
+++ b/packages/schemas/gen/v1/engagement.ts
@@ -317,6 +317,8 @@ export interface components {
       next?: string | null;
       /** @example eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9 */
       previous?: string | null;
+      /** @example 100 */
+      total_count?: number;
     };
     /**
      * @example [

--- a/packages/schemas/gen/v1/mgmt.ts
+++ b/packages/schemas/gen/v1/mgmt.ts
@@ -741,6 +741,8 @@ export interface operations {
             next?: string | null;
             /** @example eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9 */
             previous?: string | null;
+            /** @example 100 */
+            total_count?: number;
           }) & {
             results?: (components["schemas"]["sync_history"])[];
           };

--- a/packages/schemas/gen/v2/crm.ts
+++ b/packages/schemas/gen/v2/crm.ts
@@ -572,6 +572,8 @@ export interface components {
       next?: string | null;
       /** @example eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9 */
       previous?: string | null;
+      /** @example 100 */
+      total_count?: number;
     };
     /** @description Custom properties to be inserted that are not covered by the common model. Object keys must match exactly to the corresponding provider API. */
     custom_fields: {

--- a/packages/schemas/gen/v2/engagement.ts
+++ b/packages/schemas/gen/v2/engagement.ts
@@ -300,6 +300,8 @@ export interface components {
       next?: string | null;
       /** @example eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9 */
       previous?: string | null;
+      /** @example 100 */
+      total_count?: number;
     };
     /**
      * @example [

--- a/packages/schemas/gen/v2/mgmt.ts
+++ b/packages/schemas/gen/v2/mgmt.ts
@@ -735,6 +735,8 @@ export interface operations {
             next?: string | null;
             /** @example eyJpZCI6IjBjZDhmYmZkLWU5NmQtNDEwZC05ZjQxLWIwMjU1YjdmNGI4NyIsInJldmVyc2UiOnRydWV9 */
             previous?: string | null;
+            /** @example 100 */
+            total_count?: number;
           }) & {
             results?: (components["schemas"]["sync_history"])[];
           };

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -44,6 +44,7 @@ export type PaginatedResult<T> = {
   next: string | null;
   previous: string | null;
   results: T[];
+  totalCount?: number;
 };
 
 export type IntegrationCategory = 'crm' | 'engagement';


### PR DESCRIPTION
- server-side pagination for sync history mgmt ui page with 100 records at a time
- make the datagrid compact
- disallow client-side  sorting/filtering which will cause trouble when mixed with server pagination

https://github.com/supaglue-labs/supaglue/assets/471516/63f75af7-d9a2-457e-823f-e40664bea334


## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
