### PR TITLE
feat: write custom objects into a single table and create convenience views

### DIFF
--- a/docs/docs/tutorials/transformations/object-field-mapping.mdx
+++ b/docs/docs/tutorials/transformations/object-field-mapping.mdx
@@ -5,9 +5,176 @@ import TabItem from '@theme/TabItem';
 
 ![platform](https://img.shields.io/badge/Platform%20Tutorial-009be5)
 
+There are at least 3 approaches to object and field level mapping appropriate for different situations, in increasing level of effort / complexity. 
+
+1. SQL-based mapping directly in the database
+    - Declarative power of SQL, mapped result visible to all db clients with no additional jobs to manage
+2. Runtime mapping in application code
+    - Not as declarative as SQL, and mapped result only visible in the calling application. However any changes to logic propagates instantly without any backfills or workloads to manage.
+3. Post-sync transformation triggered by webhooks
+    - Most flexible, but needs to manage additional workloads responsible for the transformation. Transformation results can be visible in DB but any changes in desired logic requires re-running the transforms
+
+We recommend starting with the simplest approach and graduate to a more complex one only when necessary. 
+
+## SQL-based mapping directly in the database
+
+This approach assumes that Supaglue lands data into your postgres or a similar database. 
+
+**Field mapping** 
+
+Let’s start off with the simplest case of mapping - field mapping. Since Supaglue lands all of the data in a `_supaglue_unified_data` jsonb column, the easiest way is to add a generated column pulling data out. For example
+
+```sql
+ALTER TABLE engagement_users ADD COLUMN is_locked boolean 
+  GENERATED ALWAYS AS ((_supaglue_unified_data->> 'is_locked')::boolean) STORED;
+```
+
+In addition to renaming, you can even use the full power of SQL to do transformation on the field in the generated clause. 
+
+**Object Mapping**
+
+Suppose you want both `contacts` and `accounts` from Hubspot to be mapped into a new entity called `hubspot_objects`, you can accomplish this with a union query. 
+
+```sql
+WITH hubspot_objects as (
+  SELECT
+    'hubspot_accounts' AS entity_name,
+    _supaglue_customer_id AS customer_id,
+    raw_data
+  FROM
+    hubspot_accounts
+  UNION
+  SELECT
+    'hubspot_contacts' AS entity_name,
+    _supaglue_customer_id AS customer_id,
+    raw_data
+  FROM
+    hubspot_contacts
+)
+SELECT * from hubspot_objects;
+```
+
+Of course, you can combine object mapping and field mapping together into a single query as well. 
+
+**Per-customer object & field mapping**
+
+Now things gets a bit more complex. Suppose your customers store product ideas in their CRM and you need to pull them out to run some analysis. Except each customer may have a different workflow and therefore store their ideas in different places. `customer_a` uses Salesforce and store them on `opportunities`  as `notes`. `customer_b` uses Hubspot and store them in a custom object called `custom_ideas` inside a field called `content` and `customer_c` doesn’t even use a CRM and store them directly inside their engagement tool Outreach on `contact` called `ideas`. At the end of the day you just want a single table called `product_ideas` to feed into your ML system. What then?
+
+Go into the same database Supaglue has landed for you, and create a mapping table to capture this. 
+
+```sql
+
+CREATE TABLE product_ideas_mapping (
+  customer_id varchar,
+  object_name varchar,
+  field_name varchar
+);
+
+INSERT INTO product_ideas_mapping (customer_id, object_name, field_name)
+VALUES
+    ('customer_1', 'salesforce_opportunities', 'notes'),
+    ('customer_2', 'hubspot_ideas', 'content'),
+    ('customer_3', 'outreach_contacts', 'ideas');
+
+```
+
+Then you combine the previously approach of field & object mapping together while joining against the mapping table to pull in the right. Notably this 
+
+```sql
+
+--- This can be either a (materialized) view or a simple select query. 
+CREATE VIEW product_ideas AS (
+	WITH raw_table AS (
+	  SELECT
+	    'salesforce_opportunities' AS object_name,
+	    _supaglue_customer_id AS customer_id,
+	    raw_data
+	  FROM
+	    salesforce_opportunities
+	  UNION
+	  SELECT
+	    name AS object_name,
+	    _supaglue_customer_id AS customer_id,
+	    raw_data
+	  FROM
+	    custom_objects
+	  UNION
+	  SELECT
+	    'outreach_contacts' AS object_name,
+	    _supaglue_customer_id AS customer_id,
+	    entity_data as raw_data
+	  FROM
+	    outreach_contacts
+	)
+	SELECT
+	  p.customer_id,
+	  (r.raw_data ->> p. "field_name") AS idea
+	FROM
+	  raw_table r
+	  JOIN product_ideas_mapping p ON r.customer_id = p.customer_id
+	    AND r.object_name = p.object_name
+);
+```
+
+By the way, you may also want to specific on a per-customer basis what should be sync’ed in the first place to make available for mapping. To specify that make sure you are hitting the [update connection sync config](https://docs.supaglue.com/api/v2/mgmt/upsert-connection-sync-config) when customer changes their settings in your app.
+
+## Runtime mapping in application code
+
+Sometimes it is inconvenient or not possible to modify the database. Let’s take product idea mapping example from the previous section. Perhaps your primary application database where you store user mapping is in MongoDB while Supabase lands data into a Postgres DB. In this case you can first retrieve the mapping for a given user from Mongo, then use it to construct a dynamic SQL query (with or without the help of ORM) to retrieve the objects you care about.
+
+```tsx
+
+for (const customerId in ['customer_1', 'customer_2', 'customer_3']) {
+	const {object_name, field_name} = mongo.productIdeaMapping.find({customerId: 'customer_1')
+	if (object_name.startsWith('hubspot_custom')) {
+		const ideas = await sql`
+			SELECT _supaglue_customer_id as customer_id, raw_data->>${field_name} 
+			FROM custom_objects
+			WHERE name = ${object_name}`;
+	}	else {
+		const ideas = await sql`
+			SELECT _supaglue_customer_id as customer_id, raw_data->>${field_name}
+		  from ${object_name}`;
+	}
+}
+
+```
+
+Supposed you are using `TypeORM`, you can similarly accomplish it with the following 
+
+```tsx
+const repos = {
+	salesforce_opportunities: SalesforceOpportunityRepo,
+  custom_objects: HubspotCustomObjectsRepo
+  outreach_contacts: OutreachContactsRepo
+}
+
+for (const customerId in ['customer_1', 'customer_2', 'customer_3']) {
+	const {object_name, field_name} = mongo.productIdeaMapping.find({customerId: 'customer_1')
+	if (object_name.startsWith('hubspot_custom')) {
+		const ideas = repos.hubspotCustomObject.createQueryBuilder('ideas')
+			.select()
+			.addSelect(`raw_data->>'${field_name}'`, 'idea')
+			.where('name', '=', object_name)
+			.getRows()
+		// NOTE: You can also 
+	} else {
+	  const repo = repos[object_name]
+		const ideas = repo.createQueryBuilder('ideas')
+			.select()
+			.addSelect(`raw_data->>'${field_name}'`, 'idea')
+			.getRows()
+	}
+}
+```
+
+Similar to the SQL based mapping, you may need to hit the [update connection sync config](https://docs.supaglue.com/api/v2/mgmt/upsert-connection-sync-config) API to configure what data should be synced int the first place on a per-customer baiss. 
+
+## Post-sync transformation triggered by webhooks
+
 This tutorial will use Supaglue to sync your customers' CRM records into existing tables in your database using your schema.
 
-## Prerequisites
+### Prerequisites
 
 This tutorial assumes you have already gone through Supaglue's [Quickstart](../../quickstart) and will use the following technologies:
 
@@ -15,7 +182,7 @@ This tutorial assumes you have already gone through Supaglue's [Quickstart](../.
 - Prisma
 - Postgres
 
-## Scenario
+### Scenario
 
 Suppose that your application has two database tables, `contact` and `opportunity`, that we want to write into using your customers' CRM data:
 
@@ -45,7 +212,7 @@ In this tutorial, we'll use three example customers: `user-`, `user-2`, and `use
 | `contact`           | Hubspot `contact` | Salesforce `Lead`        | Salesforce `Contact`     |
 | `opportunity`       | Hubspot `deal`    | Salesforce `Opportunity` | Salesforce `Opportunity` |
 
-## Write mapped records to your database
+### Write mapped records to your database
 
 We will go over how to do the following:
 
@@ -57,7 +224,7 @@ We will go over how to do the following:
 "Entities" is used to refer to your application data models.
 :::
 
-### 1. Listen for Supaglue's webhook event
+#### 1. Listen for Supaglue's webhook event
 
 Supaglue [emits different kinds](../../platform/notification-webhooks) of notification webhooks. For object and field mapping, we want to process the `sync.complete` event which Supaglue emits after a full or incremental sync completes.
 
@@ -83,11 +250,11 @@ export async function POST(request: NextRequest) {
 Please refer to the [consuming webhooks](../listen-for-webhooks) tutorial for more details on how to do it.
 :::
 
-### 2. Define the transformation function
+#### 2. Define the transformation function
 
 When a sync completes for a specific provider/customer/object, we need to determine if that maps to a `contact` or `opportunity` in your application.
 
-#### Define a per-customer mapper file
+##### Define a per-customer mapper file
 
 First, create a per-customer mapper file containing the mapping configuration for each customer's records to your database tables. The following are examples for `user-1`, `user-2`, `user-3` from the [Scenario](#scenario) section above:
 
@@ -201,7 +368,7 @@ const user3: UserConfig = {
 
 </Tabs>
 
-#### Create a helper to retrieve the right mapper based on {providerName, customerId, object}
+##### Create a helper to retrieve the right mapper based on {providerName, customerId, object}
 
 The following code uses the per-customer mapper files from above:
 
@@ -240,7 +407,7 @@ export const getMapper = (providerName: string, customerId: string, object: stri
 In this sample code, you, the developer, define the object and field mappings. You could also evolve this code to allow your customers to configure the object and field mappings.
 :::
 
-#### Use the helper to call the mapper
+##### Use the helper to call the mapper
 
 Now, let's call the mapper file from your transformation function:
 
@@ -249,7 +416,7 @@ Now, let's call the mapper file from your transformation function:
 const mapper = getMapper(data.provider_name, data.customer_id, data.object);
 ```
 
-### 3. Paginate over and transform newly-synced records
+#### 3. Paginate over and transform newly-synced records
 
 Now, we want to transform the newly-synced records to write into your existing database tables. We'll use the mapper that we wrote earlier to do this.
 
@@ -406,7 +573,7 @@ const newMaxLastModifiedAtMs = await step.run('Update records', async () => {
 
 </Tabs>
 
-## More information
+### More information
 
 You can try out a working example of this tutorial by cloning the [object-field-mapping-example](https://github.com/supaglue-labs/object-field-mapping-example) repository and following the instructions in the README.
 

--- a/packages/core/destination_writers/base.ts
+++ b/packages/core/destination_writers/base.ts
@@ -53,7 +53,8 @@ export interface DestinationWriter {
     object: string,
     stream: Readable,
     heartbeat: () => void,
-    diffAndDeleteRecords: boolean
+    diffAndDeleteRecords: boolean,
+    objectType: 'standard' | 'custom'
   ): Promise<WriteObjectRecordsResult>;
 
   /**
@@ -147,7 +148,8 @@ export abstract class BaseDestinationWriter implements DestinationWriter {
     object: string,
     stream: Readable,
     heartbeat: () => void,
-    diffAndDeleteRecords: boolean
+    diffAndDeleteRecords: boolean,
+    objectType: 'standard' | 'custom'
   ): Promise<WriteObjectRecordsResult>;
 
   abstract writeEntityRecords(

--- a/packages/core/destination_writers/postgres_impl.ts
+++ b/packages/core/destination_writers/postgres_impl.ts
@@ -40,6 +40,9 @@ import {
   stripNullCharsFromString,
 } from './util';
 
+export const kCustomObject = 'custom_objects';
+export type ObjectType = 'standard' | 'custom';
+
 export class PostgresDestinationWriterImpl {
   async upsertCommonObjectRecordImpl<P extends ProviderCategory, T extends CommonObjectTypeForCategory<P>>(
     client: PoolClient,
@@ -281,10 +284,12 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
     client: PoolClient,
     { providerName, customerId, applicationId }: ConnectionSafeAny,
     schema: string,
-    table: string,
+    objectName: string,
     record: BaseFullRecord,
-    setup: () => Promise<void>
+    setup: () => Promise<void>,
+    objectType: 'standard' | 'custom'
   ): Promise<void> {
+    const table = objectType === 'standard' ? objectName : kCustomObject;
     const qualifiedTable = `"${schema}".${table}`;
     const childLogger = logger.child({ providerName, customerId });
     // Write `supaglue_mapped_data` for existing Schemas and Entities users. We should write empty object otherwise.
@@ -293,7 +298,7 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
     try {
       await setup();
 
-      const mappedRecord: Record<string, string | boolean | object> = {
+      const mappedRecord: Record<string, string | boolean | object | null> = {
         _supaglue_application_id: applicationId,
         _supaglue_provider_name: providerName,
         _supaglue_customer_id: customerId,
@@ -305,6 +310,7 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
         _supaglue_mapped_data: isSchemasOrEntitiesApplication
           ? toTransformedPropertiesWithAdditionalFields(record.mappedProperties)
           : {},
+        ...(objectType === 'custom' ? { _supaglue_object_name: objectName } : {}),
       };
       const columns = Object.keys(mappedRecord);
       const columnsToUpdate = columns.filter(
@@ -312,7 +318,8 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
           c !== '_supaglue_application_id' &&
           c !== '_supaglue_provider_name' &&
           c !== '_supaglue_customer_id' &&
-          c !== '_supaglue_id'
+          c !== '_supaglue_id' &&
+          c !== '_supaglue_object_name'
       );
 
       const columnsStr = columns.join(',');
@@ -338,12 +345,14 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
         `INSERT INTO ${qualifiedTable} (${columnsStr})
 VALUES
   (${columnPlaceholderValuesStr})
-ON CONFLICT (_supaglue_application_id, _supaglue_provider_name, _supaglue_customer_id, _supaglue_id)
+ON CONFLICT (_supaglue_application_id, _supaglue_provider_name, _supaglue_customer_id, _supaglue_id${
+          objectType === 'custom' ? ', _supaglue_object_name' : ''
+        })
 DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`,
         values
       );
     } catch (err) {
-      childLogger.error({ err }, 'Error upserting common object record');
+      childLogger.error({ err }, 'Error upserting record');
       throw err;
     } finally {
       client.release();
@@ -354,13 +363,15 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`,
     client: PoolClient,
     { providerName, customerId, applicationId }: ConnectionSafeAny,
     schema: string,
-    table: string,
+    objectName: string,
     inputStream: Readable,
     heartbeat: () => void,
     childLogger: pino.Logger,
     diffAndDeleteRecords: boolean,
-    setup: () => Promise<void>
+    setup: () => Promise<void>,
+    objectType: 'standard' | 'custom'
   ): Promise<WriteObjectRecordsResult> {
+    const table = objectType === 'standard' ? objectName : kCustomObject;
     const qualifiedTable = `"${schema}".${table}`;
     const tempTable = `"temp_${table}"`;
     const dedupedTempTable = `"deduped_temp_${table}"`;
@@ -382,13 +393,15 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`,
         '_supaglue_raw_data',
         // This is used to support entities + schemas. We should write empty object otherwise (e.g. for managed destinations).
         '_supaglue_mapped_data',
+        ...(objectType === 'custom' ? ['_supaglue_object_name'] : []),
       ];
       const columnsToUpdate = columns.filter(
         (c) =>
           c !== '_supaglue_application_id' &&
           c !== '_supaglue_provider_name' &&
           c !== '_supaglue_customer_id' &&
-          c !== '_supaglue_id'
+          c !== '_supaglue_id' &&
+          c !== '_supaglue_object_name'
       );
 
       // Output
@@ -431,6 +444,7 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`,
                 _supaglue_mapped_data: isSchemasOrEntitiesApplication
                   ? toTransformedPropertiesWithAdditionalFields(record.mappedProperties)
                   : {},
+                _supaglue_object_name: objectName,
               };
 
               ++tempTableRowCount;
@@ -490,8 +504,12 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`,
         // TODO: This may have performance implications. We should look into this later.
         // https://github.com/supaglue-labs/supaglue/issues/497
         await client.query(`INSERT INTO ${qualifiedTable} (${columns.join(',')})
-SELECT DISTINCT ON (_supaglue_id) ${columns.join(',')} FROM ${dedupedTempTable} OFFSET ${offset} limit ${batchSize}
-ON CONFLICT (_supaglue_application_id, _supaglue_provider_name, _supaglue_customer_id, _supaglue_id)
+SELECT DISTINCT ON (_supaglue_id${objectType === 'custom' ? ', _supaglue_object_name' : ''}) ${columns.join(
+          ','
+        )} FROM ${dedupedTempTable} OFFSET ${offset} limit ${batchSize}
+ON CONFLICT (_supaglue_application_id, _supaglue_provider_name, _supaglue_customer_id, _supaglue_id${
+          objectType === 'custom' ? ', _supaglue_object_name' : ''
+        })
 DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
         childLogger.info({ offset }, 'Copying from deduped temp table to main table [COMPLETED]');
         heartbeat();
@@ -499,6 +517,8 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
 
       childLogger.info('Copying from deduped temp table to main table [COMPLETED]');
 
+      // TODO: Watch for sql-injection attack around custom object name.... we should probably use a better
+      // sql library so we are not templating raw SQL strings
       if (shouldDeleteRecords(diffAndDeleteRecords, providerName)) {
         childLogger.info('Marking rows as deleted [IN PROGRESS]');
         await client.query(`
@@ -508,10 +528,12 @@ DO UPDATE SET (${columnsToUpdateStr}) = (${excludedColumnsToUpdateStr})`);
             destination._supaglue_application_id = '${applicationId}' AND
             destination._supaglue_provider_name = '${providerName}' AND
             destination._supaglue_customer_id = '${customerId}'
+            ${objectType === 'custom' ? `AND destination._supaglue_object_name = '${objectName}'` : ''}
           AND NOT EXISTS (
               SELECT 1
               FROM ${dedupedTempTable} AS temp
               WHERE temp._supaglue_id = destination._supaglue_id
+              
           );
         `);
         childLogger.info('Marking rows as deleted [COMPLETED]');

--- a/packages/sync-workflows/activities/sync_object_records.ts
+++ b/packages/sync-workflows/activities/sync_object_records.ts
@@ -128,7 +128,8 @@ export function createSyncObjectRecords(
               object,
               toHeartbeatingReadable(toMappedPropertiesReadable(stream, fieldMappingConfig)),
               heartbeat,
-              /* diffAndDeleteRecords */ shouldDeleteRecords(!updatedAfterMs, connection.providerName)
+              /* diffAndDeleteRecords */ shouldDeleteRecords(!updatedAfterMs, connection.providerName),
+              'standard'
             );
           }
           break;
@@ -145,7 +146,8 @@ export function createSyncObjectRecords(
               object,
               toHeartbeatingReadable(toMappedPropertiesReadable(stream, fieldMappingConfig)),
               heartbeat,
-              /* diffAndDeleteRecords */ shouldDeleteRecords(!updatedAfterMs, connection.providerName)
+              /* diffAndDeleteRecords */ shouldDeleteRecords(!updatedAfterMs, connection.providerName),
+              'custom'
             );
           }
           break;


### PR DESCRIPTION
## Test Plan

Manually tested this works for both custom objects and standard objects in both managed sync and customer postgres settings. Did not implement this for postgres so did not test its implementation. 

  | Standard Objects | Custom Objects
-- | -- | --
Managed sync | Tested ✅ | Tested ✅
Customer postgres | Tested ✅ | Tested ✅
Customer bigQuery | No change | No change


Also tested that that this works for the custom object lists endpoint when using Supaglue managed destination (thanks to the views)

https://github.com/supaglue-labs/supaglue/assets/696842/d1c6060d-82be-47aa-a7a3-ec6cfba6ea0e

