### PR TITLE
fix: apollo sync improvements, paginator stream changes

### DIFF
--- a/packages/core/errors.ts
+++ b/packages/core/errors.ts
@@ -125,6 +125,15 @@ export class TooManyRequestsError extends HTTPError {
   }
 }
 
+// Throw this when you want run_object_sync to throw a non retryable temporal error
+export class TerminalTooManyRequestsError extends HTTPError {
+  code = 429;
+  problemType = 'TERMINAL_TOO_MANY_REQUESTS_ERROR';
+  constructor(message: string, cause?: Error) {
+    super(message, cause);
+  }
+}
+
 export class NotModifiedError extends HTTPError {
   code = 304;
   problemType = 'NOT_MODIFIED';

--- a/packages/core/lib/apollo_ratelimit.ts
+++ b/packages/core/lib/apollo_ratelimit.ts
@@ -1,0 +1,55 @@
+import retry from 'async-retry';
+import { isAxiosError } from 'axios';
+import { logger } from '.';
+import { TerminalTooManyRequestsError, TooManyRequestsError } from '../errors';
+
+const isAxiosRateLimited = (e: any): boolean => {
+  return isAxiosError(e) && e.response?.status === 429;
+};
+
+// Heuristic to detect free plan, daily rate limit, or hourly rate limit
+const isApolloDailyHourlyRateLimited = (e: any): boolean => {
+  const isFreePlan = e.response.data.includes('This endpoint is only available to paying teams');
+  const isDailyHourlyRateLimited =
+    /^The maximum number of api calls allowed for [a-z0-9/]+ is [0-9]+ times per (hour|day). Please upgrade your plan/.test(
+      e.response.data
+    );
+  return isFreePlan || isDailyHourlyRateLimited;
+};
+
+export const retryWhenAxiosApolloRateLimited = async <Args extends any[], Return>(
+  operation: (...operationParameters: Args) => Return,
+  ...parameters: Args
+): Promise<Return> => {
+  const helper = async (bail: (e: Error) => void) => {
+    try {
+      return await operation(...parameters);
+    } catch (e: any) {
+      // bail on terminal rate limits (hourly or daily or free plan)
+      // throw TerminalTooManyRequestsError for run_object_sync to rethrow a temporal non retryable error
+      if (isAxiosRateLimited(e) && isApolloDailyHourlyRateLimited(e)) {
+        logger.warn({ errror: e }, `Encountered Apollo hourly or daily rate limiting.`);
+        bail(new TerminalTooManyRequestsError(`Encountered Apollo hourly or daily rate limiting.`));
+        return null as Return;
+      }
+
+      // continue to retry on minutely rate limits
+      if (isAxiosRateLimited(e)) {
+        logger.warn({ errror: e }, `Encountered Apollo rate limiting.`);
+        throw new TooManyRequestsError(`Encountered Apollo rate limiting.`);
+      }
+
+      // stop retrying on others
+      logger.warn({ error: e }, `Encountered Apollo error.`);
+      bail(e);
+      return null as Return;
+    }
+  };
+  return await retry(helper, {
+    retries: 5, // expo backoff for up to a minute
+    factor: 2,
+    // create some jitter so concurrent apollo syncs can make progress
+    randomize: true,
+    minTimeout: 2000,
+  });
+};

--- a/packages/sync-workflows/workflows/run_object_sync.ts
+++ b/packages/sync-workflows/workflows/run_object_sync.ts
@@ -11,7 +11,9 @@ const { syncObjectRecords, syncEntityRecords } = proxyActivities<ReturnType<type
   startToCloseTimeout: '120 minute',
   heartbeatTimeout: '5 minute',
   retry: {
-    maximumAttempts: 3,
+    // if we can't complete syncing all records within 2 hours, wait until the next sync
+    // instead of trying again and consuming api quota
+    maximumAttempts: 1,
   },
 });
 


### PR DESCRIPTION
- Don't retry workflow for `syncObjectRecords` activity to avoid draining api quota
- Apollo is special. Use its own ratelimit function
- Abort retry and fail the workflow on hourly, daily, free plan rate limits
- Increase Apollo page size
- Allow our streams to abort early on certain errors
- Fix Apollo paginating for edge case: no data

## Test Plan

- Synced 202 records while paginating
- Failed on hourly/daily rate limit early

## Deployment instructions

[Add any special deployment instructions here]
