### PR TITLE
chore: merge entity syncs into object syncs

### DIFF
--- a/packages/core/mappers/object_sync_run.ts
+++ b/packages/core/mappers/object_sync_run.ts
@@ -29,6 +29,6 @@ export const fromObjectSyncRunModelAndSyncWithObject = (
   return {
     ...fromObjectSyncRunModelAndSync(args),
     objectType: args.objectSync.objectType as ObjectType,
-    object: args.objectSync.object,
+    object: args.objectSync.object as string, // TODO: later, when we actually deal with entity syncs, we need to fix this
   };
 };

--- a/packages/core/services/object_sync_service.ts
+++ b/packages/core/services/object_sync_service.ts
@@ -60,8 +60,9 @@ export class ObjectSyncService {
   ): Promise<ObjectSync> {
     const model = await this.#prisma.objectSync.findUnique({
       where: {
-        connectionId_objectType_object: {
+        connectionId_type_objectType_object: {
           connectionId,
+          type: 'object',
           object,
           objectType,
         },

--- a/packages/core/types/object_sync_run.ts
+++ b/packages/core/types/object_sync_run.ts
@@ -9,7 +9,7 @@ export type ObjectSyncRunModelExpanded = ObjectSyncRunModel & {
 
 export type ObjectSyncRunModelExpandedWithObject = ObjectSyncRunModelExpanded & {
   objectSync: {
-    objectType: string;
-    object: string;
+    objectType: string | null;
+    object: string | null;
   };
 };

--- a/packages/db/prisma/migrations/20230721181101_merge_syncs/migration.sql
+++ b/packages/db/prisma/migrations/20230721181101_merge_syncs/migration.sql
@@ -1,0 +1,48 @@
+/*
+  Warnings:
+
+  - You are about to drop the `entity_sync_changes` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `entity_sync_runs` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `entity_syncs` table. If the table is not empty, all the data it contains will be lost.
+  - A unique constraint covering the columns `[connection_id,type,object_type,object]` on the table `object_syncs` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[connection_id,type,entity_id]` on the table `object_syncs` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "entity_sync_runs" DROP CONSTRAINT "entity_sync_runs_entity_sync_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "entity_syncs" DROP CONSTRAINT "entity_syncs_connection_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "entity_syncs" DROP CONSTRAINT "entity_syncs_entity_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "entity_syncs" DROP CONSTRAINT "entity_syncs_sync_config_id_fkey";
+
+-- DropIndex
+DROP INDEX "object_syncs_connection_id_object_type_object_key";
+
+-- AlterTable
+ALTER TABLE "object_syncs" ADD COLUMN     "entity_id" TEXT,
+ADD COLUMN     "type" TEXT NOT NULL DEFAULT 'object',
+ALTER COLUMN "object" DROP NOT NULL,
+ALTER COLUMN "object_type" DROP NOT NULL;
+
+-- DropTable
+DROP TABLE "entity_sync_changes";
+
+-- DropTable
+DROP TABLE "entity_sync_runs";
+
+-- DropTable
+DROP TABLE "entity_syncs";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "object_syncs_connection_id_type_object_type_object_key" ON "object_syncs"("connection_id", "type", "object_type", "object");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "object_syncs_connection_id_type_entity_id_key" ON "object_syncs"("connection_id", "type", "entity_id");
+
+-- AddForeignKey
+ALTER TABLE "object_syncs" ADD CONSTRAINT "object_syncs_entity_id_fkey" FOREIGN KEY ("entity_id") REFERENCES "entities"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -95,7 +95,6 @@ model SyncConfig {
   createdAt     DateTime     @default(now()) @map("created_at")
   updatedAt     DateTime     @updatedAt @map("updated_at")
   objectSyncs   ObjectSync[]
-  EntitySync    EntitySync[]
 
   // TODO: Eventually allow multiple destinations
   @@unique([providerId])
@@ -129,7 +128,6 @@ model Connection {
   schemaMappingsConfig Json?        @map("schema_mappings_config")
   entityMappings       Json?        @map("entity_mappings")
   objectSyncs          ObjectSync[]
-  entitySyncs          EntitySync[]
 
   @@unique([customerId, providerId])
   @@map("connections")
@@ -137,9 +135,13 @@ model Connection {
 
 model ObjectSync {
   id             String          @id @default(uuid())
-  // common, standard, custom
-  objectType     String          @map("object_type")
-  object         String
+  type           String          @default("object") // object | entity
+  // set `objectType` and `object` if type is `object`
+  objectType     String?         @map("object_type") // common, standard, custom
+  object         String?
+  // set `entityId` if type is `entity`
+  entityId       String?         @map("entity_id")
+  entity         Entity?         @relation(fields: [entityId], references: [id])
   state          Json
   strategy       Json
   connectionId   String          @map("connection_id")
@@ -152,7 +154,8 @@ model ObjectSync {
   updatedAt      DateTime        @updatedAt @map("updated_at")
   runs           ObjectSyncRun[]
 
-  @@unique([connectionId, objectType, object])
+  @@unique([connectionId, type, objectType, object])
+  @@unique([connectionId, type, entityId])
   @@map("object_syncs")
 }
 
@@ -176,48 +179,6 @@ model ObjectSyncRun {
   numRecordsSynced Int?       @map("num_records_synced")
 
   @@map("object_sync_runs")
-}
-
-model EntitySync {
-  id             String          @id @default(uuid())
-  entityId       String          @map("entity_id")
-  entity         Entity          @relation(fields: [entityId], references: [id])
-  state          Json
-  strategy       Json
-  connectionId   String          @map("connection_id")
-  connection     Connection      @relation(fields: [connectionId], references: [id])
-  paused         Boolean         @default(false)
-  syncConfigId   String          @map("sync_config_id")
-  syncConfig     SyncConfig      @relation(fields: [syncConfigId], references: [id])
-  argsForNextRun Json?           @map("args_for_next_run")
-  createdAt      DateTime        @default(now()) @map("created_at")
-  updatedAt      DateTime        @updatedAt @map("updated_at")
-  runs           EntitySyncRun[]
-
-  @@unique([connectionId, entityId])
-  @@map("entity_syncs")
-}
-
-model EntitySyncChange {
-  id           String   @id @default(uuid())
-  entitySyncId String   @map("entity_sync_id")
-  createdAt    DateTime @default(now()) @map("created_at")
-
-  @@map("entity_sync_changes")
-}
-
-model EntitySyncRun {
-  id               String     @id @default(uuid())
-  entitySyncId     String     @map("entity_sync_id")
-  entitySync       EntitySync @relation(fields: [entitySyncId], references: [id], onDelete: Cascade)
-  // SUCCESS | ERROR | IN_PROGRESS
-  status           String
-  errorMessage     String?    @map("error_message")
-  startTimestamp   DateTime   @map("start_timestamp")
-  endTimestamp     DateTime?  @map("end_timestamp")
-  numRecordsSynced Int?       @map("num_records_synced")
-
-  @@map("entity_sync_runs")
 }
 
 model ReplayId {
@@ -253,7 +214,7 @@ model Entity {
   config        Json
   createdAt     DateTime     @default(now()) @map("created_at")
   updatedAt     DateTime     @updatedAt @map("updated_at")
-  entitySyncs   EntitySync[]
+  syncs         ObjectSync[]
 
   @@unique([applicationId, name])
   @@map("entities")


### PR DESCRIPTION
based on feedback, merging entity syncs into object syncs table

in future PR, will do renames of prisma model names, but won't touch the columns/table names since that requires a huge migration

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
