### PR TITLE
fix: sync log filter

### DIFF
--- a/apps/api/routes/mgmt/v2/sync_run/index.ts
+++ b/apps/api/routes/mgmt/v2/sync_run/index.ts
@@ -23,24 +23,19 @@ export default function init(app: Router) {
       res: Response<GetSyncRunsResponse>
     ) => {
       function getObjectOrEntityFilter() {
-        if (req.query?.object_type && req.query.object) {
-          return {
-            objectType: req.query.object_type,
-            object: req.query.object,
-          };
-        }
+        const objectTypeSpreadTernary = req.query?.object_type
+          ? {
+              objectType: req.query?.object_type,
+            }
+          : {};
+        const objectSpreadTernary = req.query?.object ? { object: req.query.object } : {};
+        const entityIdSpreadTernary = req.query?.entity_id ? { entityId: req.query.entity_id } : {};
 
-        if (req.query?.entity_id) {
-          return {
-            entityId: req.query.entity_id,
-          };
-        }
-
-        if (!req.query?.object_type && !req.query?.object && !req.query?.entity_id) {
-          return {};
-        }
-
-        throw new BadRequestError('must filter on (object_type, object) or entity_id or neither');
+        return {
+          ...objectSpreadTernary,
+          ...objectTypeSpreadTernary,
+          ...entityIdSpreadTernary,
+        };
       }
 
       const { next, previous, results, totalCount } = await syncRunService.list({

--- a/packages/types/sync_run.ts
+++ b/packages/types/sync_run.ts
@@ -47,17 +47,12 @@ export type SyncRunFilter = {
   startTimestamp?: SyncRunTimestampFilter;
   endTimestamp?: SyncRunTimestampFilter;
   paginationParams: PaginationInternalParams;
-} & (
-  | {
-      objectType: 'common' | 'standard' | 'custom';
-      object: string;
-    }
-  | {
-      entityId: string;
-    }
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  | {}
-);
+
+  // we let the user filter on any attribute without enforcing related pairs to exist, so these are all optional
+  objectType?: 'common' | 'standard' | 'custom';
+  object?: string;
+  entityId?: string;
+};
 
 export type SyncRunTimestampFilter =
   | {


### PR DESCRIPTION
- MUI data grid x let's you filter on any attribute so allow that on the backend

Tested this locally

![Screenshot 2023-10-04 at 12 19 27 PM](https://github.com/supaglue-labs/supaglue/assets/471516/00367279-083e-4788-9d02-aeae55aae088)

![Screenshot 2023-10-04 at 12 19 52 PM](https://github.com/supaglue-labs/supaglue/assets/471516/66ca9675-a08d-4b87-949f-2e8fb33d9aee)


## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
