### PR TITLE
fix: log context for api

### DIFF
--- a/apps/api/index.ts
+++ b/apps/api/index.ts
@@ -119,6 +119,7 @@ app.use(
       'req.headers.authorization',
       'req.headers.cookie',
       'req.headers["x-api-key"]',
+      'req.headers["x-sg-internal-token"]',
       'err.config.headers.Authorization', // axios errors
     ],
     genReqId: () => uuidv4(),

--- a/apps/api/middleware/api_key.ts
+++ b/apps/api/middleware/api_key.ts
@@ -1,6 +1,4 @@
-import { configureScope } from '@sentry/node';
 import { UnauthorizedError } from '@supaglue/core/errors';
-import { addLogContext } from '@supaglue/core/lib/logger';
 import type { NextFunction, Request, Response } from 'express';
 import { getDependencyContainer } from '../dependency_container';
 
@@ -13,11 +11,7 @@ export async function apiKeyHeaderMiddleware(req: Request, res: Response, next: 
   }
 
   req.supaglueApplication = await applicationService.getByApiKey(apiKey);
-  addLogContext('applicationId', req.supaglueApplication.id);
-  configureScope((scope) => scope.setTag('applicationId', req.supaglueApplication.id));
   req.orgId = req.supaglueApplication.orgId;
-  addLogContext('orgId', req.supaglueApplication.orgId);
-  configureScope((scope) => scope.setUser({ id: req.supaglueApplication.orgId, ip_address: req.ip }));
 
   next();
 }

--- a/apps/api/middleware/pino_context.ts
+++ b/apps/api/middleware/pino_context.ts
@@ -1,0 +1,16 @@
+import { configureScope } from '@sentry/node';
+import { addLogContext } from '@supaglue/core/lib/logger';
+import type { NextFunction, Request, Response } from 'express';
+
+export async function pinoAndSentryContextMiddleware(req: Request, res: Response, next: NextFunction) {
+  addLogContext('applicationEnv', req.supaglueApplication.environment);
+  addLogContext('applicationName', req.supaglueApplication.name);
+
+  addLogContext('applicationId', req.supaglueApplication.id);
+  configureScope((scope) => scope.setTag('applicationId', req.supaglueApplication.id));
+
+  addLogContext('orgId', req.supaglueApplication.orgId);
+  configureScope((scope) => scope.setUser({ id: req.supaglueApplication.orgId, ip_address: req.ip }));
+
+  next();
+}

--- a/apps/api/routes/actions/index.ts
+++ b/apps/api/routes/actions/index.ts
@@ -1,5 +1,6 @@
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
 import { connectionHeaderMiddleware } from '@/middleware/connection';
+import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
 import { Router } from 'express';
 import v2 from './v2';
 
@@ -8,6 +9,7 @@ export default function init(app: Router): void {
 
   actionsRouter.use(apiKeyHeaderMiddleware);
   actionsRouter.use(connectionHeaderMiddleware);
+  actionsRouter.use(pinoAndSentryContextMiddleware);
 
   v2(actionsRouter);
 

--- a/apps/api/routes/crm/index.ts
+++ b/apps/api/routes/crm/index.ts
@@ -1,5 +1,6 @@
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
 import { connectionHeaderMiddleware } from '@/middleware/connection';
+import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
 import { Router } from 'express';
 import v2 from './v2';
 
@@ -8,6 +9,7 @@ export default function init(app: Router): void {
 
   crmRouter.use(apiKeyHeaderMiddleware);
   crmRouter.use(connectionHeaderMiddleware);
+  crmRouter.use(pinoAndSentryContextMiddleware);
 
   v2(crmRouter);
 

--- a/apps/api/routes/data/index.ts
+++ b/apps/api/routes/data/index.ts
@@ -1,4 +1,5 @@
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
+import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
 import { Router } from 'express';
 import v2 from './v2';
 
@@ -6,6 +7,7 @@ export default function init(app: Router): void {
   const dataRouter = Router();
 
   dataRouter.use(apiKeyHeaderMiddleware);
+  dataRouter.use(pinoAndSentryContextMiddleware);
 
   v2(dataRouter);
 

--- a/apps/api/routes/engagement/index.ts
+++ b/apps/api/routes/engagement/index.ts
@@ -1,5 +1,6 @@
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
 import { connectionHeaderMiddleware } from '@/middleware/connection';
+import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
 import { Router } from 'express';
 import v2 from './v2';
 
@@ -8,6 +9,7 @@ export default function init(app: Router): void {
 
   engagementRouter.use(apiKeyHeaderMiddleware);
   engagementRouter.use(connectionHeaderMiddleware);
+  engagementRouter.use(pinoAndSentryContextMiddleware);
 
   v2(engagementRouter);
 

--- a/apps/api/routes/marketing-automation/index.ts
+++ b/apps/api/routes/marketing-automation/index.ts
@@ -1,5 +1,6 @@
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
 import { connectionHeaderMiddleware } from '@/middleware/connection';
+import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
 import { Router } from 'express';
 import v2 from './v2';
 
@@ -8,6 +9,7 @@ export default function init(app: Router): void {
 
   marketingAutomationRouter.use(apiKeyHeaderMiddleware);
   marketingAutomationRouter.use(connectionHeaderMiddleware);
+  marketingAutomationRouter.use(pinoAndSentryContextMiddleware);
 
   v2(marketingAutomationRouter);
 

--- a/apps/api/routes/metadata/v2/index.ts
+++ b/apps/api/routes/metadata/v2/index.ts
@@ -1,5 +1,6 @@
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
 import { openapiMiddleware } from '@/middleware/openapi';
+import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
 import { Router } from 'express';
 import associationType from './association_type';
 import object from './object';
@@ -10,6 +11,7 @@ export default function init(app: Router): void {
 
   v2Router.use(apiKeyHeaderMiddleware);
   v2Router.use(openapiMiddleware('metadata', 'v2'));
+  v2Router.use(pinoAndSentryContextMiddleware);
 
   associationType(v2Router);
   object(v2Router);

--- a/apps/api/routes/mgmt/v2/index.ts
+++ b/apps/api/routes/mgmt/v2/index.ts
@@ -1,5 +1,6 @@
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
 import { openapiMiddleware } from '@/middleware/openapi';
+import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
 import { Router } from 'express';
 import connectionSyncConfig from './connection_sync_config';
 import customer from './customer';
@@ -19,6 +20,7 @@ export default function init(app: Router): void {
 
   v2Router.use(apiKeyHeaderMiddleware);
   v2Router.use(openapiMiddleware('mgmt', 'v2'));
+  v2Router.use(pinoAndSentryContextMiddleware);
 
   customer(v2Router);
   destination(v2Router);


### PR DESCRIPTION
- Empirically verified that context.X isn't in the output
- Didn't dig into pino-context code, but used trial-and-error/process of elimination to see under what situations it is logged in the output: using `addLogContext` after all the other middleware seems to work

```
supaglue-api-1          |     context: {
supaglue-api-1          |       "applicationEnv": "production",
supaglue-api-1          |       "applicationName": "My Application",
supaglue-api-1          |       "applicationId": "4acf8358-db1f-4dfa-8c3c-357106afc1a7",
supaglue-api-1          |       "orgId": "e7070cc8-36e7-43e2-81fc-ad57713cf2d3"
supaglue-api-1          |     }
```

## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
