### PR TITLE
feat!: (step 1/2) add cuid to object_sync_runs, double-write runid and cuid, cuid…

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
     "@temporalio/client": "^1.8.0",
     "@temporalio/workflow": "^1.8.0",
     "cors": "^2.8.5",
+    "cuid": "^3.0.0",
     "express": ">=5.0.0-beta.1",
     "express-openapi-validator": "^5.0.2",
     "express-prom-bundle": "^6.6.0",

--- a/apps/api/routes/internal/_multitenant_backfill/index.ts
+++ b/apps/api/routes/internal/_multitenant_backfill/index.ts
@@ -1,0 +1,67 @@
+import { getDependencyContainer } from '@/dependency_container';
+import { logger } from '@supaglue/core/lib';
+import cuid from 'cuid';
+import type { Request, Response } from 'express';
+import { Router } from 'express';
+
+const { prisma } = getDependencyContainer();
+
+export default function init(app: Router): void {
+  const systemRouter = Router();
+
+  systemRouter.post('/_object_sync_runs_cuid', async (req: Request, res: Response) => {
+    let cursor: { id: string } | null = { id: '' };
+
+    const date = new Date();
+    date.setDate(date.getDate() - 7);
+
+    while (cursor !== null) {
+      await prisma.$transaction(
+        async (tx) => {
+          const records = await tx.syncRun.findMany({
+            cursor: cursor && cursor.id ? cursor : undefined,
+            skip: cursor ? 1 : undefined,
+            take: 5000,
+            where: {
+              startTimestamp: {
+                gte: date,
+              },
+            },
+            orderBy: {
+              id: 'asc',
+            },
+          });
+
+          logger.info({ count: records.length }, 'Backfilling sync runs cuid');
+
+          const updatePromises = [];
+          for (const record of records) {
+            const updateResult = await tx.syncRun.update({
+              where: {
+                id: record.id,
+              },
+              data: {
+                ...record,
+                cuid: cuid(),
+              },
+            });
+
+            updatePromises.push(updateResult);
+          }
+
+          const lastRecord = records[records.length - 1];
+          cursor = lastRecord ? { id: lastRecord.id } : null;
+
+          return updatePromises;
+        },
+        {
+          timeout: 10000,
+        }
+      );
+    }
+
+    return res.status(200).send();
+  });
+
+  app.use('/_multitenant_backfill', systemRouter);
+}

--- a/apps/api/routes/internal/index.ts
+++ b/apps/api/routes/internal/index.ts
@@ -19,6 +19,7 @@ import sync from './sync';
 import syncConfig from './sync_config';
 import syncRun from './sync_run';
 import system from './system';
+import _multitenantBackfill from './_multitenant_backfill';
 
 export default function init(app: Router): void {
   // internal routes should require only internal middleware
@@ -27,6 +28,7 @@ export default function init(app: Router): void {
 
   system(internalRouter);
   link(internalRouter);
+  _multitenantBackfill(internalRouter);
 
   app.use('/internal', internalRouter);
 

--- a/apps/mgmt-ui/src/components/logs/SyncRunsTable.tsx
+++ b/apps/mgmt-ui/src/components/logs/SyncRunsTable.tsx
@@ -195,7 +195,7 @@ export default function SyncRunsTable(props: SyncRunsTableProps) {
         }}
         initialState={{
           sorting: {
-            sortModel: [{ field: 'startTimestamp', sort: 'desc' }],
+            sortModel: [{ field: 'cuid', sort: 'desc' }],
           },
         }}
         sx={{

--- a/apps/sync-worker/index.ts
+++ b/apps/sync-worker/index.ts
@@ -106,6 +106,12 @@ async function run() {
       activityInbound: [(ctx) => new ActivityLogInterceptor(ctx)],
       workflowModules: [`${__dirname}/interceptors/workflow_log_interceptor`],
     }),
+    bundlerOptions: {
+      webpackConfigHook(config) {
+        config.target = 'node';
+        return config;
+      },
+    },
   });
 
   const handle = () => {

--- a/packages/core/services/sync_run_service.ts
+++ b/packages/core/services/sync_run_service.ts
@@ -25,10 +25,12 @@ export class SyncRunService {
   async #upsert({
     id,
     syncId,
+    cuid,
     createParams,
   }: {
     id: string;
     syncId: string;
+    cuid: string;
     createParams: SyncRunUpsertParams;
   }): Promise<SyncRun> {
     const created: SyncRunModelExpanded = await this.#prisma.syncRun.upsert({
@@ -36,6 +38,7 @@ export class SyncRunService {
       create: {
         ...createParams,
         id,
+        cuid,
         syncId,
       },
       update: {},
@@ -69,9 +72,10 @@ export class SyncRunService {
     return fromSyncRunModelAndSync(model);
   }
 
-  public async logStart(args: { syncId: string; runId: string }): Promise<string> {
+  public async logStart(args: { syncId: string; runId: string; cuid: string }): Promise<string> {
     await this.#upsert({
       id: args.runId,
+      cuid: args.cuid,
       syncId: args.syncId,
       createParams: {
         status: 'IN_PROGRESS' as const,
@@ -140,7 +144,7 @@ export class SyncRunService {
         },
       },
       orderBy: {
-        startTimestamp: 'desc',
+        cuid: 'desc',
       },
     });
     const countPromise = this.#prisma.syncRun.count({

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -1,5 +1,4 @@
 import { PrismaClient } from '@prisma/client';
-
 const prisma = new PrismaClient();
 
 export * from '@prisma/client';

--- a/packages/db/prisma/migrations/20230920035852_object_sync_run_cuid/migration.sql
+++ b/packages/db/prisma/migrations/20230920035852_object_sync_run_cuid/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "object_sync_runs" ADD COLUMN     "cuid" TEXT;
+
+-- CreateIndex
+CREATE INDEX "object_sync_runs_cuid_idx" ON "object_sync_runs"("cuid" DESC);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -186,6 +186,7 @@ model SyncChange {
 
 model SyncRun {
   id               String    @id @default(uuid())
+  cuid             String?
   syncId           String    @map("object_sync_id")
   sync             Sync      @relation(fields: [syncId], references: [id], onDelete: Cascade)
   // SUCCESS | ERROR | IN_PROGRESS
@@ -196,6 +197,7 @@ model SyncRun {
   numRecordsSynced Int?      @map("num_records_synced")
 
   @@index([startTimestamp(sort: Desc)])
+  @@index([cuid(sort: Desc)])
   @@index([status])
   @@map("object_sync_runs")
 }

--- a/packages/sync-workflows/activities/get_sync.ts
+++ b/packages/sync-workflows/activities/get_sync.ts
@@ -1,4 +1,5 @@
 import type { Sync } from '@supaglue/types/sync';
+import cuid from 'cuid';
 import type { SyncService } from '../services/sync_service';
 
 export type GetSyncArgs = {
@@ -7,6 +8,7 @@ export type GetSyncArgs = {
 
 export type GetSyncResult = {
   sync: Sync;
+  runId: string;
 };
 
 export function createGetSync(syncService: SyncService) {
@@ -14,6 +16,7 @@ export function createGetSync(syncService: SyncService) {
     const sync = await syncService.getSyncById(syncId);
     return {
       sync,
+      runId: cuid(),
     };
   };
 }

--- a/packages/sync-workflows/activities/log_sync_start.ts
+++ b/packages/sync-workflows/activities/log_sync_start.ts
@@ -3,6 +3,7 @@ import type { SyncRunService } from '@supaglue/core/services/sync_run_service';
 export type LogSyncStartArgs = {
   syncId: string;
   runId: string;
+  cuid: string;
 };
 
 export function createLogSyncStart({ syncRunService }: { syncRunService: SyncRunService }) {

--- a/packages/sync-workflows/package.json
+++ b/packages/sync-workflows/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@supaglue/core": "workspace:*",
     "@supaglue/db": "workspace:^",
-    "@supaglue/types": "workspace:^"
+    "@supaglue/types": "workspace:^",
+    "cuid": "^3.0.0"
   },
   "devDependencies": {
     "@tsconfig/node18": "^1.0.1",

--- a/packages/sync-workflows/workflows/run_object_sync.ts
+++ b/packages/sync-workflows/workflows/run_object_sync.ts
@@ -45,7 +45,7 @@ export type RunObjectSyncArgs = {
 };
 
 export async function runObjectSync({ syncId, connectionId, category }: RunObjectSyncArgs): Promise<void> {
-  const { sync } = await getSync({ syncId });
+  const { sync, runId: cuid } = await getSync({ syncId });
 
   // Generate history id
   const runId = uuid4();
@@ -54,6 +54,7 @@ export async function runObjectSync({ syncId, connectionId, category }: RunObjec
   await logSyncStart({
     syncId,
     runId,
+    cuid,
   });
 
   let numRecordsSynced: number | undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7512,6 +7512,7 @@ __metadata:
     "@supaglue/db": "workspace:^"
     "@supaglue/types": "workspace:^"
     "@tsconfig/node18": ^1.0.1
+    cuid: ^3.0.0
     tsx: ^3.12.3
     typescript: ^4.9.5
   peerDependencies:
@@ -9455,6 +9456,7 @@ __metadata:
     "@types/simple-oauth2": ^5
     "@types/uuid": ^9.0.0
     cors: ^2.8.5
+    cuid: ^3.0.0
     dotenv: ^16.0.3
     express: ">=5.0.0-beta.1"
     express-openapi-validator: ^5.0.2
@@ -11818,6 +11820,13 @@ __metadata:
   version: 6.3.0
   resolution: "csv-stringify@npm:6.3.0"
   checksum: d2503ad298b6f432bae5932af365fb1a5f8f51b31a170d8e1c0735cb89193cb665976754612800c3302570bf7086749d60a30d97d820cc3a7c9b7cd4a49fd311
+  languageName: node
+  linkType: hard
+
+"cuid@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cuid@npm:3.0.0"
+  checksum: f9a344bd90e26b62f75a86b616ad717bad88b20b02df25c6e4008dd2c0948b081bd72ad8075b25ae644dce7fc367a43c622954e88aed972b72b1f132416faa4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
… backfill script

Overview:
- Move to cuid from uuid for `object_sync_runs.id` to utilize Prisma cursor pagination. We need the sort key and pagination key to be the same to avoid a table scan

Step 1:
- This creates the column, double writes to it, and contains a backfill script for existing sync runs
   - We will only look back 3 days for the backfill
   - We will lose the original start_timestamp order because it's too expensive to backfill in that order
   - New sync runs will be written in start_timestamp order

Step 2:
- Finish migrating `object_sync_runs.id` to use cuid instead of uuid and utilize it for the sync run mgmt-ui queries

NOTE:
- The mgmt api endpoint hasn't been updated

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
