### PR TITLE
chore: change response validation errors to warnings to reduce noise

### DIFF
--- a/apps/api/middleware/openapi.ts
+++ b/apps/api/middleware/openapi.ts
@@ -41,10 +41,10 @@ export const openapiMiddleware = (specDir: string, version = 'v2') => {
       removeAdditional: true,
     },
     validateResponses: {
-      onError: (error, body, req) => {
-        logger.error(
+      onError: (err, body, req) => {
+        logger.warn(
           {
-            error,
+            err,
             originalUrl: req.originalUrl,
           },
           'API response validation error'


### PR DESCRIPTION
These should be warnings as they flood the logs making it hard to identify true errors that customers are seeing.