### PR TITLE
chore: add tsc:watch target

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -46,7 +46,8 @@
     "lint-staged": "run -T lint-staged --no-stash --quiet",
     "lint": "run -T eslint",
     "prepare": "ts-patch install -s",
-    "init-temporal": "tsx ./init_scripts/init_temporal.ts"
+    "init-temporal": "tsx ./init_scripts/init_temporal.ts",
+    "tsc:watch": "tsc --noEmit --watch"
   },
   "lint-staged": {
     "**/*.{ts,tsx}": "tsc-files --noEmit types/express.d.ts",

--- a/apps/mgmt-ui/package.json
+++ b/apps/mgmt-ui/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "tsc:watch": "tsc --noEmit --watch"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.23.1",

--- a/apps/salesforce-pub-sub/package.json
+++ b/apps/salesforce-pub-sub/package.json
@@ -20,7 +20,8 @@
     "start": "tsx watch --clear-screen=false ./index.ts",
     "build": "tsc -p tsconfig.json",
     "lint-staged": "run -T lint-staged --no-stash --quiet",
-    "lint": "run -T eslint"
+    "lint": "run -T eslint",
+    "tsc:watch": "tsc --noEmit --watch"
   },
   "devDependencies": {
     "@types/simple-oauth2": "^5",

--- a/apps/sync-worker/package.json
+++ b/apps/sync-worker/package.json
@@ -28,6 +28,7 @@
     "start": "tsx watch --clear-screen=false ./index.ts",
     "build": "tsc -p tsconfig.build.json",
     "lint-staged": "run -T lint-staged --no-stash --quiet",
-    "lint": "run -T eslint"
+    "lint": "run -T eslint",
+    "tsc:watch": "tsc --noEmit --watch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "husky install",
     "test": "turbo run test",
     "test:watch": "turbo run test:watch",
+    "tsc:watch": "turbo run --concurrency 12 tsc:watch",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "generate": "turbo run generate",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,8 @@
     "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",
     "lint-staged": "run -T lint-staged --no-stash --quiet",
     "lint": "run -T eslint",
-    "test": "SUPAGLUE_LOG_LEVEL=debug jest"
+    "test": "SUPAGLUE_LOG_LEVEL=debug jest",
+    "tsc:watch": "tsc --noEmit --watch"
   },
   "files": [
     "dist"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -20,7 +20,8 @@
     "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",
     "lint-staged": "run -T lint-staged --no-stash --quiet",
     "lint": "run -T eslint",
-    "generate": "prisma generate"
+    "generate": "prisma generate",
+    "tsc:watch": "tsc --noEmit --watch"
   },
   "files": [
     "dist"

--- a/packages/sync-workflows/package.json
+++ b/packages/sync-workflows/package.json
@@ -23,7 +23,8 @@
     "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",
     "publish": "run -T turbo run build --filter=@supaglue/sync-workflows ... && yarn npm publish",
     "lint-staged": "run -T lint-staged --no-stash --quiet",
-    "lint": "run -T eslint"
+    "lint": "run -T eslint",
+    "tsc:watch": "tsc --noEmit --watch"
   },
   "publishConfig": {
     "main": "./dist/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,7 +13,8 @@
     "build": "yarn run clean && tsc -p .",
     "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",
     "lint-staged": "run -T lint-staged --no-stash --quiet",
-    "lint": "run -T eslint"
+    "lint": "run -T eslint",
+    "tsc:watch": "tsc --noEmit --watch"
   },
   "files": [
     "dist"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,8 @@
     "build": "yarn run clean && tsc -p .",
     "clean": "rm -rf ./dist && rm -rf tsconfig.tsbuildinfo",
     "lint-staged": "run -T lint-staged --no-stash --quiet",
-    "lint": "run -T eslint"
+    "lint": "run -T eslint",
+    "tsc:watch": "tsc --noEmit --watch"
   },
   "files": [
     "dist"

--- a/turbo.json
+++ b/turbo.json
@@ -48,6 +48,10 @@
       "cache": false,
       "persistent": true
     },
+    "tsc:watch": {
+      "cache": false,
+      "persistent": true
+    },
     "generate": {
       "outputMode": "errors-only"
     },


### PR DESCRIPTION
Can run like this to watch a target and its dependencies:

```
yarn tsc:watch --filter="api..."
```