### PR TITLE
chore: add field mapping for syncs

### DIFF
--- a/apps/api/routes/internal/sync_config/index.ts
+++ b/apps/api/routes/internal/sync_config/index.ts
@@ -35,11 +35,12 @@ export default function init(app: Router): void {
       const syncConfigs = await syncConfigService.list(req.supaglueApplication.id);
       return res.status(200).send(
         syncConfigs.map((syncConfig) => {
-          const { rawObjects, rawCustomObjects, ...rest } = syncConfig.config;
+          const { defaultConfig, rawObjects, rawCustomObjects, commonObjects } = syncConfig.config;
           return snakecaseKeys({
             ...syncConfig,
             config: {
-              ...rest,
+              defaultConfig,
+              commonObjects,
               standardObjects: rawObjects, // TODO: remove when we propogate `standardObjects` all the way through code
               customObjects: rawCustomObjects,
             },
@@ -55,18 +56,19 @@ export default function init(app: Router): void {
       req: Request<CreateSyncConfigPathParams, CreateSyncConfigResponse, CreateSyncConfigRequest>,
       res: Response<CreateSyncConfigResponse>
     ) => {
+      const { default_config, common_objects, standard_objects, custom_objects } = req.body.config;
       const syncConfig = await syncConfigService.create({
         applicationId: req.supaglueApplication.id,
         ...camelcaseKeys({
           ...req.body,
           config: {
-            ...req.body.config,
-            common_objects: req.body.config.common_objects?.map((commonObject) => ({
+            default_config,
+            common_objects: common_objects?.map((commonObject) => ({
               ...commonObject,
               object: commonObject.object as CommonModelType,
             })),
-            raw_objects: req.body.config.standard_objects,
-            raw_custom_objects: req.body.config.custom_objects,
+            raw_objects: standard_objects,
+            raw_custom_objects: custom_objects,
           },
         }),
       });
@@ -84,12 +86,13 @@ export default function init(app: Router): void {
         req.params.sync_config_id,
         req.supaglueApplication.id
       );
-      const { rawObjects, rawCustomObjects, ...rest } = syncConfig.config;
+      const { defaultConfig, commonObjects, rawObjects, rawCustomObjects } = syncConfig.config;
       return res.status(200).send(
         snakecaseKeys({
           ...syncConfig,
           config: {
-            ...rest,
+            defaultConfig,
+            commonObjects,
             standardObjects: rawObjects, // TODO: remove when we propogate `standardObjects` all the way through code
             customObjects: rawCustomObjects,
           },
@@ -104,27 +107,29 @@ export default function init(app: Router): void {
       req: Request<UpdateSyncConfigPathParams, UpdateSyncConfigResponse, UpdateSyncConfigRequest>,
       res: Response<UpdateSyncConfigResponse>
     ) => {
+      const { default_config, common_objects, standard_objects, custom_objects } = req.body.config;
       const syncConfig = await syncConfigService.update(req.params.sync_config_id, {
         applicationId: req.supaglueApplication.id,
         ...camelcaseKeys({
           ...req.body,
           config: {
-            ...req.body.config,
-            common_objects: req.body.config.common_objects?.map((commonObject) => ({
+            default_config,
+            common_objects: common_objects?.map((commonObject) => ({
               ...commonObject,
               object: commonObject.object as CommonModelType,
             })),
-            raw_objects: req.body.config.standard_objects,
-            raw_custom_objects: req.body.config.custom_objects,
+            raw_objects: standard_objects,
+            raw_custom_objects: custom_objects,
           },
         }),
       });
-      const { rawObjects, rawCustomObjects, ...rest } = syncConfig.config;
+      const { defaultConfig, commonObjects, rawObjects, rawCustomObjects } = syncConfig.config;
       return res.status(200).send(
         snakecaseKeys({
           ...syncConfig,
           config: {
-            ...rest,
+            defaultConfig,
+            commonObjects,
             standardObjects: rawObjects, // TODO: remove when we propogate `standardObjects` all the way through code
             customObjects: rawCustomObjects,
           },

--- a/apps/api/routes/mgmt/v2/customer/connection/index.ts
+++ b/apps/api/routes/mgmt/v2/customer/connection/index.ts
@@ -13,6 +13,7 @@ import {
 } from '@supaglue/schemas/v2/mgmt';
 import { snakecaseKeys } from '@supaglue/utils/snakecase';
 import { Request, Response, Router } from 'express';
+import sync from './sync';
 
 const { connectionService, connectionAndSyncService } = getDependencyContainer();
 
@@ -60,4 +61,9 @@ export default function init(app: Router): void {
   );
 
   app.use('/connections', connectionRouter);
+
+  const perConnectionRouter = Router({ mergeParams: true });
+
+  sync(perConnectionRouter);
+  connectionRouter.use('/:connection_id', perConnectionRouter);
 }

--- a/apps/api/routes/mgmt/v2/customer/connection/sync/index.ts
+++ b/apps/api/routes/mgmt/v2/customer/connection/sync/index.ts
@@ -1,0 +1,43 @@
+import { getDependencyContainer } from '@/dependency_container';
+import {
+  GetSyncPathParams,
+  GetSyncRequest,
+  GetSyncResponse,
+  UpdateSyncPathParams,
+  UpdateSyncRequest,
+  UpdateSyncResponse,
+} from '@supaglue/schemas/v2/mgmt';
+import { camelcaseKeys } from '@supaglue/utils/camelcase';
+import { snakecaseKeys } from '@supaglue/utils/snakecase';
+import { Request, Response, Router } from 'express';
+
+const { connectionAndSyncService } = getDependencyContainer();
+
+export default function init(app: Router): void {
+  const syncRouter = Router({ mergeParams: true });
+
+  syncRouter.get(
+    '/',
+    async (req: Request<GetSyncPathParams, GetSyncResponse, GetSyncRequest>, res: Response<GetSyncResponse>) => {
+      throw new Error('Not implemented');
+    }
+  );
+
+  // TODO: implement the version for `/:sync_id`
+
+  syncRouter.patch(
+    '/',
+    async (
+      req: Request<UpdateSyncPathParams, UpdateSyncResponse, UpdateSyncRequest>,
+      res: Response<UpdateSyncResponse>
+    ) => {
+      const sync = await connectionAndSyncService.updateSyncByConnectionId(
+        req.params.connection_id,
+        camelcaseKeys(req.body)
+      );
+      return res.status(200).send(snakecaseKeys(sync));
+    }
+  );
+
+  app.use('/sync', syncRouter);
+}

--- a/apps/api/routes/mgmt/v2/customer/connection/sync/index.ts
+++ b/apps/api/routes/mgmt/v2/customer/connection/sync/index.ts
@@ -1,5 +1,9 @@
 import { getDependencyContainer } from '@/dependency_container';
 import {
+  DisableSyncPathParams,
+  EnableSyncPathParams,
+  EnableSyncRequest,
+  EnableSyncResponse,
   GetSyncPathParams,
   GetSyncRequest,
   GetSyncResponse,
@@ -19,11 +23,26 @@ export default function init(app: Router): void {
   syncRouter.get(
     '/',
     async (req: Request<GetSyncPathParams, GetSyncResponse, GetSyncRequest>, res: Response<GetSyncResponse>) => {
-      throw new Error('Not implemented');
+      const sync = await connectionAndSyncService.getSyncByConnectionId(req.params.connection_id);
+      return res.status(200).send(snakecaseKeys(sync));
     }
   );
 
   // TODO: implement the version for `/:sync_id`
+
+  syncRouter.post(
+    '/',
+    async (
+      req: Request<EnableSyncPathParams, EnableSyncResponse, EnableSyncRequest>,
+      res: Response<EnableSyncResponse>
+    ) => {
+      const sync = await connectionAndSyncService.enableSyncByConnectionId(
+        req.params.connection_id,
+        camelcaseKeys(req.body)
+      );
+      return res.status(200).send(snakecaseKeys(sync));
+    }
+  );
 
   syncRouter.patch(
     '/',
@@ -38,6 +57,11 @@ export default function init(app: Router): void {
       return res.status(200).send(snakecaseKeys(sync));
     }
   );
+
+  syncRouter.delete('/', async (req: Request<DisableSyncPathParams>, res: Response) => {
+    await connectionAndSyncService.disableSyncByConnectionId(req.params.connection_id);
+    return res.status(204).send();
+  });
 
   app.use('/sync', syncRouter);
 }

--- a/apps/api/routes/mgmt/v2/sync_config/index.ts
+++ b/apps/api/routes/mgmt/v2/sync_config/index.ts
@@ -35,11 +35,12 @@ export default function init(app: Router): void {
       const syncConfigs = await syncConfigService.list(req.supaglueApplication.id);
       return res.status(200).send(
         syncConfigs.map((syncConfig) => {
-          const { rawObjects, rawCustomObjects, ...rest } = syncConfig.config;
+          const { defaultConfig, rawObjects, rawCustomObjects, commonObjects } = syncConfig.config;
           return snakecaseKeys({
             ...syncConfig,
             config: {
-              ...rest,
+              defaultConfig,
+              commonObjects,
               standardObjects: rawObjects, // TODO: remove when we propogate `standardObjects` all the way through code
               customObjects: rawCustomObjects,
             },
@@ -55,18 +56,19 @@ export default function init(app: Router): void {
       req: Request<CreateSyncConfigPathParams, CreateSyncConfigResponse, CreateSyncConfigRequest>,
       res: Response<CreateSyncConfigResponse>
     ) => {
+      const { default_config, common_objects, standard_objects, custom_objects } = req.body.config;
       const syncConfig = await syncConfigService.create({
         applicationId: req.supaglueApplication.id,
         ...camelcaseKeys({
           ...req.body,
           config: {
-            ...req.body.config,
-            common_objects: req.body.config.common_objects?.map((commonObject) => ({
+            default_config,
+            common_objects: common_objects?.map((commonObject) => ({
               ...commonObject,
               object: commonObject.object as CommonModelType,
             })),
-            raw_objects: req.body.config.standard_objects,
-            raw_custom_objects: req.body.config.custom_objects,
+            raw_objects: standard_objects,
+            raw_custom_objects: custom_objects,
           },
         }),
       });
@@ -84,12 +86,13 @@ export default function init(app: Router): void {
         req.params.sync_config_id,
         req.supaglueApplication.id
       );
-      const { rawObjects, rawCustomObjects, ...rest } = syncConfig.config;
+      const { defaultConfig, commonObjects, rawObjects, rawCustomObjects } = syncConfig.config;
       return res.status(200).send(
         snakecaseKeys({
           ...syncConfig,
           config: {
-            ...rest,
+            defaultConfig,
+            commonObjects,
             standardObjects: rawObjects, // TODO: remove when we propogate `standardObjects` all the way through code
             customObjects: rawCustomObjects,
           },
@@ -104,27 +107,29 @@ export default function init(app: Router): void {
       req: Request<UpdateSyncConfigPathParams, UpdateSyncConfigResponse, UpdateSyncConfigRequest>,
       res: Response<UpdateSyncConfigResponse>
     ) => {
+      const { default_config, common_objects, standard_objects, custom_objects } = req.body.config;
       const syncConfig = await syncConfigService.update(req.params.sync_config_id, {
         applicationId: req.supaglueApplication.id,
         ...camelcaseKeys({
           ...req.body,
           config: {
-            ...req.body.config,
-            common_objects: req.body.config.common_objects?.map((commonObject) => ({
+            default_config,
+            common_objects: common_objects?.map((commonObject) => ({
               ...commonObject,
               object: commonObject.object as CommonModelType,
             })),
-            raw_objects: req.body.config.standard_objects,
-            raw_custom_objects: req.body.config.custom_objects,
+            raw_objects: standard_objects,
+            raw_custom_objects: custom_objects,
           },
         }),
       });
-      const { rawObjects, rawCustomObjects, ...rest } = syncConfig.config;
+      const { defaultConfig, commonObjects, rawObjects, rawCustomObjects } = syncConfig.config;
       return res.status(200).send(
         snakecaseKeys({
           ...syncConfig,
           config: {
-            ...rest,
+            defaultConfig,
+            commonObjects,
             standardObjects: rawObjects, // TODO: remove when we propogate `standardObjects` all the way through code
             customObjects: rawCustomObjects,
           },

--- a/apps/api/services/connection_and_sync_service.ts
+++ b/apps/api/services/connection_and_sync_service.ts
@@ -126,7 +126,7 @@ export class ConnectionAndSyncService {
         });
         if (
           syncConfig &&
-          // TODO: when we migrate startSyncOnConnectionCreation to required, we can simplify this check
+          // TODO: when we migrate enableSyncOnConnectionCreation to be a required field, we can simplify this check
           (syncConfig.config.defaultConfig.enableSyncOnConnectionCreation === undefined ||
             syncConfig.config.defaultConfig.enableSyncOnConnectionCreation)
         ) {

--- a/apps/api/services/connection_and_sync_service.ts
+++ b/apps/api/services/connection_and_sync_service.ts
@@ -5,7 +5,7 @@ import { getCustomerIdPk } from '@supaglue/core/lib/customer_id';
 import { fromConnectionModelToConnectionUnsafe } from '@supaglue/core/mappers/connection';
 import { ApplicationService, ProviderService, SyncConfigService } from '@supaglue/core/services';
 import { ConnectionService } from '@supaglue/core/services/connection_service';
-import { PrismaClient, Sync as SyncModel } from '@supaglue/db';
+import { Prisma, PrismaClient, Sync as SyncModel } from '@supaglue/db';
 import { SYNC_TASK_QUEUE } from '@supaglue/sync-workflows/constants';
 import {
   processSyncChanges,
@@ -13,7 +13,15 @@ import {
   PROCESS_SYNC_CHANGES_WORKFLOW_ID,
 } from '@supaglue/sync-workflows/workflows/process_sync_changes';
 import { getRunManagedSyncScheduleId } from '@supaglue/sync-workflows/workflows/run_managed_sync';
-import type { ProviderName, Sync, SyncIdentifier, SyncState, SyncType } from '@supaglue/types';
+import type {
+  ProviderName,
+  SchemaMappingsConfig,
+  Sync,
+  SyncIdentifier,
+  SyncState,
+  SyncType,
+  SyncUpdateParams,
+} from '@supaglue/types';
 import type {
   ConnectionCreateParamsAny,
   ConnectionStatus,
@@ -116,14 +124,19 @@ export class ConnectionAndSyncService {
             credentials: await encrypt(JSON.stringify(params.credentials)),
           },
         });
-        if (syncConfig) {
+        if (
+          syncConfig &&
+          // TODO: when we migrate startSyncOnConnectionCreation to required, we can simplify this check
+          (syncConfig.config.defaultConfig.enableSyncOnConnectionCreation === undefined ||
+            syncConfig.config.defaultConfig.enableSyncOnConnectionCreation)
+        ) {
           await tx.sync.create({
             data: {
               id: syncId,
               connectionId,
-              syncConfigId: syncConfig?.id,
+              syncConfigId: syncConfig.id,
               strategy: {
-                type: syncConfig?.config.defaultConfig.strategy ?? 'full then incremental',
+                type: syncConfig.config.defaultConfig.strategy ?? 'full then incremental',
               },
               state: {
                 phase: 'created',
@@ -161,6 +174,18 @@ export class ConnectionAndSyncService {
         );
       }
     }
+  }
+
+  public async updateSyncByConnectionId(connectionId: string, params: SyncUpdateParams): Promise<Sync> {
+    const sync = await this.#prisma.sync.update({
+      where: {
+        connectionId,
+      },
+      data: {
+        schemaMappingsConfig: params.schemaMappingsConfig === null ? Prisma.DbNull : params.schemaMappingsConfig,
+      },
+    });
+    return fromSyncModel(sync);
   }
 
   public async delete(id: string, applicationId: string): Promise<void> {
@@ -548,5 +573,7 @@ function fromSyncModel(model: SyncModel): Sync {
     version: model.version,
     ...otherStrategyProps,
     state: model.state as SyncState,
+    paused: model.paused,
+    schemaMappingsConfig: model.schemaMappingsConfig as SchemaMappingsConfig | undefined,
   } as Sync;
 }

--- a/apps/mgmt-ui/src/components/configuration/syncConfig/SyncConfigDetailsPanel.tsx
+++ b/apps/mgmt-ui/src/components/configuration/syncConfig/SyncConfigDetailsPanel.tsx
@@ -126,7 +126,7 @@ function SyncConfigDetailsPanelImpl({ syncConfig, isLoading }: SyncConfigDetails
         defaultConfig: {
           periodMs: syncPeriodSecs ? syncPeriodSecs * 1000 : ONE_HOUR_SECONDS,
           strategy,
-          startSyncOnConnectionCreation: true,
+          enableSyncOnConnectionCreation: true,
         },
         commonObjects: commonObjects.map((object) => ({ object, fetchAllFieldsIntoRaw: true } as CommonObjectConfig)),
         rawObjects: standardObjects.map((object) => ({ object })),

--- a/openapi/v2/mgmt/components/schemas/objects/schema_mappings_config.yaml
+++ b/openapi/v2/mgmt/components/schemas/objects/schema_mappings_config.yaml
@@ -1,0 +1,24 @@
+type: object
+properties:
+  standard_objects:
+    type: array
+    items:
+      type: object
+      properties:
+        object:
+          type: string
+        field_mappings:
+          type: array
+          items:
+            type: object
+            properties:
+              schema_field:
+                type: string
+              mapped_field:
+                type: string
+            required:
+              - schema_field
+              - mapped_field
+      required:
+        - object
+        - field_mappings

--- a/openapi/v2/mgmt/components/schemas/objects/sync.yaml
+++ b/openapi/v2/mgmt/components/schemas/objects/sync.yaml
@@ -1,0 +1,24 @@
+type: object
+properties:
+  id:
+    type: string
+    example: 7a34a7bb-193a-4cca-ac16-63ef739995e1
+  connection_id:
+    type: string
+    example: 0a292508-d254-4929-98d3-dc23416efff8
+  sync_config_id:
+    type: string
+    example: ee2b63fa-edec-4875-b2f5-921d3b13ca83
+  force_sync_flag:
+    type: boolean
+    example: false
+  paused:
+    type: boolean
+    example: false
+  schema_mappings_config:
+    $ref: ./schema_mappings_config.yaml
+required:
+  - id
+  - connection_id
+  - force_sync_flag
+  - paused

--- a/openapi/v2/mgmt/components/schemas/objects/sync_config_data.yaml
+++ b/openapi/v2/mgmt/components/schemas/objects/sync_config_data.yaml
@@ -68,7 +68,7 @@ properties:
                 type:
                   type: string
                   enum:
-                    - inherited
+                    - inherit_all_fields
               required:
                 - type
       required:

--- a/openapi/v2/mgmt/components/schemas/objects/sync_config_data.yaml
+++ b/openapi/v2/mgmt/components/schemas/objects/sync_config_data.yaml
@@ -39,38 +39,24 @@ properties:
           type: string
           example: contacts
         schema:
-          oneOf:
-            - type: object
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - defined
-                fields:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      mapped_name:
-                        type: string
-                    required:
-                      - name
-                allow_additional_field_mappings:
-                  type: boolean
-              required:
-                - type
-                - fields
-                - allow_additional_field_mappings
-            - type: object
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - inherit_all_fields
-              required:
-                - type
+          type: object
+          properties:
+            fields:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  mapped_name:
+                    type: string
+                required:
+                  - name
+            allow_additional_field_mappings:
+              type: boolean
+          required:
+            - fields
+            - allow_additional_field_mappings
       required:
         - object
   custom_objects:

--- a/openapi/v2/mgmt/openapi.bundle.json
+++ b/openapi/v2/mgmt/openapi.bundle.json
@@ -2095,57 +2095,32 @@
                   "example": "contacts"
                 },
                 "schema": {
-                  "oneOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "defined"
-                          ]
-                        },
-                        "fields": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "mapped_name": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name"
-                            ]
+                  "type": "object",
+                  "properties": {
+                    "fields": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "mapped_name": {
+                            "type": "string"
                           }
                         },
-                        "allow_additional_field_mappings": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "type",
-                        "fields",
-                        "allow_additional_field_mappings"
-                      ]
+                        "required": [
+                          "name"
+                        ]
+                      }
                     },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "inherit_all_fields"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "type"
-                      ]
+                    "allow_additional_field_mappings": {
+                      "type": "boolean"
                     }
+                  },
+                  "required": [
+                    "fields",
+                    "allow_additional_field_mappings"
                   ]
                 }
               },

--- a/openapi/v2/mgmt/openapi.bundle.json
+++ b/openapi/v2/mgmt/openapi.bundle.json
@@ -1194,6 +1194,46 @@
           }
         }
       },
+      "post": {
+        "operationId": "enableSync",
+        "summary": "Enable sync",
+        "tags": [
+          "Syncs"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "schema_mappings_config": {
+                    "$ref": "#/components/schemas/sync/properties/schema_mappings_config"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sync enabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sync"
+                }
+              }
+            }
+          }
+        }
+      },
       "patch": {
         "operationId": "updateSync",
         "summary": "Update sync",
@@ -1262,6 +1302,23 @@
                 }
               }
             }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "disableSync",
+        "summary": "Disable sync",
+        "tags": [
+          "Syncs"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Sync"
           }
         }
       },

--- a/openapi/v2/mgmt/openapi.bundle.json
+++ b/openapi/v2/mgmt/openapi.bundle.json
@@ -1169,6 +1169,123 @@
         }
       ]
     },
+    "/customers/{customer_id}/connections/{connection_id}/sync": {
+      "get": {
+        "operationId": "getSync",
+        "summary": "Get sync",
+        "tags": [
+          "Syncs"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sync",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sync"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateSync",
+        "summary": "Update sync",
+        "tags": [
+          "Syncs"
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "schema_mappings_config": {
+                    "type": "object",
+                    "properties": {
+                      "standard_objects": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "object": {
+                              "type": "string"
+                            },
+                            "field_mappings": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "schema_field": {
+                                    "type": "string"
+                                  },
+                                  "mapped_field": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "schema_field",
+                                  "mapped_field"
+                                ]
+                              }
+                            }
+                          },
+                          "required": [
+                            "object",
+                            "field_mappings"
+                          ]
+                        }
+                      }
+                    },
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sync",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sync"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "customer_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "example": "0258cbc6-6020-430a-848e-aafacbadf4ae"
+          }
+        },
+        {
+          "name": "connection_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "example": "0258cbc6-6020-430a-848e-aafacbadf4ae"
+          }
+        }
+      ]
+    },
     "/webhook": {
       "get": {
         "operationId": "getWebhook",
@@ -2021,7 +2138,7 @@
                         "type": {
                           "type": "string",
                           "enum": [
-                            "inherited"
+                            "inherit_all_fields"
                           ]
                         }
                       },
@@ -2226,6 +2343,75 @@
         "type": "string",
         "enum": [
           "outreach"
+        ]
+      },
+      "sync": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "7a34a7bb-193a-4cca-ac16-63ef739995e1"
+          },
+          "connection_id": {
+            "type": "string",
+            "example": "0a292508-d254-4929-98d3-dc23416efff8"
+          },
+          "sync_config_id": {
+            "type": "string",
+            "example": "ee2b63fa-edec-4875-b2f5-921d3b13ca83"
+          },
+          "force_sync_flag": {
+            "type": "boolean",
+            "example": false
+          },
+          "paused": {
+            "type": "boolean",
+            "example": false
+          },
+          "schema_mappings_config": {
+            "type": "object",
+            "properties": {
+              "standard_objects": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "object": {
+                      "type": "string"
+                    },
+                    "field_mappings": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "schema_field": {
+                            "type": "string"
+                          },
+                          "mapped_field": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "schema_field",
+                          "mapped_field"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "object",
+                    "field_mappings"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "connection_id",
+          "force_sync_flag",
+          "paused"
         ]
       },
       "create_update_customer": {

--- a/openapi/v2/mgmt/openapi.yaml
+++ b/openapi/v2/mgmt/openapi.yaml
@@ -47,6 +47,8 @@ paths:
     $ref: paths/connections.yaml
   '/customers/{customer_id}/connections/{connection_id}':
     $ref: paths/connections@{connection_id}.yaml
+  '/customers/{customer_id}/connections/{connection_id}/sync':
+    $ref: paths/connections@{connection_id}@sync.yaml
   '/webhook':
     $ref: paths/webhook.yaml
   '/sync-history':
@@ -93,6 +95,8 @@ components:
       $ref: ./components/schemas/objects/provider_name_crm.yaml
     provider_name_engagement:
       $ref: ./components/schemas/objects/provider_name_engagement.yaml
+    sync:
+      $ref: ./components/schemas/objects/sync.yaml
     create_update_customer:
       $ref: ./components/schemas/create_update_customer.yaml
     create_provider:

--- a/openapi/v2/mgmt/paths/connections@{connection_id}@sync.yaml
+++ b/openapi/v2/mgmt/paths/connections@{connection_id}@sync.yaml
@@ -12,6 +12,30 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/objects/sync.yaml
+post:
+  operationId: enableSync
+  summary: Enable sync
+  tags:
+    - Syncs
+  parameters: []
+  security:
+    - ApiKeyAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            schema_mappings_config:
+              $ref: ../components/schemas/objects/schema_mappings_config.yaml
+  responses:
+    '200':
+      description: Sync enabled
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/objects/sync.yaml
 patch:
   operationId: updateSync
   summary: Update sync
@@ -62,6 +86,16 @@ patch:
         application/json:
           schema:
             $ref: ../components/schemas/objects/sync.yaml
+delete:
+  operationId: disableSync
+  summary: Disable sync
+  tags:
+    - Syncs
+  security:
+    - ApiKeyAuth: []
+  responses:
+    204:
+      description: Sync
 parameters:
   - name: customer_id
     in: path

--- a/openapi/v2/mgmt/paths/connections@{connection_id}@sync.yaml
+++ b/openapi/v2/mgmt/paths/connections@{connection_id}@sync.yaml
@@ -1,0 +1,77 @@
+get:
+  operationId: getSync
+  summary: Get sync
+  tags:
+    - Syncs
+  security:
+    - ApiKeyAuth: []
+  responses:
+    200:
+      description: Sync
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/objects/sync.yaml
+patch:
+  operationId: updateSync
+  summary: Update sync
+  tags:
+    - Syncs
+  parameters: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            schema_mappings_config:
+              # there is some issue with the openapi validator when using refs with nullable,
+              # so re-define the schema_mappings_config here instead of using ../components/schemas/objects/schema_mappings_config.yaml
+              # https://github.com/cdimascio/express-openapi-validator/issues/839
+              # https://github.com/ajv-validator/ajv/issues/1882
+              type: object
+              properties:
+                standard_objects:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      object:
+                        type: string
+                      field_mappings:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            schema_field:
+                              type: string
+                            mapped_field:
+                              type: string
+                          required:
+                            - schema_field
+                            - mapped_field
+                    required:
+                      - object
+                      - field_mappings
+              nullable: true
+  responses:
+    200:
+      description: Sync
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/objects/sync.yaml
+parameters:
+  - name: customer_id
+    in: path
+    required: true
+    schema:
+      type: string
+      example: 0258cbc6-6020-430a-848e-aafacbadf4ae
+  - name: connection_id
+    in: path
+    required: true
+    schema:
+      type: string
+      example: 0258cbc6-6020-430a-848e-aafacbadf4ae

--- a/packages/core/lib/schema.ts
+++ b/packages/core/lib/schema.ts
@@ -5,7 +5,7 @@ export function createFieldMappingConfig(
   schema?: RawObjectSchema,
   customerFieldMappings?: SchemaMappingsConfigStandardObjectFieldMapping[]
 ): FieldMappingConfig {
-  if (!schema || schema.type === 'inherit_all_fields') {
+  if (!schema) {
     return { type: 'inherit_all_fields' };
   }
 

--- a/packages/core/lib/schema.ts
+++ b/packages/core/lib/schema.ts
@@ -1,0 +1,69 @@
+import { RawObjectSchema, RawObjectSchemaField, SchemaMappingsConfigStandardObjectFieldMapping } from '@supaglue/types';
+import { FieldMappingConfig } from '@supaglue/types/field_mapping_config';
+
+export function createFieldMappingConfig(
+  schema?: RawObjectSchema,
+  customerFieldMappings?: SchemaMappingsConfigStandardObjectFieldMapping[]
+): FieldMappingConfig {
+  if (!schema || schema.type === 'inherit_all_fields') {
+    return { type: 'inherit_all_fields' };
+  }
+
+  const unmappedSchemaFields: RawObjectSchemaField[] = [];
+  const mappedSchemaFields: { name: string; mappedName: string }[] = [];
+
+  for (const field of schema.fields) {
+    if (field.mappedName) {
+      mappedSchemaFields.push({ name: field.name, mappedName: field.mappedName });
+    } else {
+      unmappedSchemaFields.push(field);
+    }
+  }
+
+  // Check that all fields in schema have a mapped field
+  for (const unmappedSchemaField of unmappedSchemaFields) {
+    const mappedField = customerFieldMappings?.find((field) => field.schemaField === unmappedSchemaField.name);
+    if (!mappedField) {
+      throw new Error(`No mapped field found for schema field ${unmappedSchemaField.name}`);
+    }
+  }
+
+  // Iterate over customer field mappings. Any fields that are not in the schema are only
+  // allowed if allowAdditionalFieldMappings is true.
+  for (const customerFieldMapping of customerFieldMappings ?? []) {
+    const correspondingSchemaField = schema.fields.find((field) => field.name === customerFieldMapping.schemaField);
+    if (correspondingSchemaField) {
+      // Don't allow setting of fields that are already set in the schema
+      if (correspondingSchemaField.mappedName) {
+        throw new Error(`Field ${correspondingSchemaField.name} is already mapped`);
+      }
+    } else {
+      // If the field is not in the schema, it's only allowed if allowAdditionalFieldMappings is true
+      if (!schema.allowAdditionalFieldMappings) {
+        throw new Error(`Field ${customerFieldMapping.schemaField} is not in the schema`);
+      }
+    }
+  }
+  if (
+    !schema.allowAdditionalFieldMappings &&
+    customerFieldMappings?.some(
+      (field) => !unmappedSchemaFields.find((schemaField) => schemaField.name === field.schemaField)
+    )
+  ) {
+    throw new Error('Additional field mappings are not allowed');
+  }
+
+  // Combine:
+  // 1. already-mapped schema fields
+  // 2. customer field mappings
+  return {
+    type: 'defined',
+    fieldMappings: [
+      ...mappedSchemaFields.map((field) => ({
+        schemaField: field.name,
+        mappedField: field.mappedName,
+      })),
+      ...(customerFieldMappings ?? []),
+    ],
+  };
+}

--- a/packages/core/remotes/crm/base.ts
+++ b/packages/core/remotes/crm/base.ts
@@ -8,6 +8,7 @@ import {
   CustomObjectRecordCreateParams,
   CustomObjectRecordUpdateParams,
 } from '@supaglue/types/crm/custom_object_record';
+import { FieldMappingConfig } from '@supaglue/types/field_mapping_config';
 import { EventEmitter } from 'events';
 import { Readable } from 'stream';
 import { AbstractRemoteClient, RemoteClient } from '../base';
@@ -15,7 +16,12 @@ import { AbstractRemoteClient, RemoteClient } from '../base';
 export interface CrmRemoteClient extends RemoteClient {
   category(): ProviderCategory;
 
-  listRawStandardObjectRecords(object: string, modifiedAfter?: Date, heartbeat?: () => void): Promise<Readable>;
+  listRawStandardObjectRecords(
+    object: string,
+    fieldMappingConfig: FieldMappingConfig,
+    modifiedAfter?: Date,
+    heartbeat?: () => void
+  ): Promise<Readable>;
   listRawCustomObjectRecords(object: string, modifiedAfter?: Date, heartbeat?: () => void): Promise<Readable>;
   listCommonObjectRecords(
     commonModelType: CRMCommonModelType,
@@ -66,6 +72,7 @@ export abstract class AbstractCrmRemoteClient extends AbstractRemoteClient imple
 
   public async listRawStandardObjectRecords(
     object: string,
+    fieldMappingConfig: FieldMappingConfig,
     modifiedAfter?: Date,
     heartbeat?: () => void
   ): Promise<Readable> {

--- a/packages/core/remotes/crm/ms_dynamics_365_sales/index.ts
+++ b/packages/core/remotes/crm/ms_dynamics_365_sales/index.ts
@@ -12,6 +12,7 @@ import {
   Opportunity,
   User,
 } from '@supaglue/types/crm';
+import { FieldMappingConfig } from '@supaglue/types/field_mapping_config';
 import { o, OHandler } from 'odata';
 import { plural } from 'pluralize';
 import querystring from 'querystring';
@@ -119,6 +120,7 @@ class MsDynamics365Sales extends AbstractCrmRemoteClient {
 
   public override async listRawStandardObjectRecords(
     object: string,
+    fieldMappingConfig: FieldMappingConfig,
     updatedAfter?: Date,
     heartbeat?: () => void
   ): Promise<Readable> {

--- a/packages/core/remotes/crm/salesforce/index.ts
+++ b/packages/core/remotes/crm/salesforce/index.ts
@@ -27,6 +27,7 @@ import {
   SendPassthroughRequestResponse,
   SyncConfig,
 } from '@supaglue/types';
+import { FieldMappingConfig } from '@supaglue/types/field_mapping_config';
 import retry from 'async-retry';
 import { parse } from 'csv-parse';
 import * as jsforce from 'jsforce';
@@ -258,6 +259,7 @@ ${modifiedAfter ? `WHERE SystemModstamp > ${modifiedAfter.toISOString()} ORDER B
 
   public override async listRawStandardObjectRecords(
     object: string,
+    fieldMappingConfig: FieldMappingConfig,
     modifiedAfter?: Date,
     heartbeat?: () => void
   ): Promise<Readable> {

--- a/packages/core/services/sync_config_service.ts
+++ b/packages/core/services/sync_config_service.ts
@@ -160,24 +160,18 @@ export const getDefaultCommonObjects = (
 const validateSyncConfigParams = (params: SyncConfigCreateParams | SyncConfigUpdateParams): void => {
   // Check that there are no duplicates
   const commonObjects = params.config.commonObjects?.map((object) => object.object) ?? [];
-  const rawStandardObjects = params.config.rawObjects?.map((object) => object.object) ?? [];
-  const rawCustomObjects = params.config.rawCustomObjects?.map((object) => object.object) ?? [];
+  const allRawObjects = [
+    ...(params.config.rawObjects?.map((object) => object.object) ?? []),
+    ...(params.config.rawCustomObjects?.map((object) => object.object) ?? []),
+  ];
 
   const commonObjectDuplicates = commonObjects.filter((object, index) => commonObjects.indexOf(object) !== index);
-  const rawStandardObjectDuplicates = rawStandardObjects.filter(
-    (object, index) => rawStandardObjects.indexOf(object) !== index
-  );
-  const rawCustomObjectDuplicates = rawCustomObjects.filter(
-    (object, index) => rawCustomObjects.indexOf(object) !== index
-  );
+  const allRawObjectDuplicates = allRawObjects.filter((object, index) => allRawObjects.indexOf(object) !== index);
 
   if (commonObjectDuplicates.length > 0) {
     throw new BadRequestError(`Duplicate common objects found: ${commonObjectDuplicates.join(', ')}`);
   }
-  if (rawStandardObjectDuplicates.length > 0) {
-    throw new BadRequestError(`Duplicate raw standard objects found: ${rawStandardObjectDuplicates.join(', ')}`);
-  }
-  if (rawCustomObjectDuplicates.length > 0) {
-    throw new BadRequestError(`Duplicate raw custom objects found: ${rawCustomObjectDuplicates.join(', ')}`);
+  if (allRawObjectDuplicates.length > 0) {
+    throw new BadRequestError(`Duplicate standard/custom objects found: ${allRawObjectDuplicates.join(', ')}`);
   }
 };

--- a/packages/db/prisma/migrations/20230621225824_schema_mappings_config/migration.sql
+++ b/packages/db/prisma/migrations/20230621225824_schema_mappings_config/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "syncs" ADD COLUMN     "schema_mappings_config" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -122,20 +122,21 @@ model Connection {
 }
 
 model Sync {
-  id              String        @id @default(uuid())
-  state           Json
-  forceSyncFlag   Boolean       @default(false) @map("force_sync_flag")
-  strategy        Json
-  connectionId    String        @unique @map("connection_id")
-  connection      Connection    @relation(fields: [connectionId], references: [id])
-  createdAt       DateTime      @default(now()) @map("created_at")
-  updatedAt       DateTime      @updatedAt @map("updated_at")
-  version         String        @default("v1")
-  paused          Boolean       @default(false)
-  syncConfigId    String?       @map("sync_config_id")
+  id                   String        @id @default(uuid())
+  state                Json
+  forceSyncFlag        Boolean       @default(false) @map("force_sync_flag")
+  strategy             Json
+  connectionId         String        @unique @map("connection_id")
+  connection           Connection    @relation(fields: [connectionId], references: [id])
+  createdAt            DateTime      @default(now()) @map("created_at")
+  updatedAt            DateTime      @updatedAt @map("updated_at")
+  version              String        @default("v1")
+  paused               Boolean       @default(false)
+  schemaMappingsConfig Json?         @map("schema_mappings_config")
+  syncConfigId         String?       @map("sync_config_id")
   // TODO: Eventually make this required
-  syncConfig      SyncConfig?   @relation(fields: [syncConfigId], references: [id])
-  syncHistoryList SyncHistory[]
+  syncConfig           SyncConfig?   @relation(fields: [syncConfigId], references: [id])
+  syncHistoryList      SyncHistory[]
 
   @@map("syncs")
 }

--- a/packages/schemas/gen/v2/mgmt.ts
+++ b/packages/schemas/gen/v2/mgmt.ts
@@ -120,6 +120,18 @@ export interface paths {
       };
     };
   };
+  "/customers/{customer_id}/connections/{connection_id}/sync": {
+    /** Get sync */
+    get: operations["getSync"];
+    /** Update sync */
+    patch: operations["updateSync"];
+    parameters: {
+      path: {
+        customer_id: string;
+        connection_id: string;
+      };
+    };
+  };
   "/webhook": {
     /**
      * Get webhook 
@@ -306,7 +318,7 @@ export interface components {
             allow_additional_field_mappings: boolean;
           }, {
             /** @enum {string} */
-            type: "inherited";
+            type: "inherit_all_fields";
           }]>;
         })[];
       custom_objects?: ({
@@ -392,6 +404,27 @@ export interface components {
     provider_name_crm: "hubspot" | "salesforce" | "pipedrive" | "zendesk_sell" | "ms_dynamics_365_sales" | "zoho_crm" | "capsule";
     /** @enum {string} */
     provider_name_engagement: "outreach";
+    sync: {
+      /** @example 7a34a7bb-193a-4cca-ac16-63ef739995e1 */
+      id: string;
+      /** @example 0a292508-d254-4929-98d3-dc23416efff8 */
+      connection_id: string;
+      /** @example ee2b63fa-edec-4875-b2f5-921d3b13ca83 */
+      sync_config_id?: string;
+      /** @example false */
+      force_sync_flag: boolean;
+      /** @example false */
+      paused: boolean;
+      schema_mappings_config?: {
+        standard_objects?: ({
+            object: string;
+            field_mappings: ({
+                schema_field: string;
+                mapped_field: string;
+              })[];
+          })[];
+      };
+    };
     create_update_customer: {
       /** @example your-customers-unique-application-id */
       customer_id: string;
@@ -863,6 +896,43 @@ export interface operations {
     responses: {
       /** @description Connection */
       204: never;
+    };
+  };
+  getSync: {
+    /** Get sync */
+    responses: {
+      /** @description Sync */
+      200: {
+        content: {
+          "application/json": components["schemas"]["sync"];
+        };
+      };
+    };
+  };
+  updateSync: {
+    /** Update sync */
+    requestBody: {
+      content: {
+        "application/json": {
+          schema_mappings_config?: {
+            standard_objects?: ({
+                object: string;
+                field_mappings: ({
+                    schema_field: string;
+                    mapped_field: string;
+                  })[];
+              })[];
+          } | null;
+        };
+      };
+    };
+    responses: {
+      /** @description Sync */
+      200: {
+        content: {
+          "application/json": components["schemas"]["sync"];
+        };
+      };
     };
   };
   getWebhook: {

--- a/packages/schemas/gen/v2/mgmt.ts
+++ b/packages/schemas/gen/v2/mgmt.ts
@@ -123,6 +123,10 @@ export interface paths {
   "/customers/{customer_id}/connections/{connection_id}/sync": {
     /** Get sync */
     get: operations["getSync"];
+    /** Enable sync */
+    post: operations["enableSync"];
+    /** Disable sync */
+    delete: operations["disableSync"];
     /** Update sync */
     patch: operations["updateSync"];
     parameters: {
@@ -902,6 +906,31 @@ export interface operations {
           "application/json": components["schemas"]["sync"];
         };
       };
+    };
+  };
+  enableSync: {
+    /** Enable sync */
+    requestBody: {
+      content: {
+        "application/json": {
+          schema_mappings_config?: components["schemas"]["sync"]["schema_mappings_config"];
+        };
+      };
+    };
+    responses: {
+      /** @description Sync enabled */
+      200: {
+        content: {
+          "application/json": components["schemas"]["sync"];
+        };
+      };
+    };
+  };
+  disableSync: {
+    /** Disable sync */
+    responses: {
+      /** @description Sync */
+      204: never;
     };
   };
   updateSync: {

--- a/packages/schemas/gen/v2/mgmt.ts
+++ b/packages/schemas/gen/v2/mgmt.ts
@@ -308,18 +308,13 @@ export interface components {
       standard_objects?: ({
           /** @example contacts */
           object: string;
-          schema?: OneOf<[{
-            /** @enum {string} */
-            type: "defined";
+          schema?: {
             fields: ({
                 name: string;
                 mapped_name?: string;
               })[];
             allow_additional_field_mappings: boolean;
-          }, {
-            /** @enum {string} */
-            type: "inherit_all_fields";
-          }]>;
+          };
         })[];
       custom_objects?: ({
           /** @example contacts */

--- a/packages/schemas/v2/mgmt.ts
+++ b/packages/schemas/v2/mgmt.ts
@@ -115,6 +115,19 @@ export type DeleteConnectionRequest = never;
 export type DeleteConnectionResponse =
   operations['deleteConnection']['responses'][keyof operations['deleteConnection']['responses']]['content']['application/json'];
 
+export type GetSyncPathParams =
+  paths['/customers/{customer_id}/connections/{connection_id}/sync']['parameters']['path'];
+export type GetSyncRequest = never;
+export type GetSyncResponse =
+  operations['getSync']['responses'][keyof operations['getSync']['responses']]['content']['application/json'];
+
+export type UpdateSyncPathParams =
+  paths['/customers/{customer_id}/connections/{connection_id}/sync']['parameters']['path'];
+export type UpdateSyncRequest =
+  operations['updateSync']['requestBody'][keyof operations['updateSync']['requestBody']]['application/json'];
+export type UpdateSyncResponse =
+  operations['updateSync']['responses'][keyof operations['updateSync']['responses']]['content']['application/json'];
+
 export type CreateWebhookPathParams = never;
 export type CreateWebhookRequest = operations['createWebhook']['requestBody']['content']['application/json'];
 export type CreateWebhookResponse =

--- a/packages/schemas/v2/mgmt.ts
+++ b/packages/schemas/v2/mgmt.ts
@@ -121,12 +121,25 @@ export type GetSyncRequest = never;
 export type GetSyncResponse =
   operations['getSync']['responses'][keyof operations['getSync']['responses']]['content']['application/json'];
 
+export type EnableSyncPathParams =
+  paths['/customers/{customer_id}/connections/{connection_id}/sync']['parameters']['path'];
+export type EnableSyncRequest =
+  operations['enableSync']['requestBody'][keyof operations['enableSync']['requestBody']]['application/json'];
+export type EnableSyncResponse =
+  operations['enableSync']['responses'][keyof operations['enableSync']['responses']]['content']['application/json'];
+
 export type UpdateSyncPathParams =
   paths['/customers/{customer_id}/connections/{connection_id}/sync']['parameters']['path'];
 export type UpdateSyncRequest =
   operations['updateSync']['requestBody'][keyof operations['updateSync']['requestBody']]['application/json'];
 export type UpdateSyncResponse =
   operations['updateSync']['responses'][keyof operations['updateSync']['responses']]['content']['application/json'];
+
+export type DisableSyncPathParams =
+  paths['/customers/{customer_id}/connections/{connection_id}/sync']['parameters']['path'];
+export type DisableSyncRequest = never;
+export type DisableSyncResponse =
+  operations['disableSync']['responses'][keyof operations['disableSync']['responses']]['content']['application/json'];
 
 export type CreateWebhookPathParams = never;
 export type CreateWebhookRequest = operations['createWebhook']['requestBody']['content']['application/json'];

--- a/packages/sync-workflows/activities/index.ts
+++ b/packages/sync-workflows/activities/index.ts
@@ -56,7 +56,9 @@ export const createActivities = ({
       connectionService,
       remoteService,
       destinationService,
-      applicationService
+      applicationService,
+      syncService,
+      syncConfigService
     ),
     logSyncStart: createLogSyncStart({ syncHistoryService }),
     logSyncFinish: createLogSyncFinish({ syncHistoryService, applicationService, connectionService }),

--- a/packages/sync-workflows/services/sync_service.ts
+++ b/packages/sync-workflows/services/sync_service.ts
@@ -34,6 +34,8 @@ function fromSyncModel(model: SyncModel): Sync {
     ...otherStrategyProps,
     state: model.state as SyncState,
     forceSyncFlag: model.forceSyncFlag,
+    paused: model.paused,
+    schemaMappingsConfig: model.schemaMappingsConfig,
   } as Sync;
 }
 

--- a/packages/types/field_mapping_config.ts
+++ b/packages/types/field_mapping_config.ts
@@ -1,0 +1,15 @@
+export type FieldMapping = {
+  schemaField: string;
+  mappedField: string;
+};
+
+export type InheritedFieldMappingConfig = {
+  type: 'inherit_all_fields';
+};
+
+export type DefinedFieldMappingConfig = {
+  type: 'defined';
+  fieldMappings: FieldMapping[];
+};
+
+export type FieldMappingConfig = InheritedFieldMappingConfig | DefinedFieldMappingConfig;

--- a/packages/types/sync.ts
+++ b/packages/types/sync.ts
@@ -39,6 +39,10 @@ export type FullOnlySync = BaseSync & {
 export type SyncType = 'full then incremental' | 'full only';
 export type Sync = FullThenIncrementalSync | FullOnlySync;
 
+export type SyncCreateParams = {
+  schemaMappingsConfig?: SchemaMappingsConfig;
+};
+
 export type SyncUpdateParams = {
   schemaMappingsConfig?: SchemaMappingsConfig | null;
 };

--- a/packages/types/sync.ts
+++ b/packages/types/sync.ts
@@ -8,18 +8,22 @@ type BaseSync = {
   syncConfigId?: string;
   forceSyncFlag: boolean; // flag: whether to transition a sync to the phase "created"
   version: 'v1' | 'v2';
-  // If this is undefined, we treat it as "false" to be backwards compatible.
-  // TODO: This should be required
-  paused?: boolean;
-  schemaMappingsConfig?: {
-    standardObjects?: {
-      object: string;
-      fieldMappings: {
-        schemaField: string; // my_first_column
-        mappedField: string; // blah_1
-      }[];
-    }[];
-  };
+  paused: boolean;
+  schemaMappingsConfig?: SchemaMappingsConfig;
+};
+
+export type SchemaMappingsConfig = {
+  standardObjects?: SchemaMappingsConfigStandardObject[];
+};
+
+export type SchemaMappingsConfigStandardObject = {
+  object: string;
+  fieldMappings: SchemaMappingsConfigStandardObjectFieldMapping[];
+};
+
+export type SchemaMappingsConfigStandardObjectFieldMapping = {
+  schemaField: string; // my_first_column
+  mappedField: string; // blah_1
 };
 
 export type FullThenIncrementalSync = BaseSync & {
@@ -34,6 +38,10 @@ export type FullOnlySync = BaseSync & {
 
 export type SyncType = 'full then incremental' | 'full only';
 export type Sync = FullThenIncrementalSync | FullOnlySync;
+
+export type SyncUpdateParams = {
+  schemaMappingsConfig?: SchemaMappingsConfig | null;
+};
 
 export type CRMNumCommonRecordsSyncedMap = {
   [K in CRMCommonModelType]?: number;

--- a/packages/types/sync_config.ts
+++ b/packages/types/sync_config.ts
@@ -37,17 +37,10 @@ export type RawObjectConfig = {
   schema?: RawObjectSchema;
 };
 
-export type RawObjectInheritedSchema = {
-  type: 'inherit_all_fields';
-};
-
-export type RawObjectDefinedSchema = {
-  type: 'defined';
+export type RawObjectSchema = {
   fields: RawObjectSchemaField[];
   allowAdditionalFieldMappings: boolean;
 };
-
-export type RawObjectSchema = RawObjectInheritedSchema | RawObjectDefinedSchema;
 
 export type RawObjectSchemaField = {
   name: string; // my_first_column

--- a/packages/types/sync_config.ts
+++ b/packages/types/sync_config.ts
@@ -23,7 +23,7 @@ export type SyncStrategyConfig = {
   strategy: SyncType;
   // When this is undefined, we treat it as "true" to be backwards compatible.
   // TODO: When we have time, migrate this to be a required field.
-  startSyncOnConnectionCreation?: boolean;
+  enableSyncOnConnectionCreation?: boolean;
 };
 
 export type CommonObjectConfig = {
@@ -38,7 +38,7 @@ export type RawObjectConfig = {
 };
 
 export type RawObjectInheritedSchema = {
-  type: 'inherited';
+  type: 'inherit_all_fields';
 };
 
 export type RawObjectDefinedSchema = {


### PR DESCRIPTION
- Developer can define schema
- Customer can choose how to map to schema
- Developer can enable/disable sync (distinct from pause/unpause... that isn't implemented yet)

Example config for `SyncConfig`:

```
{
    "application_id": "f72c1b96-38fc-42ca-a82a-68e81f3cbebc",
    "provider_id": "c92b0374-7c4f-42fe-9506-65c7e297dcbc",
    "destination_id": "59ab3dc1-a51a-4bb8-bf36-99c0c4757713",
    "config": {
        "common_objects": [],
        "default_config": {
            "period_ms": 3600000,
            "strategy": "full then incremental"
        },
        "standard_objects": [
            {
                "object": "company",
                "schema": {
                    "type": "defined",
                    "fields": [
                        {
                            "name": "new_name",
                            "mapped_name": "name"
                        },
                        {
                            "name": "new_city",
                            "mapped_name": "city"
                        },
                        {
                            "name": "best_time"
                        }
                    ],
                    "allow_additional_field_mappings": true
                }
            }
        ],
        "custom_objects": [
            {
                "object": "trucks"
            }
        ]
    }
}
```

Example config for `Sync`'s `schema_mappings_config`:
```
{
    "schema_mappings_config": {
        "standard_objects": [
            {
                "object": "company",
                "field_mappings": [
                    {
                        "schema_field": "best_time",
                        "mapped_field": "hs_lastmodifieddate"
                    }
                ]
            }
        ]
    }
}
```

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
