### PR TITLE
chore: remove custom hubspot/mongo code and only flatten properties at top level

### DIFF
--- a/packages/core/destination_writers/mongodb.ts
+++ b/packages/core/destination_writers/mongodb.ts
@@ -230,17 +230,6 @@ export class MongoDBDestinationWriter extends BaseDestinationWriter {
       new Transform({
         objectMode: true,
         transform: (record: ObjectRecord, encoding, callback) => {
-          let normalized = record.mappedData;
-          // TODO: this should not be the responsibility of the destination writer
-          // we should do this in the sync_entity_records and sync_object_records temporal workflows
-          if (providerName === 'hubspot') {
-            // hubspot records have a nested properties key that we want to flatten
-            const { properties, ...rest } = record.mappedData;
-            normalized = {
-              ...properties,
-              ...rest,
-            };
-          }
           try {
             const mappedRecord = {
               _supaglue_application_id: applicationId,
@@ -251,7 +240,7 @@ export class MongoDBDestinationWriter extends BaseDestinationWriter {
               _supaglue_raw_data: record.rawData,
               _supaglue_mapped_data: record.mappedData,
               id: record.id,
-              ...normalized,
+              ...record.mappedProperties,
             };
 
             ++rowCount;

--- a/packages/core/remotes/impl/gong/index.ts
+++ b/packages/core/remotes/impl/gong/index.ts
@@ -133,6 +133,7 @@ class GongClient extends AbstractEngagementRemoteClient {
             id: call.id,
             rawData: call,
             mappedData: call,
+            mappedProperties: call,
             isDeleted: false,
             lastModifiedAt: new Date(call.started),
             emittedAt,
@@ -148,6 +149,7 @@ class GongClient extends AbstractEngagementRemoteClient {
             id: detailedCall.metaData.id,
             rawData: detailedCall,
             mappedData: detailedCall,
+            mappedProperties: detailedCall,
             isDeleted: false,
             lastModifiedAt: new Date(detailedCall.metaData.started),
             emittedAt,
@@ -163,6 +165,7 @@ class GongClient extends AbstractEngagementRemoteClient {
             id: transcript.callId,
             rawData: transcript,
             mappedData: transcript,
+            mappedProperties: transcript,
             isDeleted: false,
             // we don't know the last modified at time
             // TODO: figure out some way to address this.

--- a/packages/core/remotes/impl/hubspot/index.ts
+++ b/packages/core/remotes/impl/hubspot/index.ts
@@ -574,6 +574,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
             response.results.map((result) => ({
               ...result,
               mappedData: result.rawData,
+              mappedProperties: result.rawData.properties,
             }))
           ),
         getNextCursorFromPage: (response) => response.paging?.next?.after,
@@ -585,6 +586,7 @@ class HubSpotClient extends AbstractCrmRemoteClient {
             response.results.map((result) => ({
               ...result,
               mappedData: result.rawData,
+              mappedProperties: result.rawData.properties,
             }))
           ),
         getNextCursorFromPage: (response) => response.paging?.next?.after,
@@ -1950,21 +1952,26 @@ function normalizeResponse(
 function toMappedRecords(
   records: ObjectRecordRawDataOnly<RecordWithFlattenedAssociations>[],
   fieldMappingConfig: FieldMappingConfig
-): ObjectRecord<RecordWithFlattenedAssociations>[] {
+): ObjectRecord<RecordWithFlattenedAssociations, Record<string, string>>[] {
   if (fieldMappingConfig.type === 'inherit_all_fields') {
     return records.map((record) => ({
       ...record,
       mappedData: record.rawData,
+      mappedProperties: record.rawData.properties,
     }));
   }
 
-  return records.map((record) => ({
-    ...record,
-    mappedData: {
-      ...record.rawData,
-      properties: toMappedProperties(record.rawData.properties, fieldMappingConfig),
-    },
-  }));
+  return records.map((record) => {
+    const mappedProperties = toMappedProperties(record.rawData.properties, fieldMappingConfig);
+    return {
+      ...record,
+      mappedData: {
+        ...record.rawData,
+        properties: mappedProperties,
+      },
+      mappedProperties,
+    };
+  });
 }
 
 function toMappedProperties(

--- a/packages/core/remotes/impl/ms_dynamics_365_sales/index.ts
+++ b/packages/core/remotes/impl/ms_dynamics_365_sales/index.ts
@@ -150,14 +150,18 @@ class MsDynamics365Sales extends AbstractCrmRemoteClient {
         createStreamFromPage: (response) => {
           const emittedAt = new Date();
           return Readable.from(
-            response.value.map((result: any) => ({
-              id: result[idkey],
-              rawData: result,
-              mappedData: toMappedProperties(result, fieldMappingConfig),
-              isDeleted: false,
-              lastModifiedAt: new Date(result.modifiedon),
-              emittedAt,
-            }))
+            response.value.map((result: any) => {
+              const mappedProperties = toMappedProperties(result, fieldMappingConfig);
+              return {
+                id: result[idkey],
+                rawData: result,
+                mappedData: mappedProperties,
+                mappedProperties,
+                isDeleted: false,
+                lastModifiedAt: new Date(result.modifiedon),
+                emittedAt,
+              };
+            })
           );
         },
         getNextCursorFromPage: (response) => response['@odata.nextLink'],

--- a/packages/core/remotes/impl/salesforce/index.ts
+++ b/packages/core/remotes/impl/salesforce/index.ts
@@ -312,10 +312,12 @@ ${modifiedAfter ? `WHERE SystemModstamp > ${modifiedAfter.toISOString()} ORDER B
           // TODO: types
           const { record, emittedAt } = chunk;
           // not declaring this in-line so we have the opportunity to do type checking
+          const mappedProperties = toMappedProperties(record, fieldMappingConfig);
           const emittedRecord: ObjectRecord = {
             id: record.Id,
             rawData: record,
-            mappedData: toMappedProperties(record, fieldMappingConfig),
+            mappedData: mappedProperties,
+            mappedProperties,
             isDeleted: record.IsDeleted === 'true',
             lastModifiedAt: new Date(record.SystemModstamp),
             emittedAt: emittedAt,

--- a/packages/types/object_record.ts
+++ b/packages/types/object_record.ts
@@ -1,15 +1,26 @@
 import type { SnakecasedKeys } from './snakecased_keys';
 
-export type ObjectRecordRawDataOnly<T = Record<string, any>> = {
+export type ObjectRecordRawDataOnly<D = Record<string, unknown>> = {
   id: string;
-  rawData: T;
+  rawData: D;
   isDeleted: boolean;
   lastModifiedAt: Date;
   emittedAt: Date;
 };
 
-export type ObjectRecord<T = Record<string, any>> = ObjectRecordRawDataOnly<T> & {
-  mappedData: T;
+export type ObjectRecord<
+  D extends Record<string, unknown> = Record<string, unknown>,
+  P extends Record<string, unknown> = D
+> = ObjectRecordRawDataOnly<D> & {
+  // the mapped data, in approximately the original shape from the provider
+  // - for salesforce, mappedData would look identical to mappedProperties
+  // - for hubspot, mappedData would have id, createdAt, updatedAt, associations, etc. at top-level,
+  // and `properties` would have the mapped properties, so `mappedProperties` would
+  // only contain the subset of data from `mappedData` under the `properties` key.
+  mappedData: D;
+  mappedProperties: P;
 };
 
-export type SnakecasedKeysObjectRecord<T = Record<string, any>> = SnakecasedKeys<ObjectRecord<T>>;
+export type SnakecasedKeysObjectRecord<T extends Record<string, unknown> = Record<string, unknown>> = SnakecasedKeys<
+  ObjectRecord<T>
+>;


### PR DESCRIPTION
Looks like this now for hubspot -> mongo

<img width="660" alt="image" src="https://github.com/supaglue-labs/supaglue/assets/1498227/9bd65d4e-ce1a-4324-8625-bcf453b99158">


## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
