### PR TITLE
chore(mgmt-ui): add number of synced records to sync log page

### DIFF
--- a/apps/mgmt-ui/src/components/logs/LogsTable.tsx
+++ b/apps/mgmt-ui/src/components/logs/LogsTable.tsx
@@ -7,19 +7,25 @@ const columns: GridColDef[] = [
   { field: 'customerId', headerName: 'Customer Id', width: 200, sortable: false },
   { field: 'providerName', headerName: 'Provider', width: 120, sortable: false },
   { field: 'modelName', headerName: 'Model', width: 120, sortable: false },
-  { field: 'status', headerName: 'Status', width: 120, sortable: false },
+  { field: 'status', headerName: 'Status', width: 100, sortable: false },
   {
     field: 'startTimestamp',
     headerName: 'Start Time',
-    width: 180,
+    width: 160,
     valueFormatter: ({ value }) => (value ? datetimeStringFromISOString(value) : '-'),
     sortable: false,
   },
   {
     field: 'endTimestamp',
     headerName: 'End Time',
-    width: 180,
+    width: 160,
     valueFormatter: ({ value }) => (value ? datetimeStringFromISOString(value) : '-'),
+    sortable: false,
+  },
+  {
+    field: 'numRecordsSynced',
+    headerName: '# Synced',
+    width: 90,
     sortable: false,
   },
   {

--- a/openapi/v1/mgmt/components/schemas/sync_history.yaml
+++ b/openapi/v1/mgmt/components/schemas/sync_history.yaml
@@ -34,6 +34,10 @@ properties:
       - SUCCESS
       - IN_PROGRESS
       - FAILURE
+  num_records_synced:
+    type: number
+    nullable: true
+    example: 100
 required:
   - model_name
   - start_timestamp

--- a/openapi/v1/mgmt/openapi.bundle.json
+++ b/openapi/v1/mgmt/openapi.bundle.json
@@ -2013,6 +2013,11 @@
               "IN_PROGRESS",
               "FAILURE"
             ]
+          },
+          "num_records_synced": {
+            "type": "number",
+            "nullable": true,
+            "example": 100
           }
         },
         "required": [

--- a/openapi/v2/mgmt/components/schemas/sync_history.yaml
+++ b/openapi/v2/mgmt/components/schemas/sync_history.yaml
@@ -34,6 +34,10 @@ properties:
       - SUCCESS
       - IN_PROGRESS
       - FAILURE
+  num_records_synced:
+    type: number
+    nullable: true
+    example: 100
 required:
   - model_name
   - start_timestamp

--- a/openapi/v2/mgmt/openapi.bundle.json
+++ b/openapi/v2/mgmt/openapi.bundle.json
@@ -1999,6 +1999,11 @@
               "IN_PROGRESS",
               "FAILURE"
             ]
+          },
+          "num_records_synced": {
+            "type": "number",
+            "nullable": true,
+            "example": 100
           }
         },
         "required": [

--- a/packages/core/mappers/sync_history.ts
+++ b/packages/core/mappers/sync_history.ts
@@ -10,6 +10,7 @@ export const fromSyncHistoryModelAndSync = ({
   startTimestamp,
   endTimestamp,
   sync,
+  numRecordsSynced,
 }: SyncHistoryModelExpanded): SyncHistory => {
   const { connection } = sync;
   const { applicationId, externalCustomerId } = parseCustomerIdPk(connection.customerId);
@@ -26,5 +27,6 @@ export const fromSyncHistoryModelAndSync = ({
     customerId: externalCustomerId,
     providerName: connection.providerName,
     category: connection.category as 'crm',
+    numRecordsSynced,
   };
 };

--- a/packages/core/services/sync_history_service.ts
+++ b/packages/core/services/sync_history_service.ts
@@ -78,10 +78,12 @@ export class SyncHistoryService {
     historyId,
     status,
     errorMessage,
+    numRecordsSynced,
   }: {
     historyId: string;
     status: SyncHistoryStatus;
     errorMessage?: string;
+    numRecordsSynced: number | null;
   }): Promise<void> {
     await this.update({
       id: historyId,
@@ -89,6 +91,7 @@ export class SyncHistoryService {
         status,
         errorMessage: errorMessage ?? null,
         endTimestamp: new Date(),
+        numRecordsSynced,
       },
     });
   }
@@ -111,6 +114,7 @@ export class SyncHistoryService {
         errorMessage: null,
         startTimestamp: new Date(),
         endTimestamp: null,
+        numRecordsSynced: null,
       },
     });
     return historyId;

--- a/packages/db/prisma/migrations/20230606204005_sync_history_num_records_synced/migration.sql
+++ b/packages/db/prisma/migrations/20230606204005_sync_history_num_records_synced/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "sync_history" ADD COLUMN     "num_records_synced" INTEGER;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -460,16 +460,17 @@ model SyncChange {
 }
 
 model SyncHistory {
-  id             String    @id @default(uuid())
-  syncId         String    @map("sync_id")
-  sync           Sync      @relation(fields: [syncId], references: [id], onDelete: Cascade)
+  id               String    @id @default(uuid())
+  syncId           String    @map("sync_id")
+  sync             Sync      @relation(fields: [syncId], references: [id], onDelete: Cascade)
   // contact, lead, account, opportunity, etc.
-  model          String
+  model            String
   // SUCCESS | ERROR | IN_PROGRESS
-  status         String
-  errorMessage   String?   @map("error_message")
-  startTimestamp DateTime  @map("start_timestamp")
-  endTimestamp   DateTime? @map("end_timestamp")
+  status           String
+  errorMessage     String?   @map("error_message")
+  startTimestamp   DateTime  @map("start_timestamp")
+  endTimestamp     DateTime? @map("end_timestamp")
+  numRecordsSynced Int?      @map("num_records_synced")
 
   @@map("sync_history")
 }

--- a/packages/schemas/gen/v1/mgmt.ts
+++ b/packages/schemas/gen/v1/mgmt.ts
@@ -382,6 +382,8 @@ export interface components {
       connection_id: string;
       /** @enum {string} */
       status: "SUCCESS" | "IN_PROGRESS" | "FAILURE";
+      /** @example 100 */
+      num_records_synced?: number | null;
     };
     force_sync: {
       /** @example true */

--- a/packages/schemas/gen/v2/mgmt.ts
+++ b/packages/schemas/gen/v2/mgmt.ts
@@ -376,6 +376,8 @@ export interface components {
       connection_id: string;
       /** @enum {string} */
       status: "SUCCESS" | "IN_PROGRESS" | "FAILURE";
+      /** @example 100 */
+      num_records_synced?: number | null;
     };
     force_sync: {
       /** @example true */

--- a/packages/sync-workflows/activities/log_sync_finish.ts
+++ b/packages/sync-workflows/activities/log_sync_finish.ts
@@ -12,6 +12,7 @@ export function createLogSyncFinish({ syncHistoryService }: { syncHistoryService
     status,
     errorMessage,
     errorStack,
+    numRecordsSynced,
   }: {
     syncId: string;
     connectionId: string;
@@ -19,8 +20,9 @@ export function createLogSyncFinish({ syncHistoryService }: { syncHistoryService
     status: SyncHistoryStatus;
     errorMessage?: string;
     errorStack?: string;
+    numRecordsSynced: number | null;
   }) {
-    await syncHistoryService.logFinish({ historyId, status, errorMessage });
+    await syncHistoryService.logFinish({ historyId, status, errorMessage, numRecordsSynced });
     if (status === 'FAILURE') {
       const error = new Error(errorMessage);
       error.stack = errorStack;

--- a/packages/sync-workflows/workflows/run_managed_sync.ts
+++ b/packages/sync-workflows/workflows/run_managed_sync.ts
@@ -98,6 +98,7 @@ export async function runManagedSync({ syncId, connectionId, category }: RunMana
           status: 'FAILURE',
           errorMessage,
           errorStack,
+          numRecordsSynced: null,
         });
         await maybeSendSyncFinishWebhook({
           historyId: historyIdsMap[commonModel],
@@ -120,14 +121,22 @@ export async function runManagedSync({ syncId, connectionId, category }: RunMana
 
   await Promise.all(
     getCommonModels(category).map(async (commonModel) => {
-      await logSyncFinish({ syncId, connectionId, historyId: historyIdsMap[commonModel], status: 'SUCCESS' });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore `numRecordsSyncedMap` is indeed defined here
+      const numRecordsSynced = numRecordsSyncedMap[commonModel];
+
+      await logSyncFinish({
+        syncId,
+        connectionId,
+        historyId: historyIdsMap[commonModel],
+        status: 'SUCCESS',
+        numRecordsSynced,
+      });
       await maybeSendSyncFinishWebhook({
         historyId: historyIdsMap[commonModel],
         status: 'SYNC_SUCCESS',
         connectionId,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore `numRecordsSyncedMap` is indeed defined here
-        numRecordsSynced: numRecordsSyncedMap[commonModel],
+        numRecordsSynced,
         commonModel,
       });
     })

--- a/packages/sync-workflows/workflows/run_sync.ts
+++ b/packages/sync-workflows/workflows/run_sync.ts
@@ -89,6 +89,7 @@ export async function runSync({ syncId, connectionId, category }: RunSyncArgs): 
           status: 'FAILURE',
           errorMessage,
           errorStack,
+          numRecordsSynced: null,
         });
         await maybeSendSyncFinishWebhook({
           historyId: historyIdsMap[commonModel],
@@ -111,14 +112,22 @@ export async function runSync({ syncId, connectionId, category }: RunSyncArgs): 
 
   await Promise.all(
     getCommonModels(category).map(async (commonModel) => {
-      await logSyncFinish({ syncId, connectionId, historyId: historyIdsMap[commonModel], status: 'SUCCESS' });
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore `numRecordsSyncedMap` is indeed defined here
+      const numRecordsSynced = numRecordsSyncedMap[commonModel];
+
+      await logSyncFinish({
+        syncId,
+        connectionId,
+        historyId: historyIdsMap[commonModel],
+        status: 'SUCCESS',
+        numRecordsSynced,
+      });
       await maybeSendSyncFinishWebhook({
         historyId: historyIdsMap[commonModel],
         status: 'SYNC_SUCCESS',
         connectionId,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore `numRecordsSyncedMap` is indeed defined here
-        numRecordsSynced: numRecordsSyncedMap[commonModel],
+        numRecordsSynced,
         commonModel,
       });
     })

--- a/packages/types/sync_history.ts
+++ b/packages/types/sync_history.ts
@@ -16,6 +16,7 @@ export type SyncHistory = {
   providerName: string;
   category: 'crm';
   connectionId: string;
+  numRecordsSynced: number | null;
 };
 
 export type SyncHistoryUpsertParams = {
@@ -24,6 +25,7 @@ export type SyncHistoryUpsertParams = {
   errorMessage: string | null;
   startTimestamp: Date;
   endTimestamp: Date | null;
+  numRecordsSynced: number | null;
 };
 
 export type SyncHistoryFilter = SyncInfoFilter & {


### PR DESCRIPTION
- `num_records_synced` for each sync, `null` is for start of sync and remains such if it fails, otherwise the number of records is used (same value used for the webhook payload)

<img width="1357" alt="Screenshot 2023-06-06 at 3 00 44 PM" src="https://github.com/supaglue-labs/supaglue/assets/471516/048afa9e-37c7-4db5-8754-219bf425088e">


## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
