### PR TITLE
chore: kill sync if takes too long, and provide heartbeats while retrying 429

### DIFF
--- a/packages/core/destination_writers/postgres.ts
+++ b/packages/core/destination_writers/postgres.ts
@@ -53,6 +53,7 @@ export class PostgresDestinationWriter extends BaseDestinationWriter {
     const { sslMode, ...rest } = this.#destination.config;
     const pool = new Pool({
       ...rest,
+      statement_timeout: 60 * 60 * 1000, // 1 hour - assuming that COPY FROM STDIN is subject to this timeout
       ssl: getSsl(sslMode),
     });
     return await pool.connect();

--- a/packages/core/remotes/categories/engagement/base.ts
+++ b/packages/core/remotes/categories/engagement/base.ts
@@ -4,7 +4,11 @@ import type { RemoteClient } from '../../base';
 import { AbstractRemoteClient } from '../../base';
 
 export interface EngagementRemoteClient extends RemoteClient {
-  listCommonObjectRecords(commonObjectType: EngagementCommonObjectType, updatedAfter?: Date): Promise<Readable>;
+  listCommonObjectRecords(
+    commonObjectType: EngagementCommonObjectType,
+    updatedAfter?: Date,
+    heartbeat?: () => void
+  ): Promise<Readable>;
   getCommonObjectRecord<T extends EngagementCommonObjectType>(
     commonObjectType: T,
     id: string
@@ -30,7 +34,8 @@ export abstract class AbstractEngagementRemoteClient extends AbstractRemoteClien
 
   public async listCommonObjectRecords(
     commonObjectType: EngagementCommonObjectType,
-    updatedAfter?: Date
+    updatedAfter?: Date,
+    heartbeat?: () => void
   ): Promise<Readable> {
     throw new Error('Not implemented');
   }

--- a/packages/core/remotes/impl/apollo/index.ts
+++ b/packages/core/remotes/impl/apollo/index.ts
@@ -139,8 +139,11 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     return fromApolloSequenceToSequence(response.data.emailer_campaign);
   }
 
-  async #getAccountPage(page = 1, updatedAfter?: Date): Promise<ApolloPaginatedAccounts> {
+  async #getAccountPage(page = 1, updatedAfter?: Date, heartbeat?: () => void): Promise<ApolloPaginatedAccounts> {
     return await retryWhenAxiosRateLimited(async () => {
+      if (heartbeat) {
+        heartbeat();
+      }
       const response = await axios.post<ApolloPaginatedAccounts>(
         `${this.#baseURL}/v1/accounts/search`,
         {
@@ -155,9 +158,9 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     });
   }
 
-  async #listAccounts(updatedAfter?: Date): Promise<Readable> {
+  async #listAccounts(updatedAfter?: Date, heartbeat?: () => void): Promise<Readable> {
     const normalPageFetcher = async (pageAsStr?: string) =>
-      await this.#getAccountPage(pageAsStr ? parseInt(pageAsStr) : undefined, updatedAfter);
+      await this.#getAccountPage(pageAsStr ? parseInt(pageAsStr) : undefined, updatedAfter, heartbeat);
     return await paginator([
       {
         pageFetcher: normalPageFetcher,
@@ -175,8 +178,11 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     ]);
   }
 
-  async #getContactPage(page = 1, updatedAfter?: Date): Promise<ApolloPaginatedContacts> {
+  async #getContactPage(page = 1, updatedAfter?: Date, heartbeat?: () => void): Promise<ApolloPaginatedContacts> {
     return await retryWhenAxiosRateLimited(async () => {
+      if (heartbeat) {
+        heartbeat();
+      }
       const response = await axios.post<ApolloPaginatedContacts>(
         `${this.#baseURL}/v1/contacts/search`,
         {
@@ -193,9 +199,9 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     });
   }
 
-  async #listContacts(updatedAfter?: Date): Promise<Readable> {
+  async #listContacts(updatedAfter?: Date, heartbeat?: () => void): Promise<Readable> {
     const normalPageFetcher = async (pageAsStr?: string) =>
-      await this.#getContactPage(pageAsStr ? parseInt(pageAsStr) : undefined, updatedAfter);
+      await this.#getContactPage(pageAsStr ? parseInt(pageAsStr) : undefined, updatedAfter, heartbeat);
     return await paginator([
       {
         pageFetcher: normalPageFetcher,
@@ -213,8 +219,11 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     ]);
   }
 
-  async #getUserPage(page = 1, updatedAfter?: Date): Promise<ApolloPaginatedUsers> {
+  async #getUserPage(page = 1, updatedAfter?: Date, heartbeat?: () => void): Promise<ApolloPaginatedUsers> {
     return await retryWhenAxiosRateLimited(async () => {
+      if (heartbeat) {
+        heartbeat();
+      }
       const response = await axios.get<ApolloPaginatedUsers>(`${this.#baseURL}/v1/users/search`, {
         headers: this.#headers,
         params: {
@@ -226,9 +235,9 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     });
   }
 
-  async #listUsers(updatedAfter?: Date): Promise<Readable> {
+  async #listUsers(updatedAfter?: Date, heartbeat?: () => void): Promise<Readable> {
     const normalPageFetcher = async (pageAsStr?: string) =>
-      await this.#getUserPage(pageAsStr ? parseInt(pageAsStr) : undefined, updatedAfter);
+      await this.#getUserPage(pageAsStr ? parseInt(pageAsStr) : undefined, updatedAfter, heartbeat);
     return await paginator([
       {
         pageFetcher: normalPageFetcher,
@@ -246,8 +255,11 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     ]);
   }
 
-  async #getSequencePage(page = 1, updatedAfter?: Date): Promise<ApolloPaginatedSequences> {
+  async #getSequencePage(page = 1, updatedAfter?: Date, heartbeat?: () => void): Promise<ApolloPaginatedSequences> {
     return await retryWhenAxiosRateLimited(async () => {
+      if (heartbeat) {
+        heartbeat();
+      }
       const response = await axios.post<ApolloPaginatedSequences>(
         `${this.#baseURL}/v1/emailer_campaigns/search`,
         {
@@ -262,9 +274,9 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     });
   }
 
-  async #listSequences(updatedAfter?: Date): Promise<Readable> {
+  async #listSequences(updatedAfter?: Date, heartbeat?: () => void): Promise<Readable> {
     const normalPageFetcher = async (pageAsStr?: string) =>
-      await this.#getSequencePage(pageAsStr ? parseInt(pageAsStr) : undefined, updatedAfter);
+      await this.#getSequencePage(pageAsStr ? parseInt(pageAsStr) : undefined, updatedAfter, heartbeat);
     return await paginator([
       {
         pageFetcher: normalPageFetcher,
@@ -282,8 +294,11 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     ]);
   }
 
-  async #listMailboxes(updatedAfter?: Date): Promise<Readable> {
+  async #listMailboxes(updatedAfter?: Date, heartbeat?: () => void): Promise<Readable> {
     return await retryWhenAxiosRateLimited(async () => {
+      if (heartbeat) {
+        heartbeat();
+      }
       const response = await axios.get<{ email_accounts: Record<string, any>[] }>(
         `${this.#baseURL}/v1/email_accounts`,
         {
@@ -303,9 +318,9 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     });
   }
 
-  async #listSequenceStates(updatedAfter?: Date): Promise<Readable> {
+  async #listSequenceStates(updatedAfter?: Date, heartbeat?: () => void): Promise<Readable> {
     const normalPageFetcher = async (pageAsStr?: string) =>
-      await this.#getContactPage(pageAsStr ? parseInt(pageAsStr) : undefined, updatedAfter);
+      await this.#getContactPage(pageAsStr ? parseInt(pageAsStr) : undefined, updatedAfter, heartbeat);
     return await paginator([
       {
         pageFetcher: normalPageFetcher,
@@ -325,21 +340,22 @@ class ApolloClient extends AbstractEngagementRemoteClient {
 
   public override async listCommonObjectRecords(
     commonObjectType: EngagementCommonObjectType,
-    updatedAfter?: Date | undefined
+    updatedAfter?: Date | undefined,
+    heartbeat?: () => void
   ): Promise<Readable> {
     switch (commonObjectType) {
       case 'account':
-        return await this.#listAccounts(updatedAfter);
+        return await this.#listAccounts(updatedAfter, heartbeat);
       case 'contact':
-        return await this.#listContacts(updatedAfter);
+        return await this.#listContacts(updatedAfter, heartbeat);
       case 'user':
-        return await this.#listUsers(updatedAfter);
+        return await this.#listUsers(updatedAfter, heartbeat);
       case 'sequence':
-        return await this.#listSequences(updatedAfter);
+        return await this.#listSequences(updatedAfter, heartbeat);
       case 'mailbox':
-        return await this.#listMailboxes(updatedAfter);
+        return await this.#listMailboxes(updatedAfter, heartbeat);
       case 'sequence_state':
-        return await this.#listSequenceStates(updatedAfter);
+        return await this.#listSequenceStates(updatedAfter, heartbeat);
       default:
         throw new BadRequestError(`Common object type ${commonObjectType} not supported for the Apollo API`);
     }

--- a/packages/core/remotes/impl/salesloft/index.ts
+++ b/packages/core/remotes/impl/salesloft/index.ts
@@ -81,6 +81,7 @@ class SalesloftClient extends AbstractEngagementRemoteClient {
   readonly #credentials: Credentials;
   readonly #headers: Record<string, string>;
   readonly #baseURL: string;
+
   public constructor(credentials: Credentials) {
     super('https://api.salesloft.com');
     this.#baseURL = 'https://api.salesloft.com';

--- a/packages/sync-workflows/activities/sync_object_records.ts
+++ b/packages/sync-workflows/activities/sync_object_records.ts
@@ -67,7 +67,6 @@ export function createSyncObjectRecords(
                   'common',
                   object
                 );
-
                 const readable = await client.listCommonObjectRecords(
                   object as CRMCommonObjectType,
                   fieldMappingConfig,
@@ -85,7 +84,8 @@ export function createSyncObjectRecords(
                 const [client] = await remoteService.getEngagementRemoteClient(connectionId);
                 const readable = await client.listCommonObjectRecords(
                   object as EngagementCommonObjectType,
-                  updatedAfter
+                  updatedAfter,
+                  heartbeat
                 );
                 return await writer.writeCommonObjectRecords(
                   connection,


### PR DESCRIPTION
- While retrying calls for 429, we should emit heartbeat so Temporal doesn't kill the activity
- Even if send heartbeats, we may hit the `startToCloseTimeout` for an activity. When that happens, we are screwed. We can set a statement timeout to make sure that postgres eventually cleans up connections.

We should also implement proper connection pooling as a next, but less urgent, step.

[Describe your change here]

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
