### PR TITLE
feat!: write _supaglue_id and _supaglue_additional_fields

### DIFF
--- a/docs/docs/platform/entities/overview.md
+++ b/docs/docs/platform/entities/overview.md
@@ -232,13 +232,13 @@ A few things to note:
 }
 ```
 
-If the customer defined additional fields, like `email`, they will also be included in `_supaglue_raw_data` under the `additional_fields` key:
+If the customer defined additional fields, like `email`, they will also be included in `_supaglue_raw_data` under the `_supaglue_additional_fields` key:
 
 ```json
 {
   "first_name": "Alice",
   "last_name": "Smith",
-  "additional_fields": {
+  "_supaglue_additional_fields": {
     "email": "alicesmith@gmail.com"
   }
 }

--- a/packages/core/destination_writers/base.ts
+++ b/packages/core/destination_writers/base.ts
@@ -3,8 +3,10 @@ import type {
   CommonObjectTypeForCategory,
   CommonObjectTypeMapForCategory,
   ConnectionSafeAny,
+  PropertiesWithAdditionalFields,
   ProviderCategory,
   StandardFullObjectRecord,
+  TransformedPropertiesWithAdditionalFields,
 } from '@supaglue/types';
 import type { FullEntityRecord } from '@supaglue/types/entity_record';
 import type { Readable } from 'stream';
@@ -135,4 +137,14 @@ export abstract class BaseDestinationWriter implements DestinationWriter {
     stream: Readable,
     heartbeat: () => void
   ): Promise<WriteEntityRecordsResult>;
+}
+
+export function toTransformedPropertiesWithAdditionalFields(
+  properties: PropertiesWithAdditionalFields
+): TransformedPropertiesWithAdditionalFields {
+  const { additionalFields, ...rest } = properties;
+  return {
+    ...rest,
+    _supaglue_additional_fields: additionalFields,
+  };
 }

--- a/packages/core/destination_writers/mongodb.ts
+++ b/packages/core/destination_writers/mongodb.ts
@@ -228,6 +228,7 @@ export class MongoDBDestinationWriter extends BaseDestinationWriter {
       _supaglue_customer_id: customerId,
       _supaglue_id: record.id,
       _supaglue_emitted_at: new Date(),
+      _supaglue_last_modified_at: record.metadata.lastModifiedAt,
       _supaglue_is_deleted: record.metadata.isDeleted,
       _supaglue_raw_data: record.rawData,
       _supaglue_mapped_data: toTransformedPropertiesWithAdditionalFields(record.mappedProperties),

--- a/packages/core/destination_writers/mongodb.ts
+++ b/packages/core/destination_writers/mongodb.ts
@@ -220,7 +220,7 @@ export class MongoDBDestinationWriter extends BaseDestinationWriter {
     collectionName: string,
     record: BaseFullRecord
   ): Promise<void> {
-    const { additionalFields: additionalMappedData, ...otherMappedData } = record.mappedData;
+    const { additional_fields: additionalMappedData, ...otherMappedData } = record.mappedProperties;
 
     const mappedRecord = {
       _supaglue_application_id: applicationId,
@@ -230,7 +230,7 @@ export class MongoDBDestinationWriter extends BaseDestinationWriter {
       _supaglue_emitted_at: new Date(),
       _supaglue_is_deleted: record.metadata.isDeleted,
       _supaglue_raw_data: record.rawData,
-      _supaglue_mapped_data: record.mappedData,
+      _supaglue_mapped_data: record.mappedProperties,
       ...otherMappedData,
       _supaglue_additional_fields: additionalMappedData,
     };

--- a/packages/core/destination_writers/postgres.ts
+++ b/packages/core/destination_writers/postgres.ts
@@ -339,7 +339,7 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
         _supaglue_emitted_at: new Date(),
         _supaglue_is_deleted: record.metadata.isDeleted,
         _supaglue_raw_data: record.rawData,
-        _supaglue_mapped_data: record.mappedData,
+        _supaglue_mapped_data: record.mappedProperties,
       };
       const columns = Object.keys(mappedRecord);
       const columnsToUpdate = columns.filter(

--- a/packages/core/destination_writers/postgres.ts
+++ b/packages/core/destination_writers/postgres.ts
@@ -36,7 +36,7 @@ import { keysOfSnakecasedSequenceStateWithTenant } from '../keys/engagement/sequ
 import { keysOfSnakecasedEngagementUserWithTenant } from '../keys/engagement/user';
 import { logger } from '../lib';
 import type { WriteCommonObjectRecordsResult, WriteEntityRecordsResult, WriteObjectRecordsResult } from './base';
-import { BaseDestinationWriter } from './base';
+import { BaseDestinationWriter, toTransformedPropertiesWithAdditionalFields } from './base';
 import { getSnakecasedKeysMapper } from './util';
 
 export class PostgresDestinationWriter extends BaseDestinationWriter {
@@ -339,7 +339,7 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
         _supaglue_emitted_at: new Date(),
         _supaglue_is_deleted: record.metadata.isDeleted,
         _supaglue_raw_data: record.rawData,
-        _supaglue_mapped_data: record.mappedProperties,
+        _supaglue_mapped_data: toTransformedPropertiesWithAdditionalFields(record.mappedProperties),
       };
       const columns = Object.keys(mappedRecord);
       const columnsToUpdate = columns.filter(
@@ -425,7 +425,7 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`,
           c !== '_supaglue_application_id' &&
           c !== '_supaglue_provider_name' &&
           c !== '_supaglue_customer_id' &&
-          c !== '_id'
+          c !== '_supaglue_id'
       );
 
       // Output
@@ -465,7 +465,7 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`,
                 _supaglue_last_modified_at: record.lastModifiedAt,
                 _supaglue_is_deleted: record.isDeleted,
                 _supaglue_raw_data: record.rawData,
-                _supaglue_mapped_data: record.mappedProperties,
+                _supaglue_mapped_data: toTransformedPropertiesWithAdditionalFields(record.mappedProperties),
               };
 
               ++tempTableRowCount;

--- a/packages/core/destination_writers/postgres.ts
+++ b/packages/core/destination_writers/postgres.ts
@@ -337,6 +337,7 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
         _supaglue_customer_id: customerId,
         _supaglue_id: record.id,
         _supaglue_emitted_at: new Date(),
+        _supaglue_last_modified_at: record.metadata.lastModifiedAt,
         _supaglue_is_deleted: record.metadata.isDeleted,
         _supaglue_raw_data: record.rawData,
         _supaglue_mapped_data: toTransformedPropertiesWithAdditionalFields(record.mappedProperties),

--- a/packages/core/destination_writers/s3.ts
+++ b/packages/core/destination_writers/s3.ts
@@ -15,7 +15,7 @@ import type { Readable } from 'stream';
 import { Transform } from 'stream';
 import { pipeline } from 'stream/promises';
 import type { WriteCommonObjectRecordsResult, WriteEntityRecordsResult, WriteObjectRecordsResult } from './base';
-import { BaseDestinationWriter } from './base';
+import { BaseDestinationWriter, toTransformedPropertiesWithAdditionalFields } from './base';
 import { getSnakecasedKeysMapper } from './util';
 
 const CHUNK_SIZE = 1000;
@@ -216,7 +216,7 @@ export class S3DestinationWriter extends BaseDestinationWriter {
               _supaglue_last_modified_at: record.lastModifiedAt,
               _supaglue_is_deleted: record.isDeleted,
               _supaglue_raw_data: record.rawData,
-              _supaglue_mapped_data: record.mappedProperties,
+              _supaglue_mapped_data: toTransformedPropertiesWithAdditionalFields(record.mappedProperties),
             };
             data.push(mappedRecord);
 

--- a/packages/core/destination_writers/s3.ts
+++ b/packages/core/destination_writers/s3.ts
@@ -211,12 +211,12 @@ export class S3DestinationWriter extends BaseDestinationWriter {
               _supaglue_application_id: applicationId,
               _supaglue_provider_name: providerName,
               _supaglue_customer_id: customerId,
+              _supaglue_id: record.id,
               _supaglue_emitted_at: record.emittedAt,
               _supaglue_last_modified_at: record.lastModifiedAt,
               _supaglue_is_deleted: record.isDeleted,
               _supaglue_raw_data: record.rawData,
               _supaglue_mapped_data: record.mappedProperties,
-              id: record.id,
             };
             data.push(mappedRecord);
 

--- a/packages/core/lib/entity.ts
+++ b/packages/core/lib/entity.ts
@@ -39,7 +39,7 @@ export function createFieldMappingConfigForEntity(
 }
 
 export function validateEntityOrSchemaFieldName(name: string): void {
-  if (name.startsWith('_supaglue') || name === 'id' || name === 'additional_fields') {
+  if (name.startsWith('_supaglue')) {
     throw new Error(`Invalid field name: ${name}; this is a reserved field name.`);
   }
 }

--- a/packages/core/mappers/entity_record.ts
+++ b/packages/core/mappers/entity_record.ts
@@ -1,7 +1,7 @@
 import type { EntityRecord } from '@supaglue/types/entity_record';
 
 export function toSnakecaseKeysEntityRecord(record: EntityRecord) {
-  const { additionalFields, ...rest } = record.data;
+  const { additional_fields: additionalFields, ...rest } = record.data;
   return {
     id: record.id,
     entity: record.entity,

--- a/packages/core/mappers/entity_record.ts
+++ b/packages/core/mappers/entity_record.ts
@@ -1,7 +1,7 @@
 import type { EntityRecord } from '@supaglue/types/entity_record';
 
 export function toSnakecaseKeysEntityRecord(record: EntityRecord) {
-  const { additional_fields: additionalFields, ...rest } = record.data;
+  const { additionalFields: additionalFields, ...rest } = record.data;
   return {
     id: record.id,
     entity: record.entity,

--- a/packages/core/mappers/object_record.ts
+++ b/packages/core/mappers/object_record.ts
@@ -1,7 +1,7 @@
 import type { StandardObjectRecord } from '@supaglue/types';
 
 export function toSnakecaseKeysStandardObjectRecord(record: StandardObjectRecord) {
-  const { additional_fields: additionalFields, ...rest } = record.data;
+  const { additionalFields: additionalFields, ...rest } = record.data;
   return {
     id: record.id,
     standard_object_name: record.standardObjectName,

--- a/packages/core/mappers/object_record.ts
+++ b/packages/core/mappers/object_record.ts
@@ -1,7 +1,7 @@
 import type { StandardObjectRecord } from '@supaglue/types';
 
 export function toSnakecaseKeysStandardObjectRecord(record: StandardObjectRecord) {
-  const { additionalFields, ...rest } = record.data;
+  const { additional_fields: additionalFields, ...rest } = record.data;
   return {
     id: record.id,
     standard_object_name: record.standardObjectName,

--- a/packages/core/remotes/utils/properties.ts
+++ b/packages/core/remotes/utils/properties.ts
@@ -13,7 +13,7 @@ export function toMappedProperties(
     ...Object.fromEntries(
       fieldMappingConfig.coreFieldMappings.map(({ schemaField, mappedField }) => [schemaField, properties[mappedField]])
     ),
-    additional_fields: Object.fromEntries(
+    additionalFields: Object.fromEntries(
       fieldMappingConfig.additionalFieldMappings.map(({ schemaField, mappedField }) => [
         schemaField,
         properties[mappedField],

--- a/packages/core/services/entity_record_service.ts
+++ b/packages/core/services/entity_record_service.ts
@@ -261,7 +261,7 @@ function mapObjectToEntityFields(data: EntityRecordData, fieldMappingConfig: Fie
 
       return {
         ...coreFields,
-        additional_fields: additionalFields,
+        additionalFields: additionalFields,
       };
     }
   }

--- a/packages/core/services/entity_record_service.ts
+++ b/packages/core/services/entity_record_service.ts
@@ -100,7 +100,7 @@ export class EntityRecordService {
         id: entity.id,
         name: entity.name,
       },
-      mappedData: mapObjectToEntityFields(record.data, fieldMappingConfig),
+      mappedProperties: mapObjectToEntityFields(record.data, fieldMappingConfig),
       rawData: record.data,
       metadata: record.metadata,
     };
@@ -111,7 +111,11 @@ export class EntityRecordService {
     entityName: string,
     recordId: string
   ): Promise<EntityRecord> {
-    const { id, entity, mappedData } = await this.#getFullEntityRecord(connection, entityName, recordId);
+    const {
+      id,
+      entity,
+      mappedProperties: mappedData,
+    } = await this.#getFullEntityRecord(connection, entityName, recordId);
     return {
       id,
       entity,
@@ -257,7 +261,7 @@ function mapObjectToEntityFields(data: EntityRecordData, fieldMappingConfig: Fie
 
       return {
         ...coreFields,
-        additionalFields,
+        additional_fields: additionalFields,
       };
     }
   }

--- a/packages/core/services/entity_record_service.ts
+++ b/packages/core/services/entity_record_service.ts
@@ -48,7 +48,7 @@ export class EntityRecordService {
     );
     const mappedData = mapEntityToObjectFields(data, fieldMappingConfig);
     const id = await remoteClient.createObjectRecord(object, mappedData);
-    await this.#cacheInvalidateEntityRecord(connection, entityName, id);
+    await this.#cacheInvalidateEntityRecord(connection, entityName, entity.id, id);
     return {
       id,
       entity: {
@@ -58,15 +58,20 @@ export class EntityRecordService {
     };
   }
 
-  async #cacheInvalidateEntityRecord(connection: ConnectionSafeAny, entityName: string, id: string): Promise<void> {
-    const sync = await this.#syncService.findByConnectionIdAndEntity(connection.id, entityName);
+  async #cacheInvalidateEntityRecord(
+    connection: ConnectionSafeAny,
+    entityName: string,
+    entityId: string,
+    id: string
+  ): Promise<void> {
+    const sync = await this.#syncService.findByConnectionIdAndEntity(connection.id, entityId);
     if (!sync || sync.paused) {
       return;
     }
     const [writer] = await this.#destinationService.getWriterByProviderId(connection.providerId);
     if (writer) {
-      const entity = await this.#getFullEntityRecord(connection, entityName, id);
-      await writer.upsertEntityRecord(connection, entityName, entity);
+      const record = await this.#getFullEntityRecord(connection, entityName, id);
+      await writer.upsertEntityRecord(connection, entityName, record);
     }
   }
 
@@ -138,7 +143,7 @@ export class EntityRecordService {
     const mappedData = mapEntityToObjectFields(data, fieldMappingConfig);
     await remoteClient.updateObjectRecord(object, recordId, mappedData);
 
-    await this.#cacheInvalidateEntityRecord(connection, entityName, recordId);
+    await this.#cacheInvalidateEntityRecord(connection, entityName, entity.id, recordId);
   }
 
   public async listAssociations(connectionId: string, params: ListAssociationsParams): Promise<Association[]> {

--- a/packages/core/services/object_record_service.ts
+++ b/packages/core/services/object_record_service.ts
@@ -73,8 +73,8 @@ export class ObjectRecordService {
     }
     const [writer] = await this.#destinationService.getWriterByProviderId(connection.providerId);
     if (writer) {
-      const object = await this.#getStandardFullObjectRecord(connection, objectName, id);
-      await writer.upsertStandardObjectRecord(connection, objectName, object);
+      const record = await this.#getStandardFullObjectRecord(connection, objectName, id);
+      await writer.upsertStandardObjectRecord(connection, objectName, record);
     }
   }
 

--- a/packages/core/services/object_record_service.ts
+++ b/packages/core/services/object_record_service.ts
@@ -109,7 +109,7 @@ export class ObjectRecordService {
     return {
       id: recordId,
       standardObjectName: objectName,
-      mappedData: mapObjectToSchema(record.data, fieldMappingConfig),
+      mappedProperties: mapObjectToSchema(record.data, fieldMappingConfig),
       rawData: record.data,
       metadata: record.metadata,
     };
@@ -120,11 +120,11 @@ export class ObjectRecordService {
     objectName: string,
     recordId: string
   ): Promise<StandardObjectRecord> {
-    const { id, standardObjectName, mappedData } = await this.#getStandardFullObjectRecord(
-      connection,
-      objectName,
-      recordId
-    );
+    const {
+      id,
+      standardObjectName,
+      mappedProperties: mappedData,
+    } = await this.#getStandardFullObjectRecord(connection, objectName, recordId);
     return {
       id,
       standardObjectName,
@@ -207,7 +207,7 @@ function mapObjectToSchema(data: ObjectRecordData, fieldMappingConfig: FieldMapp
 
       return {
         ...coreFields,
-        additionalFields,
+        additional_fields: additionalFields,
       };
     }
   }

--- a/packages/core/services/object_record_service.ts
+++ b/packages/core/services/object_record_service.ts
@@ -207,7 +207,7 @@ function mapObjectToSchema(data: ObjectRecordData, fieldMappingConfig: FieldMapp
 
       return {
         ...coreFields,
-        additional_fields: additionalFields,
+        additionalFields: additionalFields,
       };
     }
   }

--- a/packages/sync-workflows/activities/sync_entity_records.ts
+++ b/packages/sync-workflows/activities/sync_entity_records.ts
@@ -192,7 +192,7 @@ function toMappedProperties(
     ...Object.fromEntries(
       fieldMappingConfig.coreFieldMappings.map(({ schemaField, mappedField }) => [schemaField, properties[mappedField]])
     ),
-    additional_fields: Object.fromEntries(
+    additionalFields: Object.fromEntries(
       fieldMappingConfig.additionalFieldMappings.map(({ schemaField, mappedField }) => [
         schemaField,
         properties[mappedField],

--- a/packages/sync-workflows/activities/sync_object_records.ts
+++ b/packages/sync-workflows/activities/sync_object_records.ts
@@ -232,7 +232,7 @@ function toMappedProperties(
     ...Object.fromEntries(
       fieldMappingConfig.coreFieldMappings.map(({ schemaField, mappedField }) => [schemaField, properties[mappedField]])
     ),
-    additional_fields: Object.fromEntries(
+    additionalFields: Object.fromEntries(
       fieldMappingConfig.additionalFieldMappings.map(({ schemaField, mappedField }) => [
         schemaField,
         properties[mappedField],

--- a/packages/types/entity_record.ts
+++ b/packages/types/entity_record.ts
@@ -1,4 +1,4 @@
-import type { BaseFullRecord, ObjectRecordUpsertData } from './object_record';
+import type { BaseFullRecord, ObjectRecordUpsertData, PropertiesWithAdditionalFields } from './object_record';
 
 export type SimpleEntity = {
   id: string;
@@ -12,10 +12,7 @@ export type CreatedEntityRecord = {
 
 export type EntityRecordUpsertData = ObjectRecordUpsertData;
 
-export type EntityRecordData = {
-  additionalFields?: Record<string, unknown>;
-  [key: string]: unknown;
-};
+export type EntityRecordData = PropertiesWithAdditionalFields;
 
 export type EntityRecord = {
   id: string;

--- a/packages/types/object_record.ts
+++ b/packages/types/object_record.ts
@@ -18,15 +18,13 @@ export type ListedObjectRecord<
   rawProperties: P;
 };
 
-export type MappedListedObjectRecord<
-  D extends Record<string, unknown> = Record<string, unknown>,
-  P extends Record<string, unknown> = Record<string, unknown>
-> = ListedObjectRecordRawDataOnly<D> & {
-  // mappedProperties should only have properties
-  // - in salesforce, this is easy
-  // - in hubspot, we have to only record the data in `properties`
-  mappedProperties: P;
-};
+export type MappedListedObjectRecord<D extends Record<string, unknown> = Record<string, unknown>> =
+  ListedObjectRecordRawDataOnly<D> & {
+    // mappedProperties should only have properties
+    // - in salesforce, this is easy
+    // - in hubspot, we have to only record the data in `properties`
+    mappedProperties: PropertiesWithAdditionalFields;
+  };
 
 export type SnakecasedKeysObjectRecord<T extends Record<string, unknown> = Record<string, unknown>> = SnakecasedKeys<
   ListedObjectRecord<T>

--- a/packages/types/object_record.ts
+++ b/packages/types/object_record.ts
@@ -32,9 +32,12 @@ export type SnakecasedKeysObjectRecord<T extends Record<string, unknown> = Recor
 
 export type PropertiesWithAdditionalFields = {
   [key: string]: unknown;
-  // IMPORTANT: this is intentionally snakecase so that when we write to destination, we don't need to snakecase-ify it
-  // If you change this back to camelcase, make sure that you address this in all destination writers
-  additional_fields?: Record<string, unknown>;
+  additionalFields?: Record<string, unknown>;
+};
+
+export type TransformedPropertiesWithAdditionalFields = {
+  [key: string]: unknown;
+  _supaglue_additional_fields?: Record<string, unknown>;
 };
 
 type BaseCreatedObjectRecord = {

--- a/packages/types/object_record.ts
+++ b/packages/types/object_record.ts
@@ -32,6 +32,8 @@ export type SnakecasedKeysObjectRecord<T extends Record<string, unknown> = Recor
 
 export type PropertiesWithAdditionalFields = {
   [key: string]: unknown;
+  // IMPORTANT: this is intentionally snakecase so that when we write to destination, we don't need to snakecase-ify it
+  // If you change this back to camelcase, make sure that you address this in all destination writers
   additional_fields?: Record<string, unknown>;
 };
 
@@ -45,10 +47,7 @@ export type CreatedStandardObjectRecord = BaseCreatedObjectRecord & {
 
 export type ObjectRecordUpsertData = Record<string, unknown>;
 
-export type ObjectRecordData = {
-  additionalFields?: Record<string, unknown>;
-  [key: string]: unknown;
-};
+export type ObjectRecordData = PropertiesWithAdditionalFields;
 
 type BaseObjectRecord = {
   id: string;
@@ -72,7 +71,7 @@ export type ObjectMetadata = {
 
 export type BaseFullRecord = {
   id: string;
-  mappedData: ObjectRecordData;
+  mappedProperties: ObjectRecordData;
   rawData: Record<string, unknown>;
   metadata: ObjectMetadata;
 };


### PR DESCRIPTION
This also fixes some bugs:
- We were writing `additionalFields` for mongo cache invalidation but `additional_fields` for actual syncing.
- Cache invalidation for entities was broken. We weren't actually invalidating for entity writes.

This is backwards incompatible. We'll need to tell customers to drop their standard/custom/entity sync tables.

## Test Plan

I tested this for hubspot -> postgres and hubspot -> mongo syncs. i also tested cache invalidation.

## Deployment instructions

[Add any special deployment instructions here]
