### PR TITLE
fix: enable prisma to generate query engine for debian

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-arm64-openssl-3.0.x"]
+  binaryTargets = ["native", "linux-arm64-openssl-3.0.x", "debian-openssl-3.0.x", "debian-openssl-1.1.x"]
 }
 
 datasource db {


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->
On Ubuntu 20.04, I was experiencing [this issue](https://stackoverflow.com/questions/74773917/prisma-query-engine-library-for-current-platform-debian-openssl-1-1-x-could-no) when running the project locally with `docker-compose up` on the v0.9.7 tag. This adds binaryTargets for debian-base systems so prisma generates query engines for that system.

Validated by building and running the images on my previously broken machine.