### PR TITLE
chore: refactor svix away from getServerSideProps

### DIFF
--- a/apps/mgmt-ui/src/components/settings/WebhookTabPanel.tsx
+++ b/apps/mgmt-ui/src/components/settings/WebhookTabPanel.tsx
@@ -6,13 +6,19 @@ import { AppPortal } from 'svix-react';
 import 'svix-react/style.css';
 import Spinner from '../Spinner';
 
-export default function WebhookTabPanel({ applicationId }: { applicationId: string }) {
+export default function WebhookTabPanel({
+  applicationId,
+  svixApiToken,
+}: {
+  applicationId: string;
+  svixApiToken?: string;
+}) {
   const [svixDashboardUrl, setSvixDashboardUrl] = useState<string | null>(null);
 
   useEffect(() => {
     const getDashboardUrl = async () => {
-      if (process.env.NEXT_PUBLIC_SVIX_API_TOKEN) {
-        const svix = new Svix(process.env.NEXT_PUBLIC_SVIX_API_TOKEN as string, {
+      if (svixApiToken) {
+        const svix = new Svix(svixApiToken, {
           serverUrl: process.env.NEXT_PUBLIC_SVIX_SERVER_URL,
         });
         const dashboardUrl = (await svix.authentication.appPortalAccess(applicationId, {})).url;

--- a/apps/mgmt-ui/src/components/settings/WebhookTabPanel.tsx
+++ b/apps/mgmt-ui/src/components/settings/WebhookTabPanel.tsx
@@ -1,8 +1,32 @@
 import { Box } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { Svix } from 'svix';
 import { AppPortal } from 'svix-react';
 
 import 'svix-react/style.css';
-export default function WebhookTabPanel({ svixDashboardUrl }: { svixDashboardUrl: string }) {
+import Spinner from '../Spinner';
+
+export default function WebhookTabPanel({ applicationId }: { applicationId: string }) {
+  const [svixDashboardUrl, setSvixDashboardUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const getDashboardUrl = async () => {
+      if (process.env.NEXT_PUBLIC_SVIX_API_TOKEN) {
+        const svix = new Svix(process.env.NEXT_PUBLIC_SVIX_API_TOKEN as string, {
+          serverUrl: process.env.NEXT_PUBLIC_SVIX_SERVER_URL,
+        });
+        const dashboardUrl = (await svix.authentication.appPortalAccess(applicationId, {})).url;
+        setSvixDashboardUrl(dashboardUrl);
+      }
+    };
+
+    void getDashboardUrl();
+  }, [applicationId]);
+
+  if (!svixDashboardUrl) {
+    return <Spinner />;
+  }
+
   return (
     <Box
       sx={{

--- a/apps/mgmt-ui/src/pages/api/index.ts
+++ b/apps/mgmt-ui/src/pages/api/index.ts
@@ -4,4 +4,5 @@ export const ORGANIZATION_ID = 'e7070cc8-36e7-43e2-81fc-ad57713cf2d3';
 export const SG_INTERNAL_TOKEN = process.env.SUPAGLUE_INTERNAL_TOKEN!;
 export const IS_CLOUD = process.env.NEXT_PUBLIC_IS_CLOUD === 'true' || process.env.NEXT_PUBLIC_IS_CLOUD === '1';
 export const MUI_LICENSE_KEY = process.env.NEXT_PUBLIC_MUI_LICENSE_KEY;
+export const SVIX_API_TOKEN = process.env.SVIX_API_TOKEN!;
 export const { LEKKO_API_KEY } = process.env;

--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/index.tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/index.tsx
@@ -7,7 +7,7 @@ import { type GetServerSideProps } from 'next';
 import type { Session } from 'next-auth';
 import { getServerSession } from 'next-auth/next';
 import { useState } from 'react';
-import { API_HOST, IS_CLOUD, LEKKO_API_KEY } from '../../api';
+import { API_HOST, IS_CLOUD, LEKKO_API_KEY, SVIX_API_TOKEN } from '../../api';
 
 //
 // Lekkodefaults
@@ -42,6 +42,7 @@ export type PublicEnvProps = {
   IS_CLOUD: boolean;
   CLERK_ACCOUNT_URL: string;
   CLERK_ORGANIZATION_URL: string;
+  SVIX_API_TOKEN?: string;
   lekko: {
     homeCtaButtonConfig: HomeCtaButton;
     entitiesWhitelistConfig: EntitiesWhitelist;
@@ -128,6 +129,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, resolve
       IS_CLOUD,
       CLERK_ACCOUNT_URL,
       CLERK_ORGANIZATION_URL,
+      SVIX_API_TOKEN,
       lekko: { homeCtaButtonConfig, entitiesWhitelistConfig, schemasWhitelistConfig },
     },
   };

--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/index.tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/index.tsx
@@ -7,7 +7,6 @@ import { type GetServerSideProps } from 'next';
 import type { Session } from 'next-auth';
 import { getServerSession } from 'next-auth/next';
 import { useState } from 'react';
-import { Svix } from 'svix';
 import { API_HOST, IS_CLOUD, LEKKO_API_KEY } from '../../api';
 
 //
@@ -50,9 +49,8 @@ export type PublicEnvProps = {
   };
 };
 
-export const getServerSideProps: GetServerSideProps = async ({ req, res, query, resolvedUrl }) => {
+export const getServerSideProps: GetServerSideProps = async ({ req, res, resolvedUrl }) => {
   let session: Session | null = null;
-  const applicationId = query.applicationId as string;
 
   if (!IS_CLOUD) {
     session = await getServerSession(req, res, authOptions);
@@ -75,12 +73,6 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, query, 
         },
       };
     }
-  }
-
-  let svixDashboardUrl: string | null = null;
-  if (process.env.SVIX_API_TOKEN) {
-    const svix = new Svix(process.env.SVIX_API_TOKEN, { serverUrl: process.env.SVIX_SERVER_URL });
-    svixDashboardUrl = (await svix.authentication.appPortalAccess(applicationId, {})).url;
   }
 
   // Lekko defaults
@@ -131,7 +123,6 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, query, 
     props: {
       session,
       signedIn: true,
-      svixDashboardUrl,
       ...buildClerkProps(req),
       API_HOST,
       IS_CLOUD,

--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/settings/[...tab].tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/settings/[...tab].tsx
@@ -33,8 +33,8 @@ export default function Home(props: SupaglueProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const { tab = [] } = router.query;
   const [value, setValue] = React.useState(0);
-  const { svixDashboardUrl } = props;
   const activeApplicationId = useActiveApplicationId();
+  const enableWebhooksTab = !!process.env.NEXT_PUBLIC_SVIX_API_TOKEN;
 
   React.useEffect(() => {
     const tabIndex = settingsHeaderTabs.findIndex((settingsHeaderTab) => settingsHeaderTab.value === tab[0]);
@@ -51,7 +51,7 @@ export default function Home(props: SupaglueProps) {
         {...props}
         tabs={
           <Tabs value={value} textColor="inherit">
-            {svixDashboardUrl ? (
+            {enableWebhooksTab ? (
               <Tab
                 label="Webhooks"
                 onClick={async () => {
@@ -71,9 +71,9 @@ export default function Home(props: SupaglueProps) {
         onDrawerToggle={handleDrawerToggle}
       />
       <TabContainer>
-        {svixDashboardUrl ? (
+        {enableWebhooksTab ? (
           <TabPanel value={value} index={0} className="w-full">
-            <WebhookTabPanel svixDashboardUrl={svixDashboardUrl} />
+            <WebhookTabPanel applicationId={activeApplicationId} />
           </TabPanel>
         ) : null}
         <TabPanel value={value} index={1} className="w-full">

--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/settings/[...tab].tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/settings/[...tab].tsx
@@ -34,7 +34,7 @@ export default function Home(props: SupaglueProps) {
   const { tab = [] } = router.query;
   const [value, setValue] = React.useState(0);
   const activeApplicationId = useActiveApplicationId();
-  const enableWebhooksTab = !!process.env.NEXT_PUBLIC_SVIX_API_TOKEN;
+  const enableWebhooksTab = !!props.SVIX_API_TOKEN;
 
   React.useEffect(() => {
     const tabIndex = settingsHeaderTabs.findIndex((settingsHeaderTab) => settingsHeaderTab.value === tab[0]);
@@ -73,7 +73,7 @@ export default function Home(props: SupaglueProps) {
       <TabContainer>
         {enableWebhooksTab ? (
           <TabPanel value={value} index={0} className="w-full">
-            <WebhookTabPanel applicationId={activeApplicationId} />
+            <WebhookTabPanel applicationId={activeApplicationId} svixApiToken={props.SVIX_API_TOKEN} />
           </TabPanel>
         ) : null}
         <TabPanel value={value} index={1} className="w-full">


### PR DESCRIPTION
Context: we are calling a Svix call on every `getServerSideProps`, even on pages that don't need it. This is adding ~200-300ms of latency to each page load.

I've refactored it to move the Svix call to just that tab only. This requires moving the Svix API key to `NEXT_PUBLIC_...`