### PR TITLE
chore: downgrade prisma

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,12 +6,12 @@
   "index": "dist/index.js",
   "types": "index.ts",
   "dependencies": {
-    "@prisma/client": "^4.16.1",
+    "@prisma/client": "^4.12.0",
     "dotenv": "^16.0.3"
   },
   "devDependencies": {
     "@tsconfig/node18": "^1.0.1",
-    "prisma": "^4.16.1",
+    "prisma": "^4.12.0",
     "tsx": "^3.12.3",
     "typescript": "^4.9.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5012,7 +5012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/client@npm:^4.16.1":
+"@prisma/client@npm:^4.12.0":
   version: 4.16.1
   resolution: "@prisma/client@npm:4.16.1"
   dependencies:
@@ -5593,10 +5593,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@supaglue/db@workspace:packages/db"
   dependencies:
-    "@prisma/client": ^4.16.1
+    "@prisma/client": ^4.12.0
     "@tsconfig/node18": ^1.0.1
     dotenv: ^16.0.3
-    prisma: ^4.16.1
+    prisma: ^4.12.0
     tsx: ^3.12.3
     typescript: ^4.9.5
   languageName: unknown
@@ -16360,7 +16360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prisma@npm:^4.16.1":
+"prisma@npm:^4.12.0":
   version: 4.16.1
   resolution: "prisma@npm:4.16.1"
   dependencies:


### PR DESCRIPTION
Upgrading didn't fix the connection issues, so try downgrading to the version we used before the 0.11.0 release.