### PR TITLE
fix: denormalize object_sync_runs step 1/2

### DIFF
--- a/apps/api/routes/internal/_multitenant_backfill/index.ts
+++ b/apps/api/routes/internal/_multitenant_backfill/index.ts
@@ -1,0 +1,43 @@
+import { getDependencyContainer } from '@/dependency_container';
+import { logger } from '@supaglue/core/lib';
+import type { Request, Response } from 'express';
+import { Router } from 'express';
+
+const { prisma } = getDependencyContainer();
+
+export default function init(app: Router): void {
+  const applicationRouter = Router();
+
+  applicationRouter.post('/_denormalize_object_sync_runs', async (req: Request, res: Response) => {
+    const objectSyncIds = await prisma.$queryRaw<
+      { object_sync_id: string }[]
+    >`SELECT DISTINCT object_sync_id FROM object_sync_runs`;
+    for (const objectSyncId of objectSyncIds) {
+      const objectSync = await prisma.$queryRaw<
+        { connection_id: string; object: string; object_type: string; entity_id: string; type: string }[]
+      >`SELECT connection_id, object, object_type, entity_id, type FROM object_syncs WHERE id = ${objectSyncId.object_sync_id}`;
+
+      if (!objectSync || objectSync.length !== 1) {
+        throw new Error('object sync not found');
+      }
+
+      const updateObjectSyncRunResult: number =
+        await prisma.$queryRaw`UPDATE object_sync_runs SET connection_id = ${objectSync[0].connection_id}, object = ${objectSync[0].object}, object_type = ${objectSync[0].object_type}, entity_id = ${objectSync[0].entity_id}, sync_type = ${objectSync[0].type} WHERE object_sync_id = ${objectSyncId.object_sync_id}`;
+
+      if (updateObjectSyncRunResult === 0) {
+        throw new Error('update object sync run failed');
+      }
+
+      logger.info(
+        {
+          object_sync_id: objectSyncId.object_sync_id,
+        },
+        'backfilled object_sync_runs for a object sync id'
+      );
+    }
+
+    return res.status(200).send();
+  });
+
+  app.use('/_backfill', applicationRouter);
+}

--- a/apps/api/routes/internal/index.ts
+++ b/apps/api/routes/internal/index.ts
@@ -19,6 +19,7 @@ import sync from './sync';
 import syncConfig from './sync_config';
 import syncRun from './sync_run';
 import system from './system';
+import _multitenantBackfill from './_multitenant_backfill';
 
 export default function init(app: Router): void {
   // internal routes should require only internal middleware
@@ -27,6 +28,7 @@ export default function init(app: Router): void {
 
   system(internalRouter);
   link(internalRouter);
+  _multitenantBackfill(internalRouter);
 
   app.use('/internal', internalRouter);
 

--- a/apps/api/routes/mgmt/v2/entity/index.ts
+++ b/apps/api/routes/mgmt/v2/entity/index.ts
@@ -23,6 +23,9 @@ import { Router } from 'express';
 
 const { entityService } = getDependencyContainer();
 
+/**
+ * @deprecated
+ */
 export default function init(app: Router): void {
   const entityRouter = Router({ mergeParams: true });
 

--- a/apps/api/routes/mgmt/v2/entity_mapping/index.ts
+++ b/apps/api/routes/mgmt/v2/entity_mapping/index.ts
@@ -18,6 +18,9 @@ import { Router } from 'express';
 
 const { connectionService } = getDependencyContainer();
 
+/**
+ * @deprecated
+ */
 export default function init(app: Router): void {
   const entityMappingRouter = Router({ mergeParams: true });
   entityMappingRouter.use(connectionHeaderMiddleware);

--- a/apps/api/routes/mgmt/v2/schema/index.ts
+++ b/apps/api/routes/mgmt/v2/schema/index.ts
@@ -23,6 +23,9 @@ import { Router } from 'express';
 
 const { schemaService } = getDependencyContainer();
 
+/**
+ * @deprecated
+ */
 export default function init(app: Router): void {
   const schemaRouter = Router({ mergeParams: true });
 

--- a/packages/db/prisma/migrations/20230919212949_denormalize_object_sync_runs/migration.sql
+++ b/packages/db/prisma/migrations/20230919212949_denormalize_object_sync_runs/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "object_sync_runs" ADD COLUMN     "connection_id" TEXT,
+ADD COLUMN     "entity_id" TEXT,
+ADD COLUMN     "object" TEXT,
+ADD COLUMN     "object_type" TEXT,
+ADD COLUMN     "sync_type" TEXT DEFAULT 'object';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -30,8 +30,8 @@ model Application {
   customers    Customer[]
   destinations Destination[]
   providers    Provider[]
-  schemas      Schema[]
-  entities     Entity[]
+  schemas      Schema[] // @deprecated
+  entities     Entity[] // @deprecated
   magicLinks   MagicLink[]
 
   @@unique([orgId, name])
@@ -79,7 +79,7 @@ model Provider {
   name           String
   config         Json // {provider_app_id, oauth_client_id, oauth_client_secret, oauth_scopes}
   objects        Json?
-  entityMappings Json?
+  entityMappings Json? // @deprecated
   createdAt      DateTime     @default(now()) @map("created_at")
   updatedAt      DateTime     @updatedAt @map("updated_at")
   connections    Connection[]
@@ -131,8 +131,8 @@ model Connection {
   replayIds            ReplayId[]
   provider             Provider   @relation(fields: [providerId], references: [id])
   providerId           String     @map("provider_id")
-  schemaMappingsConfig Json?      @map("schema_mappings_config")
-  entityMappings       Json?      @map("entity_mappings")
+  schemaMappingsConfig Json?      @map("schema_mappings_config") // @deprecated
+  entityMappings       Json?      @map("entity_mappings") // @deprecated
   connectionSyncConfig Json?      @map("connection_sync_config")
   syncs                Sync[]
 
@@ -151,13 +151,13 @@ model ConnectionSyncConfigChange {
 
 model Sync {
   id             String     @id @default(uuid())
-  type           String     @default("object") // object | entity
+  type           String     @default("object") // object | entity (@deprecated)
   // set `objectType` and `object` if type is `object`
   objectType     String?    @map("object_type") // common, standard, custom
   object         String?
   // set `entityId` if type is `entity`
-  entityId       String?    @map("entity_id")
-  entity         Entity?    @relation(fields: [entityId], references: [id])
+  entityId       String?    @map("entity_id") // @deprecated
+  entity         Entity?    @relation(fields: [entityId], references: [id]) // @deprecated
   state          Json
   strategy       Json
   connectionId   String     @map("connection_id")
@@ -194,6 +194,11 @@ model SyncRun {
   startTimestamp   DateTime  @map("start_timestamp")
   endTimestamp     DateTime? @map("end_timestamp")
   numRecordsSynced Int?      @map("num_records_synced")
+  connectionId     String?   @map("connection_id")
+  objectType       String?   @map("object_type")
+  object           String?
+  syncType         String?   @default("object") @map("sync_type")
+  entityId         String?   @map("entity_id") // @deprecated
 
   @@index([startTimestamp(sort: Desc)])
   @@index([status])
@@ -212,6 +217,7 @@ model ReplayId {
   @@map("replay_ids")
 }
 
+// @deprecated
 model Schema {
   id            String      @id @default(uuid())
   name          String
@@ -225,6 +231,7 @@ model Schema {
   @@map("schemas")
 }
 
+// @deprecated
 model Entity {
   id            String      @id @default(uuid())
   name          String

--- a/packages/sync-workflows/activities/log_sync_finish.ts
+++ b/packages/sync-workflows/activities/log_sync_finish.ts
@@ -23,6 +23,12 @@ export function createLogSyncFinish({
     errorMessage,
     errorStack,
     numRecordsSynced,
+
+    // Note: loose types for object vs entity
+    type,
+    objectType,
+    object,
+    entityId,
   }: {
     syncId: string;
     connectionId: string;
@@ -31,8 +37,23 @@ export function createLogSyncFinish({
     errorMessage?: string;
     errorStack?: string;
     numRecordsSynced: number | null;
+
+    // Note: loose types for object vs entity
+    type?: string;
+    objectType?: string;
+    object?: string;
+    entityId?: string;
   }) {
-    await syncRunService.logFinish({ runId, status, errorMessage, numRecordsSynced });
+    await syncRunService.logFinish({
+      runId,
+      status,
+      errorMessage,
+      numRecordsSynced,
+      type,
+      objectType,
+      object,
+      entityId,
+    });
 
     const connection = await connectionService.getSafeById(connectionId);
     const application = await applicationService.getById(connection.applicationId);

--- a/packages/sync-workflows/activities/log_sync_start.ts
+++ b/packages/sync-workflows/activities/log_sync_start.ts
@@ -3,6 +3,7 @@ import type { SyncRunService } from '@supaglue/core/services/sync_run_service';
 export type LogSyncStartArgs = {
   syncId: string;
   runId: string;
+  connectionId: string;
 };
 
 export function createLogSyncStart({ syncRunService }: { syncRunService: SyncRunService }) {

--- a/packages/types/sync_run.ts
+++ b/packages/types/sync_run.ts
@@ -37,6 +37,10 @@ export type SyncRunUpsertParams = {
   startTimestamp: Date;
   endTimestamp: Date | null;
   numRecordsSynced: number | null;
+  objectType?: string;
+  object?: string;
+  syncType?: string;
+  entityId?: string;
 };
 
 export type SyncRunFilter = {


### PR DESCRIPTION
- denormalize the {object_syncs, object_sync_runs} for the Logs page queries
- double write to the new denormalized columns

Step 2:

- migrate Logs page query to use denormalized fields and drop usage of prisma `includes`

(Optional Step 3):

- denormalize further (application, customer, provider) and remove extra db calls and in-memory filtering

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
