### PR TITLE
chore: reverting back to temporalite

### DIFF
--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -48,17 +48,4 @@ services:
     volumes:
       - .:/app
     working_dir: /app
-    command:
-      - sh 
-      - -c
-      - |
-        yarn workspace @supaglue/db prisma migrate dev
-        yarn workspace @supaglue/db prisma db seed
-        curl -sSf https://temporal.download/cli.sh | sh
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name SyncId --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name ApplicationId --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name CustomerId --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name IntegrationId --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name ConnectionId --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name ProviderCategory --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name ProviderName --type Keyword
+    command: /bin/sh -c "yarn workspace @supaglue/db prisma migrate dev && yarn workspace @supaglue/db prisma db seed"

--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -48,4 +48,4 @@ services:
     volumes:
       - .:/app
     working_dir: /app
-    command: /bin/sh -c "yarn workspace @supaglue/db prisma migrate dev && yarn workspace @supaglue/db prisma db seed"
+    command: /bin/sh -c "yarn workspace @supaglue/db prisma migrate dev && yarn workspace @supaglue/db prisma db seed && yarn workspace api init-temporal"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,7 @@ services:
         apk add --update curl
         rm -rf /var/cache/apk/*
         curl -sSf https://temporal.download/cli.sh | sh
+        /root/.temporalio/bin/temporal operator search-attribute create --name SyncId --type Keyword --name ApplicationId --type Keyword --name CustomerId --type Keyword --name IntegrationId --type Keyword --name ConnectionId --type Keyword --name ProviderCategory --type Keyword --name ProviderName --type Keyword
         /root/.temporalio/bin/temporal server start-dev -n default --ip 0.0.0.0 -f /data/temporal.db
     volumes:
       - temporalitedata:/data
@@ -121,22 +122,7 @@ services:
         condition: service_started
     volumes:
       - .env:/app/.env
-    command:
-      - sh
-      - -c
-      - |
-        npx prisma migrate deploy
-        node node_modules/@supaglue/db/prisma/seed.js
-        apk add --update curl
-        rm -rf /var/cache/apk/*
-        curl -sSf https://temporal.download/cli.sh | sh
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name SyncId --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name ApplicationId --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name CustomerId --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name IntegrationId --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name ConnectionId --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name ProviderCategory --type Keyword
-        /root/.temporalio/bin/temporal operator search-attribute create --address temporal:7233 --name ProviderName --type Keyword
+    command: sh -c 'npx prisma migrate deploy && node node_modules/@supaglue/db/prisma/seed.js'
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,20 +81,12 @@ services:
     restart: on-failure
 
   temporal:
-    image: alpine:3.18.0
+    image: slamdev/temporalite:0.3.0 # TODO: we should replace this with one hosted by us later
     ports:
       - 7233:7233
       - 8233:8233
+    entrypoint: temporalite start -n default --ip 0.0.0.0 -f /data/temporal.db
     restart: on-failure
-    command: 
-      - /bin/sh
-      - -c
-      - |
-        apk add --update curl
-        rm -rf /var/cache/apk/*
-        curl -sSf https://temporal.download/cli.sh | sh
-        /root/.temporalio/bin/temporal operator search-attribute create --name SyncId --type Keyword --name ApplicationId --type Keyword --name CustomerId --type Keyword --name IntegrationId --type Keyword --name ConnectionId --type Keyword --name ProviderCategory --type Keyword --name ProviderName --type Keyword
-        /root/.temporalio/bin/temporal server start-dev -n default --ip 0.0.0.0 -f /data/temporal.db
     volumes:
       - temporalitedata:/data
 
@@ -122,7 +114,7 @@ services:
         condition: service_started
     volumes:
       - .env:/app/.env
-    command: sh -c 'npx prisma migrate deploy && node node_modules/@supaglue/db/prisma/seed.js'
+    command: sh -c 'npx prisma migrate deploy && node node_modules/@supaglue/db/prisma/seed.js && node init_scripts/init_temporal.js'
 
 volumes:
   pgdata:


### PR DESCRIPTION
Ran into this issue while going through quickstart. In dev override, we use `node:18` image and have no issues with apk, curl, etc. However, for normal quickstart, we use the built `api` image, which apparently doesn't have these tools for us to download temporal and apply search attributes.

```
supaglue2-init-1  |     └─ migration.sql
supaglue2-init-1  |       
supaglue2-init-1  | All migrations have been successfully applied.
supaglue2-init-1  | npm notice 
supaglue2-init-1  | npm notice New minor version of npm available! 9.5.1 -> 9.7.1
supaglue2-init-1  | npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.7.1>
supaglue2-init-1  | npm notice Run `npm install -g npm@9.7.1` to update!
supaglue2-init-1  | npm notice 
supaglue2-init-1  | sh: 3: apk: not found
supaglue2-init-1  | sh: 5: curl: not found
supaglue2-init-1  | sh: 6: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 7: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 8: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 9: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 10: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 11: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 12: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | Environment variables loaded from .env
supaglue2-init-1  | Prisma schema loaded from prisma/schema.prisma
supaglue2-init-1  | Datasource "db": PostgreSQL database "postgres", schema "api" at "postgres:5432"
supaglue2-init-1  | 
supaglue2-init-1  | 59 migrations found in prisma/migrations
supaglue2-init-1  | 
supaglue2-init-1  | 
supaglue2-init-1  | No pending migrations to apply.
supaglue2-init-1  | sh: 3: apk: not found
supaglue2-init-1  | sh: 5: curl: not found
supaglue2-init-1  | sh: 6: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 7: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 8: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 9: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 10: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 11: /root/.temporalio/bin/temporal: Permission denied
supaglue2-init-1  | sh: 12: /root/.temporalio/bin/temporal: Permission denied
```

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
