### PR TITLE
fix: don't redirect to org creation page

### DIFF
--- a/apps/mgmt-ui/src/middleware.ts
+++ b/apps/mgmt-ui/src/middleware.ts
@@ -38,11 +38,12 @@ const cloudMiddleware = authMiddleware({
 
     // if the user is signed in but does not have an org, redirect them to create an org.
     // (but don't redirect if the path is already `/create-organization`)
-    if (!orgId && !isCloudCreateOrgPath(request.nextUrl.pathname)) {
-      const createOrgUrl = new URL('/create-organization', request.url);
-      createOrgUrl.searchParams.set('redirect_url', process.env.FRONTEND_URL ?? request.url);
-      return NextResponse.redirect(createOrgUrl);
-    }
+    // TODO: figure out why sometimes there isn't an orgId even when the user does have an org
+    // if (!orgId && !isCloudCreateOrgPath(request.nextUrl.pathname)) {
+    //   const createOrgUrl = new URL('/create-organization', request.url);
+    //   createOrgUrl.searchParams.set('redirect_url', process.env.FRONTEND_URL ?? request.url);
+    //   return NextResponse.redirect(createOrgUrl);
+    // }
     return NextResponse.next();
   },
 });


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

We have users who get in a state where Clerk isn't returning an orgId for them even when they are part of an org. This gets them stuck where they can't log in without creating another org, which we don't want.
