### PR TITLE
fix: only reset full flag for processSyncChanges for manually-triggered run

### DIFF
--- a/packages/sync-workflows/activities/do_process_sync_changes.ts
+++ b/packages/sync-workflows/activities/do_process_sync_changes.ts
@@ -11,7 +11,14 @@ export function createDoProcessSyncChanges(syncService: SyncService, systemSetti
   return async function doProcessSyncChanges(args: DoProcessSyncChangesArgs): Promise<DoProcessSyncChangesResult> {
     const { processSyncChangesFull } = await systemSettingsService.getSystemSettings();
     await syncService.processSyncChanges(processSyncChangesFull);
-    await systemSettingsService.setProcessSyncChangesFull(false);
+
+    // Only reset the flag if it was true to begin with.
+    // Because the manual trigger has an OverlapPolicy of BUFFER_ONE, if there
+    // is already a run occurring, that existing run could reset this flag to false
+    // even though it executed `syncService.processSyncChanges` with `full` set to true.
+    if (processSyncChangesFull) {
+      await systemSettingsService.setProcessSyncChangesFull(false);
+    }
     return {};
   };
 }

--- a/packages/sync-workflows/workflows/process_sync_changes.ts
+++ b/packages/sync-workflows/workflows/process_sync_changes.ts
@@ -3,7 +3,7 @@ import { proxyActivities } from '@temporalio/workflow';
 import type { createActivities } from '../activities/index';
 
 const { doProcessSyncChanges } = proxyActivities<ReturnType<typeof createActivities>>({
-  startToCloseTimeout: '2 minutes',
+  startToCloseTimeout: '5 minutes',
 });
 
 export const PROCESS_SYNC_CHANGES_SCHEDULE_ID = 'periodically-process-sync-changes';


### PR DESCRIPTION
race condition causing flag to be ignored

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
