### PR TITLE
fix: upload sentry sourcemaps

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,12 +4,7 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-if [ -z "${1-}" ]; then
-  echo "usage: $0 <version>"
-  exit 1
-fi
-
-VERSION=$1
+APPS=(api sync-worker)
 
 # check $HOME/.docker/config.json if we are logged into docker hub
 # if not, then fail
@@ -37,11 +32,28 @@ check_checkly_checks
 git checkout main
 git pull
 
+if ! git log -1 --pretty=%B | grep -q "chore: release"; then
+  echo "Commit message at main must start with 'chore: release' to be able to trigger a release"
+  exit 1
+fi
+
 VERSION=$(jq -r '.version' package.json)
 
 RELEASE_SHA=$(git rev-parse HEAD | cut -c1-7 | xargs -I{} echo "sha-{}")
 
-docker buildx imagetools create supaglue/api:"$RELEASE_SHA" --tag supaglue/api:"$VERSION"
+# build each app in APPS
+for APP_NAME in "${APPS[@]}"; do
+  WORKSPACE_PATH=$(yarn workspaces list --json | jq -r "select(.name == \"${APP_NAME}\") | .location")
+
+  echo "Building and pushing $APP_NAME"
+  yarn dlx --package @sentry/cli sentry-cli releases new --project "$APP_NAME" --org supaglue "$VERSION"
+  yarn turbo run build --filter="${APP_NAME}..."
+  yarn dlx --package @sentry/cli sentry-cli releases files --project "$APP_NAME" --org supaglue "$VERSION" upload-sourcemaps "${WORKSPACE_PATH}/dist"
+  docker buildx imagetools create supaglue/"$APP_NAME":"$RELEASE_SHA" --tag supaglue/"$APP_NAME":"$VERSION"
+  yarn dlx --package @sentry/cli sentry-cli releases finalize --project "$APP_NAME" --org supaglue "$VERSION"
+done
+
+
 
 docker buildx imagetools create supaglue/sync-worker:"$RELEASE_SHA" --tag supaglue/sync-worker:"$VERSION"
 


### PR DESCRIPTION
You can speed up local builds by doing
```
yarn turbo login --team Supaglue
yarn turbo link
```

Be sure to select `Supaglue` as the scope to link.