### PR TITLE
docs: add default admin credentials to quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ git clone -b v0.9.8 https://github.com/supaglue-labs/supaglue.git && cd supaglue
 docker compose up
 ```
 
+The default login credentials are `username: admin` and `password: admin`. Alternatively, you can set the `ADMIN_PASSWORD` environment variable in the `.env` file created by `./scripts/create_quickstart_env.sh`.
+
 ## Features
 
 Supaglue offers 3 main ways to integrate with your customers' providers.

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -45,6 +45,8 @@ docker compose up
 
 Once Supaglue is running locally, open the [management portal](http://localhost:3000) in your browser.
 
+The default login credentials are `username: admin` and `password: admin`. Alternatively, use the value of the `ADMIN_PASSWORD` environment variable in the `.env` file if you modified it.
+
 </TabItem>
 
 </Tabs>


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

When following the quickstart documentation, you're instructed to go to the management UI after `docker-compose up`, but the default admin credentials aren't listed anywhere that I could see. This adds knowledge of the defaults, as well as information on how to modify the defaults if you wish.