### PR TITLE
chore: make sync_config_id required

### DIFF
--- a/packages/db/prisma/migrations/20230622192846_required_sync_config_id/migration.sql
+++ b/packages/db/prisma/migrations/20230622192846_required_sync_config_id/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Made the column `sync_config_id` on table `syncs` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "syncs" DROP CONSTRAINT "syncs_sync_config_id_fkey";
+
+-- AlterTable
+ALTER TABLE "syncs" ALTER COLUMN "sync_config_id" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "syncs" ADD CONSTRAINT "syncs_sync_config_id_fkey" FOREIGN KEY ("sync_config_id") REFERENCES "sync_configs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -132,9 +132,8 @@ model Sync {
   updatedAt            DateTime      @updatedAt @map("updated_at")
   paused               Boolean       @default(false)
   schemaMappingsConfig Json?         @map("schema_mappings_config")
-  syncConfigId         String?       @map("sync_config_id")
-  // TODO: Eventually make this required
-  syncConfig           SyncConfig?   @relation(fields: [syncConfigId], references: [id])
+  syncConfigId         String        @map("sync_config_id")
+  syncConfig           SyncConfig    @relation(fields: [syncConfigId], references: [id])
   syncHistoryList      SyncHistory[]
 
   @@map("syncs")

--- a/packages/sync-workflows/services/sync_service.ts
+++ b/packages/sync-workflows/services/sync_service.ts
@@ -283,7 +283,7 @@ export class SyncService {
         [TEMPORAL_CUSTOM_SEARCH_ATTRIBUTES.APPLICATION_ID]: [connection.applicationId],
         [TEMPORAL_CUSTOM_SEARCH_ATTRIBUTES.CUSTOMER_ID]: [connection.customerId],
         [TEMPORAL_CUSTOM_SEARCH_ATTRIBUTES.PROVIDER_ID]: [connection.providerId],
-        [TEMPORAL_CUSTOM_SEARCH_ATTRIBUTES.SYNC_CONFIG_ID]: [sync.syncConfigId ?? ''],
+        [TEMPORAL_CUSTOM_SEARCH_ATTRIBUTES.SYNC_CONFIG_ID]: [sync.syncConfigId],
         [TEMPORAL_CUSTOM_SEARCH_ATTRIBUTES.CONNECTION_ID]: [connection.id],
         [TEMPORAL_CUSTOM_SEARCH_ATTRIBUTES.PROVIDER_CATEGORY]: [connection.category],
         [TEMPORAL_CUSTOM_SEARCH_ATTRIBUTES.PROVIDER_NAME]: [connection.providerName],

--- a/packages/types/sync.ts
+++ b/packages/types/sync.ts
@@ -4,8 +4,7 @@ import { EngagementCommonModelType } from './engagement';
 type BaseSync = {
   id: string;
   connectionId: string;
-  // TODO: This should be required
-  syncConfigId?: string;
+  syncConfigId: string;
   forceSyncFlag: boolean; // flag: whether to transition a sync to the phase "created"
   paused: boolean;
   schemaMappingsConfig?: SchemaMappingsConfig;


### PR DESCRIPTION
Confirmed this is safe to push in prod and staging:
```
supaglue=> select * from syncs where sync_config_id is null;
(0 rows)
```