### PR TITLE
chore: use docker compose watch for local dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,20 @@
+FROM node:18-bullseye-slim AS base
+
+FROM base AS builder
+ARG APP
+WORKDIR /workspace
+RUN yarn global add turbo
+COPY . .
+RUN --mount=type=cache,mode=0777,target=/workspace/.yarn/cache turbo prune --scope=${APP} --docker
+
+# Add lockfile and package.json's of isolated subworkspace
+FROM base AS dev
+WORKDIR /workspace
+
+# First install dependencies (as they change less often)
+COPY . .
+COPY .yarnrc.build.yml .yarnrc.yml
+COPY .yarn .yarn
+COPY --from=builder /workspace/out/json/ .
+COPY --from=builder /workspace/out/yarn.lock ./yarn.lock
+RUN yarn install

--- a/apps/api/index.ts
+++ b/apps/api/index.ts
@@ -219,7 +219,7 @@ createTerminus(server, {
       return;
     },
   },
-  timeout: 10000,
+  timeout: process.env.ENVIRONMENT === 'development' ? 0 : 10000,
   beforeShutdown: async () => {
     logger.info('Server is shutting down');
     metricsServer.close();

--- a/depot.json
+++ b/depot.json
@@ -1,0 +1,1 @@
+{"id":"njz6kvt3dk"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-supaglue}
 
   api:
-    image: node:18-bullseye
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+      args:
+        - APP=api
     ports:
       - '8080:8080'
     depends_on:
@@ -53,9 +57,21 @@ services:
         condition: service_started
       init:
         condition: service_completed_successfully
-    volumes:
-      - .:/app
-    working_dir: /app
+    working_dir: /workspace
+    develop:
+      watch:
+        - action: sync
+          path: ./apps/api
+          target: /workspace/apps/api
+          ignore:
+            - node_modules/
+        - action: sync
+          path: ./packages
+          target: /workspace/packages
+        - action: rebuild
+          path: package.json
+        - action: rebuild
+          path: ./apps/api/package.json
     environment:
       <<: [*common-env, *fe-api-common-env]
       SUPAGLUE_API_PORT: ${SUPAGLUE_API_PORT:-8080}
@@ -63,22 +79,38 @@ services:
       SUPAGLUE_SYNC_PERIOD_MS:
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin}
     restart: on-failure
-    command: /bin/sh -c "./apps/api/scripts/start_dev.sh"
+    command: /bin/sh -c "yarn workspace api start"
 
   sync-worker:
-    image: node:18-bullseye
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+      args:
+        - APP=sync-worker
     depends_on:
       postgres:
         condition: service_started
       init:
         condition: service_completed_successfully
-    volumes:
-      - .:/app
-    working_dir: /app
+    working_dir: /workspace
+    develop:
+      watch:
+        - action: sync
+          path: ./apps/sync-worker
+          target: /workspace/apps/sync-worker
+          ignore:
+            - node_modules/
+        - action: sync
+          path: ./packages
+          target: /workspace/packages
+        - action: rebuild
+          path: package.json
+        - action: rebuild
+          path: ./apps/sync-worker/package.json
     environment:
       <<: *common-env
     restart: on-failure
-    command: /bin/sh -c "./apps/sync-worker/scripts/start_dev.sh"
+    command: /bin/sh -c "yarn workspace sync-worker start"
 
   temporal:
     image: alpine:3.18.0
@@ -109,7 +141,6 @@ services:
       - sh
       - -c
       - |
-        yarn install
         yarn workspace @supaglue/db prisma migrate dev
         yarn workspace @supaglue/db prisma db seed
         yarn workspace api init-temporal


### PR DESCRIPTION
Once this lands, use `docker compose watch` to start the stack. If you want to watch logs, use `docker compose logs -f`

Note: first start will take a while as it builds images