### PR TITLE
chore: make Advanced Field Settings clickable

### DIFF
--- a/apps/mgmt-ui/src/components/configuration/schema/SchemaDetailsPanel.tsx
+++ b/apps/mgmt-ui/src/components/configuration/schema/SchemaDetailsPanel.tsx
@@ -188,8 +188,10 @@ function SchemaDetailsPanelImpl({ schemaId }: SchemaDetailsPanelImplProps) {
               }}
             />
             <Stack direction="column" className="gap-2">
-              <Stack direction="row" className="gap-2 items-center">
-                <Typography variant="subtitle1">Advanced Field Settings</Typography>
+              <Stack direction="row" className="items-center">
+                <Button variant="text" color="inherit" onClick={handleExpandClick}>
+                  <Typography variant="subtitle1">Advanced Field Settings</Typography>
+                </Button>
                 <ExpandButton
                   expanded={expanded}
                   onClick={handleExpandClick}

--- a/apps/mgmt-ui/src/components/configuration/schema/SchemaDetailsPanel.tsx
+++ b/apps/mgmt-ui/src/components/configuration/schema/SchemaDetailsPanel.tsx
@@ -8,18 +8,7 @@ import { toGetSchemasResponse, useSchemas } from '@/hooks/useSchemas';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import type { IconButtonProps } from '@mui/material';
-import {
-  Autocomplete,
-  Breadcrumbs,
-  Button,
-  Chip,
-  Collapse,
-  Grid,
-  IconButton,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Autocomplete, Breadcrumbs, Button, Chip, Collapse, Grid, Stack, TextField, Typography } from '@mui/material';
 import Card from '@mui/material/Card';
 import type { Schema, SchemaCreateParams } from '@supaglue/types';
 import Link from 'next/link';
@@ -190,19 +179,14 @@ function SchemaDetailsPanelImpl({ schemaId }: SchemaDetailsPanelImplProps) {
             <Stack direction="column" className="gap-2">
               <Stack direction="row" className="items-center">
                 <Button variant="text" color="inherit" onClick={handleExpandClick}>
-                  <Typography variant="subtitle1">Advanced Field Settings</Typography>
+                  <Stack direction="row" className="items-center gap-2">
+                    <Typography variant="subtitle1">Advanced Field Settings</Typography>
+                    <ExpandIcon expanded={expanded}></ExpandIcon>
+                  </Stack>
                 </Button>
-                <ExpandButton
-                  expanded={expanded}
-                  onClick={handleExpandClick}
-                  aria-expanded={expanded}
-                  aria-label="show more"
-                >
-                  <ExpandMoreIcon />
-                </ExpandButton>
               </Stack>
               <Collapse in={expanded} timeout="auto" unmountOnExit>
-                <Stack direction="column" className="gap-2">
+                <Stack direction="column" className="gap-2 pt-2">
                   {fields.map((field) => {
                     return (
                       // <Stack direction="row" className="pl-4 gap-4 items-center">
@@ -282,11 +266,10 @@ function SchemaDetailsPanelImpl({ schemaId }: SchemaDetailsPanelImplProps) {
   );
 }
 
-interface ExpandButtonProps extends IconButtonProps {
+interface ExpandIconProps extends IconButtonProps {
   expanded: boolean;
 }
 
-const ExpandButton = (props: ExpandButtonProps) => {
-  const { expanded, ...other } = props;
-  return <IconButton {...other}>{expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}</IconButton>;
+const ExpandIcon = ({ expanded }: ExpandIconProps) => {
+  return expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />;
 };

--- a/apps/mgmt-ui/src/components/configuration/schema/SchemaDetailsPanel.tsx
+++ b/apps/mgmt-ui/src/components/configuration/schema/SchemaDetailsPanel.tsx
@@ -7,7 +7,6 @@ import { useActiveApplicationId } from '@/hooks/useActiveApplicationId';
 import { toGetSchemasResponse, useSchemas } from '@/hooks/useSchemas';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import type { IconButtonProps } from '@mui/material';
 import { Autocomplete, Breadcrumbs, Button, Chip, Collapse, Grid, Stack, TextField, Typography } from '@mui/material';
 import Card from '@mui/material/Card';
 import type { Schema, SchemaCreateParams } from '@supaglue/types';
@@ -181,7 +180,7 @@ function SchemaDetailsPanelImpl({ schemaId }: SchemaDetailsPanelImplProps) {
                 <Button variant="text" color="inherit" onClick={handleExpandClick}>
                   <Stack direction="row" className="items-center gap-2">
                     <Typography variant="subtitle1">Advanced Field Settings</Typography>
-                    <ExpandIcon expanded={expanded}></ExpandIcon>
+                    {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
                   </Stack>
                 </Button>
               </Stack>
@@ -265,11 +264,3 @@ function SchemaDetailsPanelImpl({ schemaId }: SchemaDetailsPanelImplProps) {
     </div>
   );
 }
-
-interface ExpandIconProps extends IconButtonProps {
-  expanded: boolean;
-}
-
-const ExpandIcon = ({ expanded }: ExpandIconProps) => {
-  return expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />;
-};


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

Previously you had to click on the very small chevron icon to expand. Now you can click on the whole row to expand.

## Test Plan

Tested locally

https://www.loom.com/share/2fb7f2e5321644ad97f0de6ff8ff1be1

## Deployment instructions

[Add any special deployment instructions here]
