### PR TITLE
chore: oncall alert cleanup

### DIFF
--- a/packages/core/lib/webhook.ts
+++ b/packages/core/lib/webhook.ts
@@ -30,7 +30,7 @@ export const maybeSendWebhookPayload = async (
     });
   } catch (e) {
     // TODO: Don't swallow this error.
-    logger.error(e, 'Failed to send webhook');
+    logger.warn(e, 'Failed to send webhook');
   }
 };
 

--- a/packages/core/mappers/application.ts
+++ b/packages/core/mappers/application.ts
@@ -1,10 +1,11 @@
 import type { Application as ApplicationModel } from '@supaglue/db';
 import { Application, ApplicationConfig } from '@supaglue/types';
 
-export const fromApplicationModel = ({ id, name, config, orgId }: ApplicationModel): Application => {
+export const fromApplicationModel = ({ id, name, environment, config, orgId }: ApplicationModel): Application => {
   return {
     id,
     name,
+    environment,
     config: config as ApplicationConfig,
     orgId,
   };

--- a/packages/db/prisma/migrations/20230621214425_application_environment/migration.sql
+++ b/packages/db/prisma/migrations/20230621214425_application_environment/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "applications" ADD COLUMN     "environment" TEXT NOT NULL DEFAULT 'production';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Application {
   createdAt   DateTime      @default(now()) @map("created_at")
   updatedAt   DateTime      @updatedAt @map("updated_at")
   orgId       String        @map("org_id")
+  environment String        @default("production")
   Customer    Customer[]
   Destination Destination[]
   Provider    Provider[]

--- a/packages/types/application.ts
+++ b/packages/types/application.ts
@@ -2,6 +2,7 @@ import { WebhookConfig } from './webhook';
 
 type BaseApplication = {
   name: string;
+  environment: string;
   config: ApplicationConfig;
 };
 


### PR DESCRIPTION
- add `environment` field to application
- lower webhook from error to warn
- warn on sync failures for `environment` === `development` (i'll set this for certain customer applications)

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
