### PR TITLE
chore(cleanup): remove unused remote_id superseded by instance_url

### DIFF
--- a/apps/api/routes/oauth.ts
+++ b/apps/api/routes/oauth.ts
@@ -196,19 +196,16 @@ export default function init(app: Router): void {
       });
 
       let instanceUrl = (tokenWrapper.token['instance_url'] as string) ?? '';
-      let remoteId = instanceUrl ?? '';
 
       if (providerName === 'hubspot') {
         const accessToken = tokenWrapper.token['access_token'] as string;
         const hubspotClient = new HubspotClient({ accessToken: tokenWrapper.token['access_token'] as string });
         const { hubId } = await hubspotClient.oauth.accessTokensApi.getAccessToken(accessToken);
-        remoteId = hubId.toString();
-        instanceUrl = `https://app.hubspot.com/contacts/${remoteId}`;
+        instanceUrl = `https://app.hubspot.com/contacts/${hubId.toString()}`;
       }
 
       if (providerName === 'pipedrive') {
         instanceUrl = tokenWrapper.token.api_domain as string;
-        remoteId = instanceUrl;
       }
 
       if (providerName === 'ms_dynamics_365_sales') {
@@ -226,7 +223,6 @@ export default function init(app: Router): void {
           refreshToken: tokenWrapper.token['refresh_token'] as string,
           expiresAt: (tokenWrapper.token['expires_at'] as string | undefined) ?? null,
         },
-        remoteId,
         instanceUrl,
       };
 

--- a/apps/api/services/connection_and_sync_service.ts
+++ b/apps/api/services/connection_and_sync_service.ts
@@ -81,7 +81,6 @@ export class ConnectionAndSyncService {
         customerId,
         integrationId: integration.id,
         status,
-        remoteId: params.remoteId,
         credentials: await encrypt(JSON.stringify(params.credentials)),
       },
       update: {
@@ -90,7 +89,6 @@ export class ConnectionAndSyncService {
         customerId,
         integrationId: integration.id,
         status,
-        remoteId: params.remoteId,
         credentials: await encrypt(JSON.stringify(params.credentials)),
       },
       where: {
@@ -134,7 +132,6 @@ export class ConnectionAndSyncService {
             customerId: getCustomerIdPk(params.applicationId, params.customerId),
             integrationId: integration.id,
             status,
-            remoteId: params.remoteId,
             instanceUrl: params.instanceUrl,
             credentials: await encrypt(JSON.stringify(params.credentials)),
           },

--- a/openapi/v1/mgmt/components/schemas/objects/connection.yaml
+++ b/openapi/v1/mgmt/components/schemas/objects/connection.yaml
@@ -24,11 +24,6 @@ properties:
     $ref: ./provider_name.yaml
   category:
     $ref: ./category.yaml
-  remote_id:
-    type: string
-    description: For Hubspot, this is the account ID of the connected customer. For Salesforce, this is the instance URL.
-    example: 123456
-    deprecated: true
   instance_url:
     type: string
     description: Instance URL for the connected customer.
@@ -41,5 +36,4 @@ required:
   - integration_id
   - provider_name
   - category
-  - remote_id
   - instance_url

--- a/openapi/v1/mgmt/openapi.bundle.json
+++ b/openapi/v1/mgmt/openapi.bundle.json
@@ -1580,12 +1580,6 @@
           "category": {
             "$ref": "#/components/schemas/category"
           },
-          "remote_id": {
-            "type": "string",
-            "description": "For Hubspot, this is the account ID of the connected customer. For Salesforce, this is the instance URL.",
-            "example": 123456,
-            "deprecated": true
-          },
           "instance_url": {
             "type": "string",
             "description": "Instance URL for the connected customer.",
@@ -1600,7 +1594,6 @@
           "integration_id",
           "provider_name",
           "category",
-          "remote_id",
           "instance_url"
         ]
       },

--- a/packages/core/mappers/connection.ts
+++ b/packages/core/mappers/connection.ts
@@ -19,7 +19,6 @@ export async function fromConnectionModelToConnectionUnsafe<T extends ProviderNa
   providerName,
   status,
   credentials,
-  remoteId,
   instanceUrl,
 }: ConnectionModel): Promise<ConnectionUnsafe<T>> {
   const { applicationId, externalCustomerId } = parseCustomerIdPk(customerId);
@@ -33,7 +32,6 @@ export async function fromConnectionModelToConnectionUnsafe<T extends ProviderNa
     status: status as ConnectionStatus,
     providerName: providerName as T,
     credentials: JSON.parse(await decrypt(credentials)),
-    remoteId,
     instanceUrl,
   };
 }
@@ -46,7 +44,6 @@ export function fromConnectionModelToConnectionSafe({
   providerId,
   providerName,
   status,
-  remoteId,
   instanceUrl,
 }: ConnectionModel): ConnectionSafeAny {
   const { applicationId, externalCustomerId } = parseCustomerIdPk(customerId);
@@ -59,7 +56,6 @@ export function fromConnectionModelToConnectionSafe({
     category: category as 'crm',
     status: status as ConnectionStatus,
     providerName: providerName as CRMProviderName,
-    remoteId,
     instanceUrl,
   };
 }

--- a/packages/db/prisma/migrations/20230613033542_remove_remote_id/migration.sql
+++ b/packages/db/prisma/migrations/20230613033542_remove_remote_id/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `remote_id` on the `connections` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "connections" DROP COLUMN "remote_id";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -125,8 +125,6 @@ model Connection {
   credentials   Bytes // encrypted, {type, access_token, refresh_token, expires_at, raw}
   customer      Customer    @relation(fields: [customerId], references: [id], onDelete: Cascade)
   customerId    String      @map("customer_id")
-  /// Deprecated
-  remoteId      String      @map("remote_id")
   instanceUrl   String      @default("") @map("instance_url")
   createdAt     DateTime    @default(now()) @map("created_at")
   updatedAt     DateTime    @updatedAt @map("updated_at")

--- a/packages/schemas/gen/v1/mgmt.ts
+++ b/packages/schemas/gen/v1/mgmt.ts
@@ -234,12 +234,6 @@ export interface components {
       provider_name: components["schemas"]["provider_name"];
       category: components["schemas"]["category"];
       /**
-       * @deprecated 
-       * @description For Hubspot, this is the account ID of the connected customer. For Salesforce, this is the instance URL. 
-       * @example 123456
-       */
-      remote_id: string;
-      /**
        * @description Instance URL for the connected customer. 
        * @example https://app.hubspot.com/contacts/123456
        */

--- a/packages/types/connection.ts
+++ b/packages/types/connection.ts
@@ -35,8 +35,6 @@ export type ConnectionCreateParams<T extends ProviderName> = {
   category: CategoryOfProviderName<T>;
   providerName: T;
   credentials: ConnectionCredentialsDecrypted<T>;
-  // Deprecated -- use instanceUrl instead
-  remoteId: string;
   instanceUrl: string;
 };
 


### PR DESCRIPTION
I was touching oauth code earlier today. Verified remote_id isn't being used so removing.

[Describe your change here]

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
