### PR TITLE
fix: missing mongodb icon on mongodb config page

### DIFF
--- a/apps/mgmt-ui/src/utils/companyToIcon.tsx
+++ b/apps/mgmt-ui/src/utils/companyToIcon.tsx
@@ -8,6 +8,7 @@ import PipedriveIcon from '@/assets/connector_icons/pipedrive.png';
 import SalesforceIcon from '@/assets/connector_icons/salesforce.png';
 import ZendeskSellIcon from '@/assets/connector_icons/zendesk_sell.png';
 import BigQueryIcon from '@/assets/destination_icons/bigquery.png';
+import MongoDBIcon from '@/assets/destination_icons/mongodb.png';
 import PostgresIcon from '@/assets/destination_icons/postgres.png';
 import S3Icon from '@/assets/destination_icons/s3.png';
 import Image from 'next/image';
@@ -22,6 +23,7 @@ export default function getIcon(name: string, size = 25): ReactNode {
     hubspot: <Image key={name} alt={name} src={HubspotIcon} width={size} height={size} />,
     copper: <Image key={name} alt={name} src={CopperIcon} width={size} height={size} />,
     activecampaign: <Image key={name} alt={name} src={ActiveCampaignIcon} width={size} height={size} />,
+    mongodb: <Image key={name} alt={name} src={MongoDBIcon} width={size} height={size} />,
     ms_dynamics_365_sales: (
       <Image key={name} alt={name} src={MicrosoftDynamics365SalesIcon} width={size} height={size} />
     ),


### PR DESCRIPTION
![Screenshot 2023-07-17 at 4 13 55 PM](https://github.com/supaglue-labs/supaglue/assets/885074/317ff136-6cf4-426b-885d-1384721c48ff)
