### PR TITLE
feat(mgmt-ui): add profile and team mgmt for cloud

### DIFF
--- a/apps/mgmt-ui/src/components/AccountMenu/index.tsx
+++ b/apps/mgmt-ui/src/components/AccountMenu/index.tsx
@@ -1,12 +1,34 @@
+import { useNextLambdaEnv } from '@/hooks/useNextLambdaEnv';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import { Link as MUILink, ListItemIcon, MenuItem } from '@mui/material';
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Menu from '@mui/material/Menu';
 import Tooltip from '@mui/material/Tooltip';
+import NextLink from 'next/link';
 import * as React from 'react';
 import { Logout } from '../Logout';
 
+function Profile() {
+  return (
+    <MUILink
+      href="https://accounts.supaglue.io/user"
+      component={NextLink}
+      sx={{ color: 'inherit', textDecoration: 'inherit' }}
+    >
+      <MenuItem>
+        <ListItemIcon>
+          <AccountCircleIcon />
+        </ListItemIcon>
+        Profile
+      </MenuItem>
+    </MUILink>
+  );
+}
+
 export default function AccountMenu() {
+  const { nextLambdaEnv } = useNextLambdaEnv();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -66,6 +88,7 @@ export default function AccountMenu() {
         transformOrigin={{ horizontal: 'right', vertical: 'top' }}
         anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
       >
+        {nextLambdaEnv?.IS_CLOUD ? <Profile /> : null}
         <Logout />
       </Menu>
     </React.Fragment>

--- a/apps/mgmt-ui/src/hooks/useNextLambdaEnv.ts
+++ b/apps/mgmt-ui/src/hooks/useNextLambdaEnv.ts
@@ -2,7 +2,10 @@ import useSWR from 'swr';
 import { fetcher } from '.';
 
 export function useNextLambdaEnv() {
-  const { data, error, isLoading, ...rest } = useSWR(`/api/internal/env`, fetcher<{ API_HOST: string }>);
+  const { data, error, isLoading, ...rest } = useSWR(
+    `/api/internal/env`,
+    fetcher<{ API_HOST: string; IS_CLOUD: boolean }>
+  );
 
   return {
     nextLambdaEnv: data,

--- a/apps/mgmt-ui/src/layout/Navigator.tsx
+++ b/apps/mgmt-ui/src/layout/Navigator.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import ApplicationMenu from '@/components/ApplicationMenu';
 import { useActiveApplicationId } from '@/hooks/useActiveApplicationId';
+import { useNextLambdaEnv } from '@/hooks/useNextLambdaEnv';
 import { Biotech, FindInPage, MenuBook, Tune } from '@mui/icons-material';
 import HomeIcon from '@mui/icons-material/Home';
+import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
 import PeopleIcon from '@mui/icons-material/People';
 import {
   Box,
@@ -37,6 +39,7 @@ const item = {
 export default function Navigator(props: DrawerProps) {
   const { ...other } = props;
 
+  const { nextLambdaEnv } = useNextLambdaEnv();
   const applicationId = useActiveApplicationId();
 
   const categories: {
@@ -70,6 +73,16 @@ export default function Navigator(props: DrawerProps) {
           icon: <FindInPage />,
           active: false,
         },
+        ...(nextLambdaEnv?.IS_CLOUD
+          ? [
+              {
+                id: 'Team Settings',
+                to: 'https://accounts.supaglue.io/organization',
+                icon: <ManageAccountsIcon />,
+                active: false,
+              },
+            ]
+          : []),
       ],
     },
     {

--- a/apps/mgmt-ui/src/pages/api/internal/env.ts
+++ b/apps/mgmt-ui/src/pages/api/internal/env.ts
@@ -1,8 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { API_HOST } from '..';
+import { API_HOST, IS_CLOUD } from '..';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse<{ API_HOST: string }>) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ API_HOST: string; IS_CLOUD: boolean }>
+) {
   return res.status(200).json({
     API_HOST,
+    IS_CLOUD,
   });
 }


### PR DESCRIPTION
- use clerk hosted pages for profile and team mgmt on cloud


https://github.com/supaglue-labs/supaglue/assets/471516/37467397-bd82-4800-a8a7-b326c96c07b8



## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
