### PR TITLE
fix: inferred salesforce title

### DIFF
--- a/packages/core/remotes/impl/salesforce/index.ts
+++ b/packages/core/remotes/impl/salesforce/index.ts
@@ -1316,7 +1316,10 @@ ${modifiedAfter ? `WHERE SystemModstamp > ${modifiedAfter.toISOString()} ORDER B
 
     // jsforce doesn't provide a stable jsonapi "title" so infer it from the message.
     // assumed format: "Some Title: Array of json details" or "Some Title"
-    const inferredTitle = error.message.substring(0, Math.min(error.message.indexOf(':'), error.message.length));
+    const inferredTitle = error.message.substring(
+      0,
+      error.message.includes(':') ? error.message.indexOf(':') : error.message.length
+    );
 
     // https://developer.salesforce.com/docs/atlas.en-us.210.0.object_reference.meta/object_reference/sforce_api_calls_concepts_core_data_objects.htm#i1421192
     switch (error.errorCode) {


### PR DESCRIPTION
empirically jsforce returns three error message formats:
1. "title"
2. `<html>...</html>`
3. "title: json details"

Tested the change to have the the `title` response be the whole string for cases (1) and (2) and the title portion for (3)

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
