### PR TITLE
feat: sync standard objects for gong

### DIFF
--- a/apps/mgmt-ui/src/components/configuration/syncConfig/SyncConfigDetailsPanel.tsx
+++ b/apps/mgmt-ui/src/components/configuration/syncConfig/SyncConfigDetailsPanel.tsx
@@ -150,7 +150,7 @@ function SyncConfigDetailsPanelImpl({ syncConfigId }: SyncConfigDetailsPanelImpl
   const selectedDestination = destinations?.find((d) => d.id === destinationId);
   const supportsStandardDestinations = ['postgres', 'bigquery'];
   const supportsCustomDestinations = ['postgres', 'bigquery'];
-  const supportsStandardObjects = ['hubspot', 'salesforce', 'ms_dynamics_365_sales'];
+  const supportsStandardObjects = ['hubspot', 'salesforce', 'ms_dynamics_365_sales', 'gong'];
   const supportsCustomObjects = ['hubspot', 'salesforce'];
 
   const standardObjectsOptions = getStandardObjectOptions(selectedProvider?.name);

--- a/packages/core/remotes/impl/gong/index.ts
+++ b/packages/core/remotes/impl/gong/index.ts
@@ -1,6 +1,42 @@
-import type { ConnectionUnsafe, Provider } from '@supaglue/types';
+import type { ConnectionUnsafe, NormalizedRawRecord, Provider } from '@supaglue/types';
+import type { FieldMappingConfig } from '@supaglue/types/field_mapping_config';
+import axios from 'axios';
+import { Readable } from 'stream';
+import { retryWhenAxiosRateLimited } from '../../../lib';
+import { REFRESH_TOKEN_THRESHOLD_MS } from '../../../lib/constants';
 import type { ConnectorAuthConfig } from '../../base';
 import { AbstractEngagementRemoteClient } from '../../categories/engagement/base';
+import { paginator } from '../../utils/paginator';
+import { toGongStandardObject } from './mappers';
+
+type GongPaginatedResponse<K extends string, R extends Record<string, unknown> = Record<string, unknown>> = {
+  requestId: string;
+  records: {
+    totalRecords: number;
+    currentPageSize: number;
+    currentPageNumber: number;
+    cursor?: string;
+  };
+} & Record<K, R[]>;
+
+type GongCall = {
+  id: string;
+  started: string; // ISO string
+  // ... other fields that aren't needed in NormalizedRawRecord
+};
+
+type GongDetailedCall = {
+  metaData: {
+    id: string;
+    started: string; // ISO string
+  };
+  // ... other fields that aren't needed in NormalizedRawRecord
+};
+
+type GongCallTranscript = {
+  callId: string;
+  // ... other fields that aren't needed in NormalizedRawRecord
+};
 
 type GongClientConfig = {
   instanceUrl: string;
@@ -24,6 +60,172 @@ class GongClient extends AbstractEngagementRemoteClient {
       Authorization: `Bearer ${this.#config.accessToken}`,
     };
   }
+
+  private async maybeRefreshAccessToken(): Promise<void> {
+    if (!this.#config.expiresAt || Date.parse(this.#config.expiresAt) < Date.now() + REFRESH_TOKEN_THRESHOLD_MS) {
+      const {
+        data: { access_token, expires_in },
+      } = await axios.post<{ access_token: string; expires_in: number }>(
+        `${authConfig.tokenHost}${authConfig.tokenPath}`,
+        {
+          grant_type: 'refresh_token',
+          refresh_token: this.#config.refreshToken,
+        },
+        {
+          headers: {
+            Authorization: `Basic ${Buffer.from(`${this.#config.clientId}:${this.#config.clientSecret}`).toString()}`,
+          },
+        }
+      );
+
+      const newExpiresAt = new Date(Date.now() + expires_in * 1000).toISOString();
+      this.#config.accessToken = access_token;
+      this.#config.expiresAt = newExpiresAt;
+      this.emit('token_refreshed', access_token, newExpiresAt);
+    }
+  }
+
+  public override async listStandardObjectRecords(
+    object: string,
+    fieldMappingConfig: FieldMappingConfig,
+    modifiedAfter?: Date | undefined,
+    heartbeat?: (() => void) | undefined
+  ): Promise<Readable> {
+    const validatedObject = toGongStandardObject(object);
+
+    // TODO: Need to create stream with id
+    switch (validatedObject) {
+      case 'call': {
+        return await this.#getPaginatorByGet<'calls', GongCall>(
+          'v2/calls',
+          'calls',
+          (call, emittedAt) => ({
+            id: call.id,
+            rawData: call,
+            isDeleted: false,
+            lastModifiedAt: new Date(call.started),
+            emittedAt,
+          }),
+          modifiedAfter
+        );
+      }
+      case 'callDetail': {
+        return await this.#getPaginatorByPost<'calls', GongDetailedCall>(
+          'v2/calls/extensive',
+          'calls',
+          (detailedCall, emittedAt) => ({
+            id: detailedCall.metaData.id,
+            rawData: detailedCall,
+            isDeleted: false,
+            lastModifiedAt: new Date(detailedCall.metaData.started),
+            emittedAt,
+          }),
+          modifiedAfter
+        );
+      }
+      case 'callTranscript': {
+        return await this.#getPaginatorByPost<'callTranscripts', GongCallTranscript>(
+          'v2/calls/transcript',
+          'callTranscripts',
+          (transcript, emittedAt) => ({
+            id: transcript.callId,
+            rawData: transcript,
+            isDeleted: false,
+            lastModifiedAt: new Date(0), // we don't know the last modified at time
+            emittedAt,
+          }),
+          modifiedAfter
+        );
+      }
+      default:
+        throw new Error(`Unsupported object: ${object}`);
+    }
+  }
+
+  #getPaginatorByGet<K extends string, R extends Record<string, unknown>>(
+    path: string,
+    key: K,
+    mapper: (record: R, emittedAt: Date) => NormalizedRawRecord<R>,
+    modifiedAfter?: Date
+  ): Promise<Readable> {
+    return paginator([
+      {
+        pageFetcher: this.#getPageFetcherByGet<K, R>(path, modifiedAfter),
+        createStreamFromPage: ({ [key]: records }) => {
+          const emittedAt = new Date();
+          return Readable.from(records.map((record) => mapper(record, emittedAt)));
+        },
+        getNextCursorFromPage: ({ records }) => records.cursor,
+      },
+    ]);
+  }
+
+  #getPaginatorByPost<K extends string, R extends Record<string, unknown>>(
+    path: string,
+    key: K,
+    mapper: (record: R, emittedAt: Date) => NormalizedRawRecord<R>,
+    modifiedAfter?: Date
+  ): Promise<Readable> {
+    return paginator([
+      {
+        pageFetcher: this.#getPageFetcherByPost<K, R>(path, modifiedAfter),
+        createStreamFromPage: ({ [key]: records }) => {
+          const emittedAt = new Date();
+          return Readable.from(records.map((record) => mapper(record, emittedAt)));
+        },
+        getNextCursorFromPage: ({ records }) => records.cursor,
+      },
+    ]);
+  }
+
+  #getPageFetcherByGet<K extends string, R extends Record<string, unknown>>(
+    path: string,
+    modifiedAfter?: Date
+  ): (cursor?: string) => Promise<GongPaginatedResponse<K, R>> {
+    return async (cursor?: string) => {
+      return await retryWhenAxiosRateLimited(async () => {
+        await this.maybeRefreshAccessToken();
+        const { data } = await axios.get<GongPaginatedResponse<K, R>>(`${this.#config.instanceUrl}/${path}`, {
+          headers: {
+            Authorization: `Bearer ${this.#config.accessToken}`,
+          },
+          params: {
+            cursor,
+            fromDateTime: modifiedAfter?.toISOString(),
+          },
+        });
+
+        return data;
+      });
+    };
+  }
+
+  #getPageFetcherByPost<K extends string, R extends Record<string, unknown>>(
+    path: string,
+    modifiedAfter?: Date
+  ): (cursor?: string) => Promise<GongPaginatedResponse<K, R>> {
+    return async (cursor?: string) => {
+      return await retryWhenAxiosRateLimited(async () => {
+        await this.maybeRefreshAccessToken();
+        const { data } = await axios.post<GongPaginatedResponse<K, R>>(
+          `${this.#config.instanceUrl}/${path}`,
+          {
+            cursor,
+            filter: {
+              fromDateTime: modifiedAfter?.toISOString(),
+            },
+          },
+          {
+            headers: {
+              Authorization: `Bearer ${this.#config.accessToken}`,
+            },
+          }
+        );
+
+        return data;
+      });
+    };
+  }
 }
 
 export function newClient(connection: ConnectionUnsafe<'gong'>, provider: Provider): GongClient {
@@ -37,7 +239,6 @@ export function newClient(connection: ConnectionUnsafe<'gong'>, provider: Provid
   });
 }
 
-// TODO: support other geographies
 export const authConfig: ConnectorAuthConfig = {
   tokenHost: 'https://app.gong.io',
   tokenPath: '/oauth2/generate-customer-token',

--- a/packages/core/remotes/impl/gong/index.ts
+++ b/packages/core/remotes/impl/gong/index.ts
@@ -131,7 +131,12 @@ class GongClient extends AbstractEngagementRemoteClient {
             id: transcript.callId,
             rawData: transcript,
             isDeleted: false,
-            lastModifiedAt: new Date(0), // we don't know the last modified at time
+            // we don't know the last modified at time
+            // TODO: figure out some way to address this.
+            // Otherwise, we're just going to be constantly doing full refresh for transcripts.
+            // Maybe there is some way to get the max last modified at time for the 'calls' sync
+            // and use that?
+            lastModifiedAt: new Date(0),
             emittedAt,
           }),
           modifiedAfter

--- a/packages/core/remotes/impl/gong/mappers.ts
+++ b/packages/core/remotes/impl/gong/mappers.ts
@@ -1,0 +1,11 @@
+import { BadRequestError } from '../../../errors';
+
+export const gongStandardObjects = ['call', 'callDetail', 'callTranscript'] as const;
+export type GongStandardObject = (typeof gongStandardObjects)[number];
+
+export const toGongStandardObject = (object: string): GongStandardObject => {
+  if (!gongStandardObjects.includes(object as GongStandardObject)) {
+    throw new BadRequestError(`Unsupported object ${object}`);
+  }
+  return object as GongStandardObject;
+};

--- a/packages/core/services/connection_service.ts
+++ b/packages/core/services/connection_service.ts
@@ -5,7 +5,6 @@ import type {
   ConnectionUnsafe,
   ConnectionUnsafeAny,
   ConnectionUpdateParams,
-  CRMProvider,
   FieldMappingInfo,
   ObjectFieldMappingInfo,
   ObjectFieldMappingUpdateParams,
@@ -303,10 +302,7 @@ export class ConnectionService {
     objectName: string
   ): Promise<FieldMappingConfig> {
     const connection = await this.getSafeById(connectionId);
-    if (connection.category !== 'crm') {
-      throw new BadRequestError(`Field mappings are only supported for the CRM vertical`);
-    }
-    const provider = await this.#providerService.getById<CRMProvider>(connection.providerId);
+    const provider = await this.#providerService.getById(connection.providerId);
     const schemaId = provider.objects?.[objectType]?.find((o) => o.name === objectName)?.schemaId;
     const schema = schemaId ? await this.#schemaService.getById(schemaId) : undefined;
     let customerFieldMapping: SchemaMappingsConfigObjectFieldMapping[] | undefined = undefined;


### PR DESCRIPTION
Supports syncing standard objects for Gong.

Caveats:
- even if a field mapping is set, it's ignored
- haven't tested real rate limiting (429), because I didn't run into it while testing; we can artificially try to hit 429 if we want

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
