### PR TITLE
chore: fix flaky integration tests for pipedrive

### DIFF
--- a/apps/api/routes/crm/v2/account.integration.test.ts
+++ b/apps/api/routes/crm/v2/account.integration.test.ts
@@ -92,6 +92,11 @@ describe('account', () => {
 
       expect(updateResponse.status).toEqual(200);
 
+      // Pipedrive does not have read after write guarantees, so we need to wait
+      if (providerName === 'pipedrive') {
+        await new Promise((resolve) => setTimeout(resolve, 12000));
+      }
+
       const getResponse = await apiClient.get<GetAccountResponse>(`/crm/v2/accounts/${response.data.record?.id}`, {
         headers: { 'x-provider-name': providerName },
       });

--- a/apps/api/routes/crm/v2/contact.integration.test.ts
+++ b/apps/api/routes/crm/v2/contact.integration.test.ts
@@ -97,6 +97,11 @@ describe('contact', () => {
 
       expect(updateResponse.status).toEqual(200);
 
+      // Pipedrive does not have read after write guarantees, so we need to wait
+      if (providerName === 'pipedrive') {
+        await new Promise((resolve) => setTimeout(resolve, 12000));
+      }
+
       const getResponse = await apiClient.get<GetContactResponse>(`/crm/v2/contacts/${response.data.record?.id}`, {
         headers: { 'x-provider-name': providerName },
       });

--- a/apps/api/routes/crm/v2/lead.integration.test.ts
+++ b/apps/api/routes/crm/v2/lead.integration.test.ts
@@ -141,6 +141,11 @@ describe('lead', () => {
 
       expect(updateResponse.status).toEqual(200);
 
+      // Pipedrive does not have read after write guarantees, so we need to wait
+      if (providerName === 'pipedrive') {
+        await new Promise((resolve) => setTimeout(resolve, 12000));
+      }
+
       const getResponse = await apiClient.get<GetLeadResponse>(`/crm/v2/leads/${response.data.record?.id}`, {
         headers: { 'x-provider-name': providerName },
       });


### PR DESCRIPTION
Pipedrive has no read after write guarantees, so we should wait before doing the GET to check its values.