### PR TITLE
chore: refactor modals

### DIFF
--- a/apps/api/routes/mgmt/v2/webhook/index.ts
+++ b/apps/api/routes/mgmt/v2/webhook/index.ts
@@ -59,7 +59,6 @@ export default function init(app: Router): void {
       await applicationService.update(req.supaglueApplication.id, req.supaglueApplication.orgId, {
         config: { ...req.supaglueApplication.config, webhook: null },
       });
-      // TODO: Figure out why typing doesn't work here
       return res.status(200).send();
     }
   );

--- a/apps/mgmt-ui/src/components/ApplicationMenu/index.tsx
+++ b/apps/mgmt-ui/src/components/ApplicationMenu/index.tsx
@@ -226,7 +226,6 @@ function UpdateApplicationMenuItem({
           <Button
             onClick={() => {
               onUpdateApplicationName(application.id, applicationName);
-              // TODO: error state
               handleClose();
             }}
           >
@@ -298,7 +297,6 @@ function DeleteApplicationMenuItem({
             disabled={application.name !== applicationName}
             onClick={() => {
               onDeleteApplication(application.id);
-              // TODO: error state
               handleClose();
             }}
           >
@@ -354,8 +352,6 @@ function NewApplication({ onCreate }: { onCreate: (name: string) => void }) {
           <Button
             onClick={() => {
               onCreate(applicationName);
-              // TODO: error state
-              // TODO: Validate application name (e.g. empty)
               handleClose();
             }}
           >

--- a/apps/mgmt-ui/src/components/configuration/ApiKeyTabPanel.tsx
+++ b/apps/mgmt-ui/src/components/configuration/ApiKeyTabPanel.tsx
@@ -45,6 +45,7 @@ export default function ApiKeyTabPanel() {
               if (!response.ok) {
                 return addNotification({ message: response.errorMessage, severity: 'error' });
               }
+              addNotification({ message: 'Successfully regenerated API Key', severity: 'success' });
               setDidRegenerate(true);
               setApiKey(response.data.api_key);
             }}

--- a/apps/mgmt-ui/src/components/configuration/DeleteWebhook.tsx
+++ b/apps/mgmt-ui/src/components/configuration/DeleteWebhook.tsx
@@ -1,6 +1,6 @@
-import { useNotification } from '@/context/notification';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
+import { Button } from '@mui/material';
 import { useState } from 'react';
+import { DeleteConfirmationModal } from '../modals';
 
 export type DeleteWebhookProps = {
   disabled: boolean;
@@ -8,7 +8,6 @@ export type DeleteWebhookProps = {
 };
 
 export function DeleteWebhook({ disabled, onDelete }: DeleteWebhookProps) {
-  const { addNotification } = useNotification();
   const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
@@ -25,28 +24,13 @@ export function DeleteWebhook({ disabled, onDelete }: DeleteWebhookProps) {
         Delete
       </Button>
 
-      <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>Delete webhook</DialogTitle>
-        <DialogContent>
-          <Typography>Are you sure you want to delete this webhook?</Typography>
-        </DialogContent>
-        <DialogActions sx={{ justifyContent: 'space-between', padding: '16px 24px' }}>
-          <Button
-            variant="text"
-            color="error"
-            onClick={() => {
-              onDelete();
-              addNotification({ message: 'Successfully deleted webhook', severity: 'success' });
-              handleClose();
-            }}
-          >
-            Delete
-          </Button>
-          <Button variant="contained" onClick={handleClose}>
-            Cancel
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <DeleteConfirmationModal
+        open={open}
+        handleClose={handleClose}
+        onDelete={onDelete}
+        title="Delete webhook"
+        resourceName="this webhook"
+      />
     </>
   );
 }

--- a/apps/mgmt-ui/src/components/configuration/DeleteWebhook.tsx
+++ b/apps/mgmt-ui/src/components/configuration/DeleteWebhook.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@mui/material';
 import { useState } from 'react';
-import { DeleteConfirmationModal } from '../modals';
+import { DeleteResourceConfirmationModal } from '../modals';
 
 export type DeleteWebhookProps = {
   disabled: boolean;
@@ -24,7 +24,7 @@ export function DeleteWebhook({ disabled, onDelete }: DeleteWebhookProps) {
         Delete
       </Button>
 
-      <DeleteConfirmationModal
+      <DeleteResourceConfirmationModal
         open={open}
         handleClose={handleClose}
         onDelete={onDelete}

--- a/apps/mgmt-ui/src/components/configuration/RegenerateApiKey.tsx
+++ b/apps/mgmt-ui/src/components/configuration/RegenerateApiKey.tsx
@@ -29,8 +29,9 @@ export function RegenerateApiKey({ disabled, onConfirm }: RegenerateApiKeyProps)
         title="Regenerate API Key"
         handleClose={handleClose}
         onConfirm={onConfirm}
-        cancelVariant="contained"
-        confirmVariant="text"
+        cancelVariant="text"
+        confirmVariant="contained"
+        confirmColor="error"
         content={
           <Typography>Are you sure you want to regenerate this API Key? This will revoke the existing key.</Typography>
         }

--- a/apps/mgmt-ui/src/components/configuration/RegenerateApiKey.tsx
+++ b/apps/mgmt-ui/src/components/configuration/RegenerateApiKey.tsx
@@ -1,6 +1,6 @@
-import { useNotification } from '@/context/notification';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import { useState } from 'react';
+import { ConfirmationModal } from '../modals';
 
 export type RegenerateApiKeyProps = {
   disabled: boolean;
@@ -8,7 +8,6 @@ export type RegenerateApiKeyProps = {
 };
 
 export function RegenerateApiKey({ disabled, onConfirm }: RegenerateApiKeyProps) {
-  const { addNotification } = useNotification();
   const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
@@ -25,27 +24,17 @@ export function RegenerateApiKey({ disabled, onConfirm }: RegenerateApiKeyProps)
         Regenerate
       </Button>
 
-      <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>Regenerate API Key</DialogTitle>
-        <DialogContent>
+      <ConfirmationModal
+        open={open}
+        title="Regenerate API Key"
+        handleClose={handleClose}
+        onConfirm={onConfirm}
+        cancelVariant="contained"
+        confirmVariant="text"
+        content={
           <Typography>Are you sure you want to regenerate this API Key? This will revoke the existing key.</Typography>
-        </DialogContent>
-        <DialogActions sx={{ justifyContent: 'space-between', padding: '16px 24px' }}>
-          <Button
-            variant="text"
-            onClick={() => {
-              onConfirm();
-              addNotification({ message: 'Successfully regenerated API Key', severity: 'success' });
-              handleClose();
-            }}
-          >
-            Confirm
-          </Button>
-          <Button variant="contained" onClick={handleClose}>
-            Cancel
-          </Button>
-        </DialogActions>
-      </Dialog>
+        }
+      />
     </>
   );
 }

--- a/apps/mgmt-ui/src/components/configuration/provider/DeleteProviderButton.tsx
+++ b/apps/mgmt-ui/src/components/configuration/provider/DeleteProviderButton.tsx
@@ -1,5 +1,5 @@
-import { useNotification } from '@/context/notification';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
+import { DeleteConfirmationModal } from '@/components/modals';
+import { Button } from '@mui/material';
 import { useState } from 'react';
 
 export type DeleteProviderButtonProps = {
@@ -8,7 +8,6 @@ export type DeleteProviderButtonProps = {
 };
 
 export function DeleteProviderButton({ providerName, onDelete }: DeleteProviderButtonProps) {
-  const { addNotification } = useNotification();
   const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
@@ -24,31 +23,13 @@ export function DeleteProviderButton({ providerName, onDelete }: DeleteProviderB
       <Button variant="text" color="error" onClick={handleClickOpen} size="small">
         Delete
       </Button>
-      <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>Delete Provider</DialogTitle>
-        <DialogContent>
-          <Typography>
-            Are you sure you want to delete{' '}
-            <Typography fontWeight="bold" display="inline">
-              provider for {providerName}
-            </Typography>
-            ?
-          </Typography>
-        </DialogContent>
-        <DialogActions sx={{ justifyContent: 'space-between', padding: '16px 24px' }}>
-          <Button
-            variant="text"
-            color="error"
-            onClick={() => {
-              onDelete();
-              handleClose();
-            }}
-          >
-            Delete
-          </Button>
-          <Button onClick={handleClose}>Cancel</Button>
-        </DialogActions>
-      </Dialog>
+      <DeleteConfirmationModal
+        open={open}
+        handleClose={handleClose}
+        onDelete={onDelete}
+        resourceName={`provider for ${providerName}`}
+        title="Delete Provider"
+      />
     </>
   );
 }

--- a/apps/mgmt-ui/src/components/configuration/provider/DeleteProviderButton.tsx
+++ b/apps/mgmt-ui/src/components/configuration/provider/DeleteProviderButton.tsx
@@ -1,4 +1,4 @@
-import { DeleteConfirmationModal } from '@/components/modals';
+import { DeleteResourceConfirmationModal } from '@/components/modals';
 import { Button } from '@mui/material';
 import { useState } from 'react';
 
@@ -23,7 +23,7 @@ export function DeleteProviderButton({ providerName, onDelete }: DeleteProviderB
       <Button variant="text" color="error" onClick={handleClickOpen} size="small">
         Delete
       </Button>
-      <DeleteConfirmationModal
+      <DeleteResourceConfirmationModal
         open={open}
         handleClose={handleClose}
         onDelete={onDelete}

--- a/apps/mgmt-ui/src/components/configuration/syncConfig/DeleteSyncConfig.tsx
+++ b/apps/mgmt-ui/src/components/configuration/syncConfig/DeleteSyncConfig.tsx
@@ -1,4 +1,4 @@
-import { DeleteConfirmationModal } from '@/components/modals';
+import { DeleteResourceConfirmationModal } from '@/components/modals';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { IconButton } from '@mui/material';
 import { useState } from 'react';
@@ -24,7 +24,7 @@ export function DeleteSyncConfig({ syncConfigId, onDelete }: DeleteSyncConfigPro
       <IconButton className="p-1" onClick={handleClickOpen} size="small">
         <DeleteIcon />
       </IconButton>
-      <DeleteConfirmationModal
+      <DeleteResourceConfirmationModal
         open={open}
         handleClose={handleClose}
         onDelete={onDelete}

--- a/apps/mgmt-ui/src/components/configuration/syncConfig/DeleteSyncConfig.tsx
+++ b/apps/mgmt-ui/src/components/configuration/syncConfig/DeleteSyncConfig.tsx
@@ -1,6 +1,6 @@
-import { useNotification } from '@/context/notification';
+import { DeleteConfirmationModal } from '@/components/modals';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, Typography } from '@mui/material';
+import { IconButton } from '@mui/material';
 import { useState } from 'react';
 
 export type DeleteSyncConfigProps = {
@@ -9,7 +9,6 @@ export type DeleteSyncConfigProps = {
 };
 
 export function DeleteSyncConfig({ syncConfigId, onDelete }: DeleteSyncConfigProps) {
-  const { addNotification } = useNotification();
   const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
@@ -25,32 +24,13 @@ export function DeleteSyncConfig({ syncConfigId, onDelete }: DeleteSyncConfigPro
       <IconButton className="p-1" onClick={handleClickOpen} size="small">
         <DeleteIcon />
       </IconButton>
-      <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>Delete Sync Config</DialogTitle>
-        <DialogContent>
-          <Typography>
-            Are you sure you want to delete{' '}
-            <Typography fontWeight="bold" display="inline">
-              Sync Config {syncConfigId}
-            </Typography>
-            ?
-          </Typography>
-        </DialogContent>
-        <DialogActions sx={{ justifyContent: 'space-between', padding: '16px 24px' }}>
-          <Button
-            variant="text"
-            color="error"
-            onClick={() => {
-              onDelete();
-              addNotification({ message: 'Successfully removed Sync Config', severity: 'success' });
-              handleClose();
-            }}
-          >
-            Delete
-          </Button>
-          <Button onClick={handleClose}>Cancel</Button>
-        </DialogActions>
-      </Dialog>
+      <DeleteConfirmationModal
+        open={open}
+        handleClose={handleClose}
+        onDelete={onDelete}
+        title="Delete Sync Config"
+        resourceName={`Sync Config ${syncConfigId}`}
+      />
     </>
   );
 }

--- a/apps/mgmt-ui/src/components/configuration/syncConfig/SyncConfigListPanel.tsx
+++ b/apps/mgmt-ui/src/components/configuration/syncConfig/SyncConfigListPanel.tsx
@@ -107,6 +107,7 @@ export default function SyncConfigListPanel() {
                 addNotification({ message: response.errorMessage, severity: 'error' });
                 return;
               }
+              addNotification({ message: 'Successfully removed Sync Config', severity: 'success' });
               await mutate(toGetSyncConfigsResponse(syncConfigs.filter((s) => s.id !== params.row.id)), false);
             }}
           />

--- a/apps/mgmt-ui/src/components/connections/DeleteConnection.tsx
+++ b/apps/mgmt-ui/src/components/connections/DeleteConnection.tsx
@@ -1,7 +1,7 @@
 import DeleteIcon from '@mui/icons-material/Delete';
 import { IconButton } from '@mui/material';
 import { useState } from 'react';
-import { DeleteConfirmationModal } from '../modals';
+import { DeleteResourceConfirmationModal } from '../modals';
 
 export type DeleteConnectionProps = {
   customerId: string;
@@ -25,7 +25,7 @@ export function DeleteConnection({ customerId, providerName, onDelete }: DeleteC
       <IconButton className="p-1" onClick={handleClickOpen} size="small">
         <DeleteIcon />
       </IconButton>
-      <DeleteConfirmationModal
+      <DeleteResourceConfirmationModal
         open={open}
         handleClose={handleClose}
         title="Delete connection"

--- a/apps/mgmt-ui/src/components/connections/DeleteConnection.tsx
+++ b/apps/mgmt-ui/src/components/connections/DeleteConnection.tsx
@@ -1,7 +1,7 @@
-import { useNotification } from '@/context/notification';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, Typography } from '@mui/material';
+import { IconButton } from '@mui/material';
 import { useState } from 'react';
+import { DeleteConfirmationModal } from '../modals';
 
 export type DeleteConnectionProps = {
   customerId: string;
@@ -10,7 +10,6 @@ export type DeleteConnectionProps = {
 };
 
 export function DeleteConnection({ customerId, providerName, onDelete }: DeleteConnectionProps) {
-  const { addNotification } = useNotification();
   const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
@@ -26,32 +25,13 @@ export function DeleteConnection({ customerId, providerName, onDelete }: DeleteC
       <IconButton className="p-1" onClick={handleClickOpen} size="small">
         <DeleteIcon />
       </IconButton>
-      <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>Delete connection</DialogTitle>
-        <DialogContent>
-          <Typography>
-            Are you sure you want to delete{' '}
-            <Typography fontWeight="bold" display="inline">
-              {customerId}'s {providerName}
-            </Typography>{' '}
-            connection?
-          </Typography>
-        </DialogContent>
-        <DialogActions sx={{ justifyContent: 'space-between', padding: '16px 24px' }}>
-          <Button
-            variant="text"
-            color="error"
-            onClick={() => {
-              onDelete();
-              addNotification({ message: 'Successfully removed connection', severity: 'success' });
-              handleClose();
-            }}
-          >
-            Delete
-          </Button>
-          <Button onClick={handleClose}>Cancel</Button>
-        </DialogActions>
-      </Dialog>
+      <DeleteConfirmationModal
+        open={open}
+        handleClose={handleClose}
+        title="Delete connection"
+        resourceName={`${customerId}'s ${providerName}`}
+        onDelete={onDelete}
+      />
     </>
   );
 }

--- a/apps/mgmt-ui/src/components/customers/DeleteCustomer.tsx
+++ b/apps/mgmt-ui/src/components/customers/DeleteCustomer.tsx
@@ -1,7 +1,7 @@
 import DeleteIcon from '@mui/icons-material/Delete';
 import { IconButton } from '@mui/material';
 import { useState } from 'react';
-import { DeleteConfirmationModal } from '../modals';
+import { DeleteResourceConfirmationModal } from '../modals';
 
 export type DeleteCustomerProps = {
   disabled: boolean;
@@ -25,7 +25,7 @@ export function DeleteCustomer({ disabled, customerId, onDelete }: DeleteCustome
       <IconButton className="p-1" onClick={handleClickOpen} size="small" disabled={disabled}>
         <DeleteIcon />
       </IconButton>
-      <DeleteConfirmationModal
+      <DeleteResourceConfirmationModal
         open={open}
         handleClose={handleClose}
         onDelete={onDelete}

--- a/apps/mgmt-ui/src/components/customers/DeleteCustomer.tsx
+++ b/apps/mgmt-ui/src/components/customers/DeleteCustomer.tsx
@@ -1,7 +1,7 @@
-import { useNotification } from '@/context/notification';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, Typography } from '@mui/material';
+import { IconButton } from '@mui/material';
 import { useState } from 'react';
+import { DeleteConfirmationModal } from '../modals';
 
 export type DeleteCustomerProps = {
   disabled: boolean;
@@ -10,7 +10,6 @@ export type DeleteCustomerProps = {
 };
 
 export function DeleteCustomer({ disabled, customerId, onDelete }: DeleteCustomerProps) {
-  const { addNotification } = useNotification();
   const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
@@ -26,32 +25,13 @@ export function DeleteCustomer({ disabled, customerId, onDelete }: DeleteCustome
       <IconButton className="p-1" onClick={handleClickOpen} size="small" disabled={disabled}>
         <DeleteIcon />
       </IconButton>
-      <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>Delete customer</DialogTitle>
-        <DialogContent>
-          <Typography>
-            Are you sure you want to delete customer{' '}
-            <Typography fontWeight="bold" display="inline">
-              {customerId}
-            </Typography>
-            ?
-          </Typography>
-        </DialogContent>
-        <DialogActions sx={{ justifyContent: 'space-between', padding: '16px 24px' }}>
-          <Button
-            variant="text"
-            color="error"
-            onClick={() => {
-              onDelete();
-              addNotification({ message: 'Successfully removed customer', severity: 'success' });
-              handleClose();
-            }}
-          >
-            Delete
-          </Button>
-          <Button onClick={handleClose}>Cancel</Button>
-        </DialogActions>
-      </Dialog>
+      <DeleteConfirmationModal
+        open={open}
+        handleClose={handleClose}
+        onDelete={onDelete}
+        title="Delete customer"
+        resourceName={customerId}
+      />
     </>
   );
 }

--- a/apps/mgmt-ui/src/components/customers/NewCustomer.tsx
+++ b/apps/mgmt-ui/src/components/customers/NewCustomer.tsx
@@ -1,4 +1,3 @@
-import { useNotification } from '@/context/notification';
 import AddIcon from '@mui/icons-material/Add';
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, TextField } from '@mui/material';
 import { useState } from 'react';
@@ -8,7 +7,6 @@ export type NewCustomerProps = {
 };
 
 export function NewCustomer({ onCreate }: NewCustomerProps) {
-  const { addNotification } = useNotification();
   const [customerId, setCustomerId] = useState('');
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -86,7 +84,6 @@ export function NewCustomer({ onCreate }: NewCustomerProps) {
           <Button
             onClick={() => {
               onCreate(customerId, name, email);
-              addNotification({ message: 'Successfully added customer', severity: 'success' });
               handleClose();
             }}
           >

--- a/apps/mgmt-ui/src/components/modals/ConfirmationModal.tsx
+++ b/apps/mgmt-ui/src/components/modals/ConfirmationModal.tsx
@@ -1,0 +1,51 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+
+export type ConfirmationModalProps = {
+  title: string;
+  content: React.ReactNode;
+  open: boolean;
+  cancelText?: string;
+  confirmText?: string;
+  cancelVariant?: 'text' | 'contained' | 'outlined';
+  cancelColor?: 'error' | 'inherit' | 'primary' | 'secondary' | 'success' | 'info' | 'warning';
+  confirmVariant?: 'text' | 'contained' | 'outlined';
+  confirmColor?: 'error' | 'inherit' | 'primary' | 'secondary' | 'success' | 'info' | 'warning';
+  handleClose: () => void;
+  onConfirm: () => void;
+};
+
+export function ConfirmationModal({
+  title,
+  content,
+  confirmText,
+  cancelText,
+  cancelVariant,
+  cancelColor,
+  confirmVariant,
+  confirmColor,
+  onConfirm,
+  handleClose,
+  open,
+}: ConfirmationModalProps) {
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>{content}</DialogContent>
+      <DialogActions sx={{ justifyContent: 'space-between', padding: '16px 24px' }}>
+        <Button variant={cancelVariant} color={cancelColor} onClick={handleClose}>
+          {cancelText ?? 'Cancel'}
+        </Button>
+        <Button
+          variant={confirmVariant}
+          color={confirmColor}
+          onClick={() => {
+            onConfirm();
+            handleClose();
+          }}
+        >
+          {confirmText ?? 'Confirm'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/mgmt-ui/src/components/modals/DeleteConfirmationModal.tsx
+++ b/apps/mgmt-ui/src/components/modals/DeleteConfirmationModal.tsx
@@ -22,8 +22,8 @@ export function DeleteConfirmationModal({
       handleClose={handleClose}
       onConfirm={onDelete}
       confirmText="Delete"
-      cancelVariant="contained"
-      confirmVariant="text"
+      cancelVariant="text"
+      confirmVariant="contained"
       confirmColor="error"
       title={title}
       content={

--- a/apps/mgmt-ui/src/components/modals/DeleteConfirmationModal.tsx
+++ b/apps/mgmt-ui/src/components/modals/DeleteConfirmationModal.tsx
@@ -1,0 +1,40 @@
+import { Typography } from '@mui/material';
+import { ConfirmationModal } from './ConfirmationModal';
+
+export type DeleteConfirmationModalProps = {
+  title: string;
+  resourceName: string;
+  open: boolean;
+  handleClose: () => void;
+  onDelete: () => void;
+};
+
+export function DeleteConfirmationModal({
+  title,
+  resourceName,
+  onDelete,
+  handleClose,
+  open,
+}: DeleteConfirmationModalProps) {
+  return (
+    <ConfirmationModal
+      open={open}
+      handleClose={handleClose}
+      onConfirm={onDelete}
+      confirmText="Delete"
+      cancelVariant="contained"
+      confirmVariant="text"
+      confirmColor="error"
+      title={title}
+      content={
+        <Typography>
+          Are you sure you want to delete{' '}
+          <Typography fontWeight="bold" display="inline">
+            {resourceName}
+          </Typography>
+          ?
+        </Typography>
+      }
+    />
+  );
+}

--- a/apps/mgmt-ui/src/components/modals/DeleteResourceConfirmationModal.tsx
+++ b/apps/mgmt-ui/src/components/modals/DeleteResourceConfirmationModal.tsx
@@ -1,7 +1,7 @@
 import { Typography } from '@mui/material';
 import { ConfirmationModal } from './ConfirmationModal';
 
-export type DeleteConfirmationModalProps = {
+export type DeleteResourceConfirmationModalProps = {
   title: string;
   resourceName: string;
   open: boolean;
@@ -9,13 +9,13 @@ export type DeleteConfirmationModalProps = {
   onDelete: () => void;
 };
 
-export function DeleteConfirmationModal({
+export function DeleteResourceConfirmationModal({
   title,
   resourceName,
   onDelete,
   handleClose,
   open,
-}: DeleteConfirmationModalProps) {
+}: DeleteResourceConfirmationModalProps) {
   return (
     <ConfirmationModal
       open={open}

--- a/apps/mgmt-ui/src/components/modals/index.ts
+++ b/apps/mgmt-ui/src/components/modals/index.ts
@@ -1,2 +1,2 @@
 export * from './ConfirmationModal';
-export * from './DeleteConfirmationModal';
+export * from './DeleteResourceConfirmationModal';

--- a/apps/mgmt-ui/src/components/modals/index.ts
+++ b/apps/mgmt-ui/src/components/modals/index.ts
@@ -1,0 +1,2 @@
+export * from './ConfirmationModal';
+export * from './DeleteConfirmationModal';

--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/customers/[customerId]/connections/index.tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/customers/[customerId]/connections/index.tsx
@@ -53,6 +53,7 @@ export default function Home() {
                 addNotification({ message: response.errorMessage, severity: 'error' });
                 return;
               }
+              addNotification({ message: 'Successfully removed connection', severity: 'success' });
               await mutate(
                 connections.filter((c) => c.id !== params.row.id),
                 false

--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/customers/index.tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/customers/index.tsx
@@ -34,6 +34,7 @@ export default function Home() {
       addNotification({ message: response.errorMessage, severity: 'error' });
       return;
     }
+    addNotification({ message: 'Successfully added customer', severity: 'success' });
     await mutate([...customers, { applicationId, customerId, name, email, connections: [] }], false);
   };
 
@@ -103,6 +104,7 @@ export default function Home() {
                 addNotification({ message: response.errorMessage, severity: 'error' });
                 return;
               }
+              addNotification({ message: 'Successfully removed customer', severity: 'success' });
               await mutate(
                 customers.filter((customer) => customer.customerId !== params.row.id),
                 false


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

Fixes SUP1-428

Refactor modal code to re-use same component. This also includes some other misc cleanups.

Also swaps cancel + confirm buttons.

## Test Plan

Tested locally

![image](https://github.com/supaglue-labs/supaglue/assets/1498449/090e4010-cf96-460e-84f8-519b1c61e044)


## Deployment instructions

[Add any special deployment instructions here]
