### PR TITLE
fix: sort syncs by customerId, then providerName, then object

### DIFF
--- a/packages/core/services/sync_service.ts
+++ b/packages/core/services/sync_service.ts
@@ -34,6 +34,21 @@ export class SyncService {
       include: {
         connection: true,
       },
+      orderBy: [
+        {
+          connection: {
+            customerId: 'asc',
+          },
+        },
+        {
+          connection: {
+            providerName: 'asc',
+          },
+        },
+        {
+          object: 'asc',
+        },
+      ],
     });
     const countPromise = this.#prisma.sync.count({
       where: {


### PR DESCRIPTION
![image](https://github.com/supaglue-labs/supaglue/assets/1498449/e3454b77-939c-43f6-95c4-07cf9bed998d)
