### PR TITLE
feat: put additional fields in a separate key

### DIFF
--- a/packages/core/lib/entity.ts
+++ b/packages/core/lib/entity.ts
@@ -13,6 +13,9 @@ export function createFieldMappingConfigForEntity(
   // throw an error on that.
 
   // If there are any extra fields mapped, throw an error unless allowAdditionalFieldMappings is true
+  const coreFieldMappings = fieldMappings?.filter((field) =>
+    config.fields.find((entityField) => entityField.name === field.entityField)
+  );
   const additionalFieldMappings = fieldMappings?.filter(
     (field) => !config.fields.find((entityField) => entityField.name === field.entityField)
   );
@@ -22,8 +25,13 @@ export function createFieldMappingConfigForEntity(
 
   return {
     type: 'defined',
-    fieldMappings:
-      fieldMappings?.map(({ entityField, mappedField }) => ({
+    coreFieldMappings:
+      coreFieldMappings?.map(({ entityField, mappedField }) => ({
+        schemaField: entityField,
+        mappedField,
+      })) ?? [],
+    additionalFieldMappings:
+      additionalFieldMappings?.map(({ entityField, mappedField }) => ({
         schemaField: entityField,
         mappedField,
       })) ?? [],

--- a/packages/core/lib/schema.ts
+++ b/packages/core/lib/schema.ts
@@ -57,19 +57,22 @@ export function createFieldMappingConfig(
     throw new Error('Additional field mappings are not allowed');
   }
 
-  // Combine:
-  // 1. already-mapped schema fields
-  // 2. customer field mappings
   return {
     type: 'defined',
-    fieldMappings: [
+    coreFieldMappings: [
       ...mappedSchemaFields
         .filter(({ mappedName }) => !!mappedName)
         .map((field) => ({
           schemaField: field.name,
           mappedField: field.mappedName as string,
         })),
-      ...((customerFieldMappings?.filter(({ mappedField }) => !!mappedField) ?? []) as FieldMapping[]),
+      // customer-mapped fields that aren't already in mappedSchemaFields
+      ...((customerFieldMappings?.filter(
+        ({ schemaField, mappedField }) => !!mappedField && schema.fields.find((field) => field.name === schemaField)
+      ) ?? []) as FieldMapping[]),
     ],
+    additionalFieldMappings: (customerFieldMappings?.filter(
+      ({ schemaField, mappedField }) => !!mappedField && !schema.fields.find((field) => field.name === schemaField)
+    ) ?? []) as FieldMapping[],
   };
 }

--- a/packages/core/lib/util.ts
+++ b/packages/core/lib/util.ts
@@ -16,6 +16,10 @@ export const intersection = (listA: string[], listB: string[]): string[] => {
   return result;
 };
 
+export const union = (listA: string[], listB: string[]): string[] => {
+  return Array.from(new Set([...listA, ...listB]));
+};
+
 export const maxDate = (...dates: (Date | undefined | null)[]): Date => {
   const filteredDates = dates.filter((date) => date !== undefined && date !== null) as Date[];
   if (filteredDates.length === 0) {

--- a/packages/core/remotes/impl/ms_dynamics_365_sales/index.ts
+++ b/packages/core/remotes/impl/ms_dynamics_365_sales/index.ts
@@ -31,6 +31,7 @@ import {
 import type { ConnectorAuthConfig } from '../../base';
 import { AbstractCrmRemoteClient } from '../../categories/crm/base';
 import { paginator } from '../../utils/paginator';
+import { toMappedProperties } from '../../utils/properties';
 import {
   fromDynamicsAccountToRemoteAccount,
   fromDynamicsContactToRemoteContact,
@@ -45,7 +46,6 @@ import {
   toDynamicsLeadUpdateParams,
   toDynamicsOpportunityCreateParams,
   toDynamicsOpportunityUpdateParams,
-  toMappedProperties,
 } from './mappers';
 
 const MAX_PAGE_SIZE = 1000;

--- a/packages/core/remotes/impl/ms_dynamics_365_sales/mappers.ts
+++ b/packages/core/remotes/impl/ms_dynamics_365_sales/mappers.ts
@@ -15,6 +15,7 @@ import type {
 } from '@supaglue/types/crm';
 import type { Address, EmailAddress, PhoneNumber } from '@supaglue/types/crm/common';
 import type { FieldMappingConfig } from '@supaglue/types/field_mapping_config';
+import { toMappedProperties } from '../../utils/properties';
 
 const industryCodeToName = {
   1: 'Accounting',
@@ -807,16 +808,3 @@ const toDynamicsPhoneNumbers = (phoneNumbers: PhoneNumber[] | undefined): Record
     };
   }, {});
 };
-
-export function toMappedProperties(
-  properties: Record<string, any>,
-  fieldMappingConfig: FieldMappingConfig
-): Record<string, any> {
-  if (fieldMappingConfig.type === 'inherit_all_fields') {
-    return properties;
-  }
-
-  return Object.fromEntries(
-    fieldMappingConfig.fieldMappings.map(({ schemaField, mappedField }) => [schemaField, properties[mappedField]])
-  );
-}

--- a/packages/core/remotes/impl/pipedrive/index.ts
+++ b/packages/core/remotes/impl/pipedrive/index.ts
@@ -39,6 +39,7 @@ import { REFRESH_TOKEN_THRESHOLD_MS, retryWhenAxiosRateLimited } from '../../../
 import type { ConnectorAuthConfig } from '../../base';
 import { AbstractCrmRemoteClient } from '../../categories/crm/base';
 import { paginator } from '../../utils/paginator';
+import { toMappedProperties } from '../../utils/properties';
 import {
   fromPipedriveDealToOpportunity,
   fromPipedriveLeadToLead,
@@ -761,17 +762,4 @@ function filterForUpdatedAfter<
       return updatedAfter < new Date(record.updated_time);
     }),
   };
-}
-
-function toMappedProperties(
-  properties: Record<string, any>,
-  fieldMappingConfig: FieldMappingConfig
-): Record<string, any> {
-  if (fieldMappingConfig.type === 'inherit_all_fields') {
-    return properties;
-  }
-
-  return Object.fromEntries(
-    fieldMappingConfig.fieldMappings.map(({ schemaField, mappedField }) => [schemaField, properties[mappedField]])
-  );
 }

--- a/packages/core/remotes/utils/properties.ts
+++ b/packages/core/remotes/utils/properties.ts
@@ -1,0 +1,23 @@
+import type { FieldMappingConfig } from '@supaglue/types/field_mapping_config';
+import type { PropertiesWithAdditionalFields } from '@supaglue/types/object_record';
+
+export function toMappedProperties(
+  properties: Record<string, any>,
+  fieldMappingConfig: FieldMappingConfig
+): PropertiesWithAdditionalFields {
+  if (fieldMappingConfig.type === 'inherit_all_fields') {
+    return properties;
+  }
+
+  return {
+    ...Object.fromEntries(
+      fieldMappingConfig.coreFieldMappings.map(({ schemaField, mappedField }) => [schemaField, properties[mappedField]])
+    ),
+    additional_fields: Object.fromEntries(
+      fieldMappingConfig.additionalFieldMappings.map(({ schemaField, mappedField }) => [
+        schemaField,
+        properties[mappedField],
+      ])
+    ),
+  };
+}

--- a/packages/core/services/common_objects/crm/common_object_service.ts
+++ b/packages/core/services/common_objects/crm/common_object_service.ts
@@ -100,7 +100,7 @@ const mapCustomFields = (
   }
 
   Object.entries(customFields).forEach(([key, value]) => {
-    const fieldMapping = fieldMappingConfig.fieldMappings.find(({ schemaField }) => schemaField === key);
+    const fieldMapping = fieldMappingConfig.coreFieldMappings.find(({ schemaField }) => schemaField === key);
     if (fieldMapping) {
       if (fieldMapping.mappedField !== key && customFields[fieldMapping.mappedField]) {
         throw new BadRequestError(

--- a/packages/types/field_mapping_config.ts
+++ b/packages/types/field_mapping_config.ts
@@ -9,7 +9,8 @@ export type InheritedFieldMappingConfig = {
 
 export type DefinedFieldMappingConfig = {
   type: 'defined';
-  fieldMappings: FieldMapping[];
+  coreFieldMappings: FieldMapping[];
+  additionalFieldMappings: FieldMapping[];
 };
 
 export type FieldMappingConfig = InheritedFieldMappingConfig | DefinedFieldMappingConfig;

--- a/packages/types/object_record.ts
+++ b/packages/types/object_record.ts
@@ -24,3 +24,8 @@ export type ObjectRecord<
 export type SnakecasedKeysObjectRecord<T extends Record<string, unknown> = Record<string, unknown>> = SnakecasedKeys<
   ObjectRecord<T>
 >;
+
+export type PropertiesWithAdditionalFields = {
+  [key: string]: unknown;
+  additional_fields?: Record<string, unknown>;
+};


### PR DESCRIPTION
Example of entity sync:
<img width="761" alt="image" src="https://github.com/supaglue-labs/supaglue/assets/1498227/04672e33-251f-4076-85e4-e98af85a98f4">

Example with common object sync:
<img width="862" alt="image" src="https://github.com/supaglue-labs/supaglue/assets/1498227/38e9a116-cb5c-4977-80bc-e32cfc81ea50">

Example with standard object sync:
<img width="634" alt="image" src="https://github.com/supaglue-labs/supaglue/assets/1498227/20ad22e5-cc3c-4078-a313-605ca2cf10ff">

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
