### PR TITLE
fix: add openApiErrorHandlerMiddleware to places it's missing from

### DIFF
--- a/apps/api/routes/actions/v2/index.ts
+++ b/apps/api/routes/actions/v2/index.ts
@@ -1,5 +1,5 @@
 import { getDependencyContainer } from '@/dependency_container';
-import { openapiMiddleware } from '@/middleware/openapi';
+import { openApiErrorHandlerMiddleware, openapiMiddleware } from '@/middleware/openapi';
 import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
 import { addLogContext } from '@supaglue/core/lib/logger';
 import type {
@@ -33,6 +33,8 @@ export default function init(app: Router): void {
       return res.status(200).send(response);
     }
   );
+
+  v2Router.use(openApiErrorHandlerMiddleware);
 
   app.use('/v2', v2Router);
 }

--- a/apps/api/routes/metadata/v2/index.ts
+++ b/apps/api/routes/metadata/v2/index.ts
@@ -1,5 +1,5 @@
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
-import { openapiMiddleware } from '@/middleware/openapi';
+import { openApiErrorHandlerMiddleware, openapiMiddleware } from '@/middleware/openapi';
 import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
 import { Router } from 'express';
 import object from './object';
@@ -14,6 +14,8 @@ export default function init(app: Router): void {
 
   object(v2Router);
   property(v2Router);
+
+  v2Router.use(openApiErrorHandlerMiddleware);
 
   app.use('/v2', v2Router);
 }

--- a/apps/api/routes/mgmt/v2/index.ts
+++ b/apps/api/routes/mgmt/v2/index.ts
@@ -1,5 +1,5 @@
 import { apiKeyHeaderMiddleware } from '@/middleware/api_key';
-import { openapiMiddleware } from '@/middleware/openapi';
+import { openApiErrorHandlerMiddleware, openapiMiddleware } from '@/middleware/openapi';
 import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
 import { Router } from 'express';
 import connectionSyncConfig from './connection_sync_config';
@@ -30,6 +30,8 @@ export default function init(app: Router): void {
   entity(v2Router);
   entityMapping(v2Router);
   magicLink(v2Router);
+
+  v2Router.use(openApiErrorHandlerMiddleware);
 
   app.use('/v2', v2Router);
 }


### PR DESCRIPTION
This middleware should be used anywhere we use the open api validation middleware. It was missing from a few places, and that means that requests that should have returned a 400 were returning a 500 instead.