### PR TITLE
chore: reverse toggle on syncs page from isPaused to isActive

### DIFF
--- a/apps/mgmt-ui/src/components/logs/SyncsTable.tsx
+++ b/apps/mgmt-ui/src/components/logs/SyncsTable.tsx
@@ -84,17 +84,17 @@ export default function SyncsTable(props: SyncsTableProps) {
       filterOperators: equalOperatorOnly,
     },
     {
-      field: 'paused',
-      headerName: 'Paused?',
+      field: 'active',
+      headerName: 'Active?',
       width: 120,
       sortable: false,
       filterable: false,
       renderCell: (params) => {
         return (
           <Switch
-            checked={params.row.paused}
+            checked={!params.row.paused}
             onChange={async (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
-              if (checked) {
+              if (!checked) {
                 const response =
                   params.row.type === 'object'
                     ? await pauseSync({


### PR DESCRIPTION
<!-- Please title your PR using conventional commits (https://www.conventionalcommits.org/en/v1.0.0/): -->

Fixes: SUP-549

![image](https://github.com/supaglue-labs/supaglue/assets/1498449/88284db9-78dc-45f4-b037-778747c290f7)
