### PR TITLE
fix: persist new refresh token

### DIFF
--- a/apps/salesforce-pub-sub/index.ts
+++ b/apps/salesforce-pub-sub/index.ts
@@ -77,7 +77,7 @@ const { connectionService, providerService, webhookService, applicationService }
       // TODO we should fix this in the connection service
       const { access_token: accessToken, instance_url: instanceUrl } = await conn.oauth2.refreshToken(refreshToken);
       // expiresAt is not returned from the refresh token response
-      await connectionService.updateConnectionWithNewAccessToken(connectionId, accessToken, /* expiresAt */ null);
+      await connectionService.updateConnectionWithNewTokens(connectionId, accessToken, undefined, /* expiresAt */ null);
 
       // get the latest recorded replayId, if any
       const encodedReplayId = await webhookService.getReplayId(connectionId, eventType);

--- a/packages/core/remotes/base.ts
+++ b/packages/core/remotes/base.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
 import type { Readable } from 'stream';
 
 interface RemoteClientEvents {
-  token_refreshed: (accessToken: string, expiresAt: string | null) => void;
+  token_refreshed: (args: { accessToken: string; refreshToken?: string; expiresAt: string | null }) => void;
 }
 
 export interface RemoteClient {

--- a/packages/core/remotes/impl/hubspot/index.ts
+++ b/packages/core/remotes/impl/hubspot/index.ts
@@ -338,11 +338,19 @@ class HubSpotClient extends AbstractCrmRemoteClient {
         this.#config.refreshToken
       );
       const newAccessToken = token.accessToken;
+      const newRefreshToken = token.refreshToken;
       const newExpiresAt = new Date(Date.now() + token.expiresIn * 1000).toISOString();
+
       this.#config.accessToken = newAccessToken;
+      this.#config.refreshToken = newRefreshToken;
       this.#config.expiresAt = newExpiresAt;
+
       this.#client.setAccessToken(newAccessToken);
-      this.emit('token_refreshed', newAccessToken, newExpiresAt);
+      this.emit('token_refreshed', {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+        expiresAt: newExpiresAt,
+      });
     }
   }
 

--- a/packages/core/remotes/impl/ms_dynamics_365_sales/index.ts
+++ b/packages/core/remotes/impl/ms_dynamics_365_sales/index.ts
@@ -96,15 +96,21 @@ class MsDynamics365Sales extends AbstractCrmRemoteClient {
       const newToken = await token.refresh();
 
       const newAccessToken = newToken.token.access_token as string;
+      const newRefreshToken = newToken.token.refresh_token as string;
       const newExpiresAt = (newToken.token.expires_at as Date).toISOString();
 
       this.#credentials.accessToken = newAccessToken;
+      this.#credentials.refreshToken = newRefreshToken;
       this.#credentials.expiresAt = newExpiresAt;
 
       this.#headers.Authorization = `Bearer ${newAccessToken}`;
       this.#odata = o(this.baseUrl, { headers: this.#headers, referrer: undefined });
 
-      this.emit('token_refreshed', newAccessToken, newExpiresAt);
+      this.emit('token_refreshed', {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+        expiresAt: newExpiresAt,
+      });
     }
   }
 

--- a/packages/core/remotes/impl/outreach/index.ts
+++ b/packages/core/remotes/impl/outreach/index.ts
@@ -168,20 +168,29 @@ class OutreachClient extends AbstractEngagementRemoteClient {
       !this.#credentials.expiresAt ||
       Date.parse(this.#credentials.expiresAt) < Date.now() + REFRESH_TOKEN_THRESHOLD_MS
     ) {
-      const response = await axios.post<{ access_token: string; expires_in: number }>(`${this.#baseURL}/oauth/token`, {
-        client_id: this.#credentials.clientId,
-        client_secret: this.#credentials.clientSecret,
-        grant_type: 'refresh_token',
-        refresh_token: this.#credentials.refreshToken,
-      });
+      const response = await axios.post<{ refresh_token: string; access_token: string; expires_in: number }>(
+        `${this.#baseURL}/oauth/token`,
+        {
+          client_id: this.#credentials.clientId,
+          client_secret: this.#credentials.clientSecret,
+          grant_type: 'refresh_token',
+          refresh_token: this.#credentials.refreshToken,
+        }
+      );
 
       const newAccessToken = response.data.access_token;
+      const newRefreshToken = response.data.refresh_token;
       const newExpiresAt = new Date(Date.now() + response.data.expires_in * 1000).toISOString();
 
       this.#credentials.accessToken = newAccessToken;
+      this.#credentials.refreshToken = newRefreshToken;
       this.#credentials.expiresAt = newExpiresAt;
 
-      this.emit('token_refreshed', newAccessToken, newExpiresAt);
+      this.emit('token_refreshed', {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+        expiresAt: newExpiresAt,
+      });
     }
   }
 

--- a/packages/core/remotes/impl/pipedrive/index.ts
+++ b/packages/core/remotes/impl/pipedrive/index.ts
@@ -146,7 +146,7 @@ class PipedriveClient extends AbstractCrmRemoteClient {
       !this.#credentials.expiresAt ||
       Date.parse(this.#credentials.expiresAt) < Date.now() + REFRESH_TOKEN_THRESHOLD_MS
     ) {
-      const response = await axios.post<{ access_token: string; expires_in: number }>(
+      const response = await axios.post<{ access_token: string; refresh_token: string; expires_in: number }>(
         `${authConfig.tokenHost}${authConfig.tokenPath}`,
         {
           grant_type: 'refresh_token',
@@ -161,12 +161,18 @@ class PipedriveClient extends AbstractCrmRemoteClient {
       );
 
       const newAccessToken = response.data.access_token;
+      const newRefreshToken = response.data.refresh_token;
       const newExpiresAt = new Date(Date.now() + response.data.expires_in * 1000).toISOString();
 
       this.#credentials.accessToken = newAccessToken;
+      this.#credentials.refreshToken = newRefreshToken;
       this.#credentials.expiresAt = newExpiresAt;
 
-      this.emit('token_refreshed', newAccessToken, newExpiresAt);
+      this.emit('token_refreshed', {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+        expiresAt: newExpiresAt,
+      });
     }
   }
 

--- a/packages/core/remotes/impl/salesforce/index.ts
+++ b/packages/core/remotes/impl/salesforce/index.ts
@@ -1030,7 +1030,10 @@ ${modifiedAfter ? `WHERE SystemModstamp > ${modifiedAfter.toISOString()} ORDER B
     // TODO: Shouldn't be relying on `jsforce` to do this.
     const token = await this.#client.oauth2.refreshToken(this.#refreshToken);
     this.#accessToken = token.access_token;
-    this.emit('token_refreshed', token.access_token, null);
+    this.emit('token_refreshed', {
+      accessToken: token.access_token,
+      expiresAt: null,
+    });
   }
 
   async #fetchImpl(path: string, init: RequestInit, timeout = FETCH_TIMEOUT) {

--- a/packages/core/services/connection_service.ts
+++ b/packages/core/services/connection_service.ts
@@ -267,9 +267,10 @@ export class ConnectionService {
     return await this.#schemaService.getById(schemaId);
   }
 
-  public async updateConnectionWithNewAccessToken(
+  public async updateConnectionWithNewTokens(
     connectionId: string,
     accessToken: string,
+    refreshToken: string | undefined,
     expiresAt: string | null
   ): Promise<ConnectionSafeAny> {
     // TODO: Not atomic.
@@ -281,6 +282,7 @@ export class ConnectionService {
     const newCredentials: ConnectionCredentialsDecryptedAny = {
       ...(oldCredentialsUnsafe as ConnectionCredentialsDecryptedAny),
       accessToken,
+      refreshToken: refreshToken ?? oldCredentialsUnsafe.refreshToken,
       expiresAt,
     };
 

--- a/packages/core/services/remote_service.ts
+++ b/packages/core/services/remote_service.ts
@@ -89,12 +89,23 @@ export class RemoteService {
   }
 
   #persistRefreshedToken(connectionId: string, client: RemoteClient) {
-    client.on('token_refreshed', (accessToken: string, expiresAt: string | null) => {
-      this.#connectionService
-        .updateConnectionWithNewAccessToken(connectionId, accessToken, expiresAt)
-        .catch((err: unknown) => {
-          logger.error({ err, connectionId }, `Failed to persist refreshed token`);
-        });
-    });
+    client.on(
+      'token_refreshed',
+      ({
+        accessToken,
+        refreshToken,
+        expiresAt,
+      }: {
+        accessToken: string;
+        refreshToken?: string;
+        expiresAt: string | null;
+      }) => {
+        this.#connectionService
+          .updateConnectionWithNewTokens(connectionId, accessToken, refreshToken, expiresAt)
+          .catch((err: unknown) => {
+            logger.error({ err, connectionId }, `Failed to persist refreshed token`);
+          });
+      }
+    );
   }
 }


### PR DESCRIPTION
we need to be persisting new refresh tokens.

for gong, this is critical, since the previous refresh token is invalidated when you refresh the access token

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
