### PR TITLE
feat(mgmt-ui): Enable deleting providers and sync configs

### DIFF
--- a/apps/api/routes/internal/index.ts
+++ b/apps/api/routes/internal/index.ts
@@ -14,7 +14,7 @@ import syncHistory from './sync_history';
 import syncInfo from './sync_info';
 import webhook from './webhook';
 
-const { prisma, connectionAndSyncService } = getDependencyContainer();
+const { prisma } = getDependencyContainer();
 
 export default function init(app: Router): void {
   // application routes should not require application header

--- a/apps/mgmt-ui/src/client.ts
+++ b/apps/mgmt-ui/src/client.ts
@@ -14,13 +14,6 @@ import type {
 } from '@supaglue/types';
 import { snakecaseKeys, snakecaseKeysSansHeaders } from '@supaglue/utils/snakecase';
 
-export type ClientResponse<T> = {
-  ok: boolean;
-  status: number;
-  statusText: string;
-  result: T;
-};
-
 export async function createRemoteApiKey(applicationId: string): Promise<{ api_key: string }> {
   const result = await fetch(`/api/internal/api_keys/create`, {
     method: 'POST',

--- a/apps/mgmt-ui/src/client.ts
+++ b/apps/mgmt-ui/src/client.ts
@@ -14,7 +14,12 @@ import type {
 } from '@supaglue/types';
 import { snakecaseKeys, snakecaseKeysSansHeaders } from '@supaglue/utils/snakecase';
 
-// TODO: use Supaglue TS client
+export type ClientResponse<T> = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  result: T;
+};
 
 export async function createRemoteApiKey(applicationId: string): Promise<{ api_key: string }> {
   const result = await fetch(`/api/internal/api_keys/create`, {
@@ -94,6 +99,18 @@ export async function updateRemoteProvider(applicationId: string, data: Provider
   return r;
 }
 
+export async function deleteProvider(applicationId: string, providerId: string) {
+  const result = await fetch(`/api/internal/providers/${providerId}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-application-id': applicationId,
+    },
+  });
+  const r = await result.json();
+  return r;
+}
+
 export async function createSyncConfig(applicationId: string, data: SyncConfigCreateParams): Promise<SyncConfig> {
   const result = await fetch(`/api/internal/sync-configs/create`, {
     method: 'POST',
@@ -120,6 +137,16 @@ export async function updateSyncConfig(applicationId: string, data: SyncConfig):
 
   const r = await result.json();
   return r;
+}
+
+export async function deleteSyncConfig(applicationId: string, syncConfigId: string): Promise<void> {
+  await fetch(`/api/internal/sync-configs/${syncConfigId}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-application-id': applicationId,
+    },
+  });
 }
 
 export async function createDestination(data: DestinationCreateParams): Promise<Destination> {

--- a/apps/mgmt-ui/src/components/configuration/provider/DeleteProviderButton.tsx
+++ b/apps/mgmt-ui/src/components/configuration/provider/DeleteProviderButton.tsx
@@ -1,0 +1,55 @@
+import { useNotification } from '@/context/notification';
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
+import { useState } from 'react';
+
+export type DeleteProviderButtonProps = {
+  providerName: string;
+  onDelete: () => void;
+};
+
+export function DeleteProviderButton({ providerName, onDelete }: DeleteProviderButtonProps) {
+  const { addNotification } = useNotification();
+  const [open, setOpen] = useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Button variant="text" color="error" onClick={handleClickOpen} size="small">
+        Delete
+      </Button>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>Delete Provider</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete{' '}
+            <Typography fontWeight="bold" display="inline">
+              provider for {providerName}
+            </Typography>
+            ?
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ justifyContent: 'space-between', padding: '16px 24px' }}>
+          <Button
+            variant="text"
+            color="error"
+            onClick={() => {
+              onDelete();
+              addNotification({ message: `Successfully removed ${providerName} provider`, severity: 'success' });
+              handleClose();
+            }}
+          >
+            Delete
+          </Button>
+          <Button onClick={handleClose}>Cancel</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/mgmt-ui/src/components/configuration/syncConfig/DeleteSyncConfig.tsx
+++ b/apps/mgmt-ui/src/components/configuration/syncConfig/DeleteSyncConfig.tsx
@@ -1,0 +1,56 @@
+import { useNotification } from '@/context/notification';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, Typography } from '@mui/material';
+import { useState } from 'react';
+
+export type DeleteSyncConfigProps = {
+  syncConfigId: string;
+  onDelete: () => void;
+};
+
+export function DeleteSyncConfig({ syncConfigId, onDelete }: DeleteSyncConfigProps) {
+  const { addNotification } = useNotification();
+  const [open, setOpen] = useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <IconButton className="p-1" onClick={handleClickOpen} size="small">
+        <DeleteIcon />
+      </IconButton>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>Delete Sync Config</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete{' '}
+            <Typography fontWeight="bold" display="inline">
+              Sync Config {syncConfigId}
+            </Typography>
+            ?
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ justifyContent: 'space-between', padding: '16px 24px' }}>
+          <Button
+            variant="text"
+            color="error"
+            onClick={() => {
+              onDelete();
+              addNotification({ message: 'Successfully removed Sync Config', severity: 'success' });
+              handleClose();
+            }}
+          >
+            Delete
+          </Button>
+          <Button onClick={handleClose}>Cancel</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/mgmt-ui/src/components/configuration/syncConfig/SyncConfigListPanel.tsx
+++ b/apps/mgmt-ui/src/components/configuration/syncConfig/SyncConfigListPanel.tsx
@@ -1,9 +1,10 @@
+import { deleteSyncConfig } from '@/client';
 import MetricCard from '@/components/MetricCard';
 import Spinner from '@/components/Spinner';
 import { useActiveApplicationId } from '@/hooks/useActiveApplicationId';
 import { useDestinations } from '@/hooks/useDestinations';
 import { useProviders } from '@/hooks/useProviders';
-import { useSyncConfigs } from '@/hooks/useSyncConfigs';
+import { toGetSyncConfigsResponse, useSyncConfigs } from '@/hooks/useSyncConfigs';
 import getIcon from '@/utils/companyToIcon';
 import providerToIcon from '@/utils/providerToIcon';
 import { PeopleAltOutlined } from '@mui/icons-material';
@@ -11,9 +12,10 @@ import AddIcon from '@mui/icons-material/Add';
 import { Breadcrumbs, IconButton, Stack, Typography } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import Link from 'next/link';
+import { DeleteSyncConfig } from './DeleteSyncConfig';
 
 export default function SyncConfigListPanel() {
-  const { syncConfigs = [], isLoading } = useSyncConfigs();
+  const { syncConfigs = [], isLoading, mutate } = useSyncConfigs();
   const { providers = [], isLoading: isLoadingProviders } = useProviders();
   const { destinations = [], isLoading: isLoadingDestinations } = useDestinations();
   const applicationId = useActiveApplicationId();
@@ -88,6 +90,22 @@ export default function SyncConfigListPanel() {
       },
     },
     { field: 'frequency', headerName: 'Frequency', width: 250 },
+    {
+      field: '_',
+      headerName: 'Admin',
+      width: 100,
+      renderCell: (params) => {
+        return (
+          <DeleteSyncConfig
+            syncConfigId={params.row.id}
+            onDelete={async () => {
+              await deleteSyncConfig(applicationId, params.row.id);
+              await mutate(toGetSyncConfigsResponse(syncConfigs.filter((s) => s.id !== params.row.id)), false);
+            }}
+          />
+        );
+      },
+    },
   ];
 
   const rows = syncConfigs.map((syncConfig) => ({

--- a/apps/mgmt-ui/src/pages/api/internal/providers/[...providerId].ts
+++ b/apps/mgmt-ui/src/pages/api/internal/providers/[...providerId].ts
@@ -1,19 +1,40 @@
 import { getApplicationIdScopedHeaders } from '@/utils/headers';
-import { GetProvidersResponse } from '@supaglue/schemas/v2/mgmt';
+import { DeleteProviderResponse, GetProvidersResponse } from '@supaglue/schemas/v2/mgmt';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { API_HOST } from '../..';
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse<GetProvidersResponse | null>) {
-  const result = await fetch(`${API_HOST}/internal/providers/${req.query.providerId}`, {
-    method: 'GET',
-    headers: getApplicationIdScopedHeaders(req),
-  });
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GetProvidersResponse | DeleteProviderResponse | null>
+) {
+  switch (req.method) {
+    case 'GET': {
+      const result = await fetch(`${API_HOST}/internal/providers/${req.query.providerId}`, {
+        method: 'GET',
+        headers: getApplicationIdScopedHeaders(req),
+      });
 
-  if (!result.ok) {
-    return res.status(500).json(null);
+      if (!result.ok) {
+        return res.status(500).json(null);
+      }
+
+      const r = await result.json();
+
+      return res.status(200).json(r);
+    }
+    case 'DELETE': {
+      const result = await fetch(`${API_HOST}/internal/providers/${req.query.providerId}`, {
+        method: 'DELETE',
+        headers: getApplicationIdScopedHeaders(req),
+      });
+
+      if (!result.ok) {
+        return res.status(500).json(null);
+      }
+
+      const r = await result.json();
+
+      return res.status(204).send(r);
+    }
   }
-
-  const r = await result.json();
-
-  return res.status(200).json(r);
 }

--- a/apps/mgmt-ui/src/pages/api/internal/sync-configs/[...syncConfigId].ts
+++ b/apps/mgmt-ui/src/pages/api/internal/sync-configs/[...syncConfigId].ts
@@ -4,16 +4,32 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { API_HOST } from '../..';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<GetSyncConfigsResponse | null>) {
-  const result = await fetch(`${API_HOST}/internal/sync_configs/${req.query.syncConfigId}`, {
-    method: 'GET',
-    headers: getApplicationIdScopedHeaders(req),
-  });
+  switch (req.method) {
+    case 'GET': {
+      const result = await fetch(`${API_HOST}/internal/sync_configs/${req.query.syncConfigId}`, {
+        method: 'GET',
+        headers: getApplicationIdScopedHeaders(req),
+      });
 
-  if (!result.ok) {
-    return res.status(500).json(null);
+      if (!result.ok) {
+        return res.status(500).json(null);
+      }
+
+      const r = await result.json();
+
+      return res.status(200).json(r);
+    }
+    case 'DELETE': {
+      const result = await fetch(`${API_HOST}/internal/sync_configs/${req.query.syncConfigId}`, {
+        method: 'DELETE',
+        headers: getApplicationIdScopedHeaders(req),
+      });
+
+      if (!result.ok) {
+        return res.status(500).json(null);
+      }
+
+      return res.status(204).send(null);
+    }
   }
-
-  const r = await result.json();
-
-  return res.status(200).json(r);
 }

--- a/packages/core/services/sync_config_service.ts
+++ b/packages/core/services/sync_config_service.ts
@@ -135,6 +135,14 @@ export class SyncConfigService {
   }
 
   public async delete(id: string, applicationId: string): Promise<void> {
+    const syncs = await this.#prisma.sync.findMany({
+      where: {
+        syncConfigId: id,
+      },
+    });
+    if (syncs.length) {
+      throw new BadRequestError('Cannot delete sync config with active syncs');
+    }
     await this.#prisma.syncConfig.deleteMany({
       where: { id, applicationId },
     });


### PR DESCRIPTION
caveat: sometimes deleting providers and sync configs will fail (because there are existing connections). Because of how our nextjs proxy / client is written, we don't propagate this information to the FE so we don't know when the BE request fails. We need to fix this.

