### PR TITLE
chore: use new temporal instead of temporalite

### DIFF
--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -48,4 +48,4 @@ services:
     volumes:
       - .:/app
     working_dir: /app
-    command: /bin/sh -c "yarn workspace @supaglue/db prisma migrate dev && yarn workspace @supaglue/db prisma db seed && yarn workspace api init-temporal"
+    command: /bin/sh -c "yarn workspace @supaglue/db prisma migrate dev && yarn workspace @supaglue/db prisma db seed"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,12 +81,20 @@ services:
     restart: on-failure
 
   temporal:
-    image: slamdev/temporalite:0.3.0 # TODO: we should replace this with one hosted by us later
+    image: alpine:3.18.0
     ports:
       - 7233:7233
       - 8233:8233
-    entrypoint: temporalite start -n default --ip 0.0.0.0 -f /data/temporal.db
     restart: on-failure
+    command: 
+      - /bin/sh
+      - -c
+      - |
+        apk add --update curl
+        rm -rf /var/cache/apk/*
+        curl -sSf https://temporal.download/cli.sh | sh
+        /root/.temporalio/bin/temporal operator search-attribute create --name SyncId --type Keyword --name ApplicationId --type Keyword --name CustomerId --type Keyword --name IntegrationId --type Keyword --name ConnectionId --type Keyword --name ProviderCategory --type Keyword --name ProviderName --type Keyword
+        /root/.temporalio/bin/temporal server start-dev -n default --ip 0.0.0.0 -f /data/temporal.db
     volumes:
       - temporalitedata:/data
 
@@ -114,7 +122,7 @@ services:
         condition: service_started
     volumes:
       - .env:/app/.env
-    command: sh -c 'npx prisma migrate deploy && node node_modules/@supaglue/db/prisma/seed.js && node init_scripts/init_temporal.js'
+    command: sh -c 'npx prisma migrate deploy && node node_modules/@supaglue/db/prisma/seed.js'
 
 volumes:
   pgdata:


### PR DESCRIPTION
temporalite is being deprecated

ideally, we should just `brew install temporal` and use that, but that makes it harder to start up, since we can't just run `docker compose up` and need to run another script too.

Thoughts?

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
