### PR TITLE
fix: custom object entity mappings

### DIFF
--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/customers/[customerId]/connections/[providerName]/index.tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/customers/[customerId]/connections/[providerName]/index.tsx
@@ -41,29 +41,17 @@ import { useEffect, useState } from 'react';
 
 export { getServerSideProps };
 
-type FriendlyStandardOrCustomObject =
-  | {
-      type: 'standard';
-      name: string;
-    }
-  | {
-      type: 'custom';
-      id: string;
-      name: string;
-    };
+type FriendlyStandardOrCustomObject = {
+  type: 'standard' | 'custom';
+  name: string;
+};
 
-type FriendlyStandardOrCustomObjectWithAttribution =
-  | {
-      type: 'standard';
-      name: string;
-      from: 'developer' | 'customer';
-    }
-  | {
-      type: 'custom';
-      id: string;
-      name: string;
-      from: 'developer' | 'customer';
-    };
+type FriendlyStandardOrCustomObjectWithAttribution = {
+  type: 'standard' | 'custom';
+  id: string;
+  name: string;
+  from: 'developer' | 'customer';
+};
 
 export default function Home(props: SupaglueProps) {
   const applicationId = useActiveApplicationId();
@@ -232,6 +220,7 @@ function EntityMapping({ customerId, entity, providerName, initialMapping, saveE
     mergedEntityMapping.object
       ? {
           type: mergedEntityMapping.object.type,
+          id: mergedEntityMapping.object.name,
           name: mergedEntityMapping.object.name,
           from: mergedEntityMapping.object.from,
         }
@@ -314,12 +303,13 @@ function EntityObjectMapping({ entity, customerId, providerName, object, setObje
     setObjectOptions([
       ...standardObjectOptions.map(({ name }) => ({
         type: 'standard' as const,
+        id: name,
         name,
       })),
-      ...customObjectOptions.map((object) => ({
+      ...customObjectOptions.map(({ name }) => ({
         type: 'custom' as const,
-        id: object.id,
-        name: object.name,
+        id: name,
+        name: name,
       })),
     ]);
   }, [standardObjectOptions, customObjectOptions, customObjectOptionsError, standardObjectOptionsError]);

--- a/apps/mgmt-ui/src/pages/applications/[applicationId]/customers/[customerId]/connections/[providerName]/index.tsx
+++ b/apps/mgmt-ui/src/pages/applications/[applicationId]/customers/[customerId]/connections/[providerName]/index.tsx
@@ -175,23 +175,15 @@ function EntityMapping({ customerId, entity, providerName, initialMapping, saveE
   const [mergedEntityMapping, setMergedEntityMapping] = useState<MergedEntityMapping>(initialMapping);
   const [isDirty, setIsDirty] = useState<boolean>(false);
 
-  const { data: customObjectOptions = [] } = useCustomObjects(customerId, providerName);
-
   const setObject = (selected: FriendlyStandardOrCustomObject | undefined) => {
     setMergedEntityMapping({
       ...mergedEntityMapping,
       object: selected
-        ? selected.type === 'standard'
-          ? {
-              type: 'standard',
-              name: selected.name,
-              from: 'customer',
-            }
-          : {
-              type: 'custom',
-              name: selected.id,
-              from: 'customer',
-            }
+        ? {
+            type: selected.type,
+            name: selected.name,
+            from: 'customer',
+          }
         : undefined,
     });
     setIsDirty(true);
@@ -238,18 +230,11 @@ function EntityMapping({ customerId, entity, providerName, initialMapping, saveE
 
   const entityMappingFriendlyObjectWithAttribution: FriendlyStandardOrCustomObjectWithAttribution | undefined =
     mergedEntityMapping.object
-      ? mergedEntityMapping.object.type === 'standard'
-        ? {
-            type: 'standard',
-            name: mergedEntityMapping.object.name,
-            from: mergedEntityMapping.object.from,
-          }
-        : {
-            type: 'custom',
-            id: mergedEntityMapping.object.name,
-            name: customObjectOptions.find(({ id }) => id === mergedEntityMapping.object?.name)?.name ?? '',
-            from: mergedEntityMapping.object.from,
-          }
+      ? {
+          type: mergedEntityMapping.object.type,
+          name: mergedEntityMapping.object.name,
+          from: mergedEntityMapping.object.from,
+        }
       : undefined;
 
   return (


### PR DESCRIPTION
Hubspot API does not allow lookup by ID (expects name) -- not sure how this was ever working.

Note: For any customers that have already mapped entities to custom objects, they will have to remap them.