### PR TITLE
fix: two run object sync changes

### DIFF
--- a/packages/sync-workflows/workflows/run_object_sync.ts
+++ b/packages/sync-workflows/workflows/run_object_sync.ts
@@ -283,9 +283,11 @@ async function doFullThenIncrementalSync(sync: FullThenIncrementalSync): Promise
 
 const getErrorMessageStack = (err: Error): { message: string; stack: string } => {
   if (err instanceof ActivityFailure) {
+    // Return the inner most error cause that is two layers deep, otherwise return the first child's error cause
+    // so we don't return Temporal error messages to customers, but Provider error messages
     return {
-      message: err.failure?.cause?.message ?? 'Unknown error',
-      stack: err.failure?.cause?.stackTrace ?? 'No proto stack',
+      message: err.failure?.cause?.cause?.message ?? err.failure?.cause?.message ?? 'Unknown error',
+      stack: err.failure?.cause?.cause?.stackTrace ?? err.failure?.cause?.stackTrace ?? 'No proto stack',
     };
   }
   if (err instanceof ApplicationFailure) {


### PR DESCRIPTION
- bump activity timeout from 10s to 12s
- try to log the inner most cause first

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
