### PR TITLE
chore: more logs for axios and passthrough for debuggability

### DIFF
--- a/apps/api/routes/actions/v2/index.ts
+++ b/apps/api/routes/actions/v2/index.ts
@@ -1,7 +1,7 @@
 import { getDependencyContainer } from '@/dependency_container';
 import { openApiErrorHandlerMiddleware, openapiMiddleware } from '@/middleware/openapi';
 import { pinoAndSentryContextMiddleware } from '@/middleware/pino_context';
-import { addLogContext } from '@supaglue/core/lib/logger';
+import { addLogContext, logger } from '@supaglue/core/lib/logger';
 import type {
   SendPassthroughRequestPathParams,
   SendPassthroughRequestRequest,
@@ -30,6 +30,17 @@ export default function init(app: Router): void {
         query: req.body.query,
       });
       const response = await passthroughService.send(req.customerConnection.id, req.body);
+
+      if (response.status >= 300) {
+        logger.warn(
+          {
+            passthroughBody: req.body,
+            passthroughResponse: response,
+          },
+          'non-2xx passthrough axios response'
+        );
+      }
+
       return res.status(200).send(response);
     }
   );

--- a/apps/api/services/passthrough_service.ts
+++ b/apps/api/services/passthrough_service.ts
@@ -1,4 +1,3 @@
-import { addLogContext } from '@supaglue/core/lib';
 import type { RemoteService } from '@supaglue/core/services/remote_service';
 import type { SendPassthroughRequestRequest, SendPassthroughRequestResponse } from '@supaglue/types/passthrough';
 
@@ -14,12 +13,6 @@ export class PassthroughService {
     request: SendPassthroughRequestRequest
   ): Promise<SendPassthroughRequestResponse> {
     const client = await this.#remoteService.getRemoteClient(connectionId);
-    // TODO I don't think this is actually working right now. Not seeing any context on successful request logs
-    //      and error logs are missing this key. Figure out why
-    addLogContext('passthroughRequest', {
-      path: request.path,
-      method: request.method,
-    });
     return await client.sendPassthroughRequest(request);
   }
 }

--- a/packages/core/lib/logger.ts
+++ b/packages/core/lib/logger.ts
@@ -59,7 +59,6 @@ export const logger: Logger = wrapLogger(
       base: undefined, // don't log hostname and pid,
       redact: [
         'err.config.headers.Authorization', // axios errors
-        'context.passthroughRequest.body',
       ],
     },
     pino.multistream(streams)

--- a/packages/core/lib/webhook.ts
+++ b/packages/core/lib/webhook.ts
@@ -1,6 +1,6 @@
+import axios from '@supaglue/core/remotes/sg_axios';
 import type { WebhookConfig, WebhookPayload } from '@supaglue/types';
 import { snakecaseKeys } from '@supaglue/utils/snakecase';
-import axios from 'axios';
 import { logger } from './logger';
 
 export type WebhookPayloadType = 'CONNECTION_SUCCESS' | 'CONNECTION_ERROR' | 'SYNC_SUCCESS' | 'SYNC_ERROR';

--- a/packages/core/remotes/base.ts
+++ b/packages/core/remotes/base.ts
@@ -1,3 +1,4 @@
+import axios from '@supaglue/core/remotes/sg_axios';
 import type {
   CreatePropertyParams,
   ObjectRecordUpsertData,
@@ -20,7 +21,6 @@ import type {
 } from '@supaglue/types/custom_object';
 import type { FieldsToFetch } from '@supaglue/types/fields_to_fetch';
 import type { StandardOrCustomObject } from '@supaglue/types/standard_or_custom_object';
-import axios from 'axios';
 import { EventEmitter } from 'events';
 import type { Readable } from 'stream';
 import { NotImplementedError } from '../errors';

--- a/packages/core/remotes/impl/6sense/index.ts
+++ b/packages/core/remotes/impl/6sense/index.ts
@@ -1,3 +1,4 @@
+import axios from '@supaglue/core/remotes/sg_axios';
 import type {
   ConnectionUnsafe,
   Provider,
@@ -5,7 +6,6 @@ import type {
   SendPassthroughRequestResponse,
 } from '@supaglue/types';
 import type { PersonEnrichmentData } from '@supaglue/types/enrichment/person_enrichment_data';
-import axios from 'axios';
 import { BadRequestError } from '../../../errors';
 import type { ConnectorAuthConfig } from '../../base';
 import { AbstractEnrichmentRemoteClient } from '../../categories/enrichment/base';

--- a/packages/core/remotes/impl/apollo/index.ts
+++ b/packages/core/remotes/impl/apollo/index.ts
@@ -1,3 +1,4 @@
+import axios from '@supaglue/core/remotes/sg_axios';
 import type {
   ConnectionUnsafe,
   Provider,
@@ -15,7 +16,6 @@ import type {
   SequenceStateCreateParams,
   SequenceStepCreateParams,
 } from '@supaglue/types/engagement';
-import axios from 'axios';
 import { Readable } from 'stream';
 import { BadRequestError, InternalServerError, NotFoundError } from '../../../errors';
 import { retryWhenAxiosApolloRateLimited } from '../../../lib/apollo_ratelimit';

--- a/packages/core/remotes/impl/clearbit/index.ts
+++ b/packages/core/remotes/impl/clearbit/index.ts
@@ -1,3 +1,4 @@
+import axios from '@supaglue/core/remotes/sg_axios';
 import type {
   ConnectionUnsafe,
   Provider,
@@ -5,7 +6,6 @@ import type {
   SendPassthroughRequestResponse,
 } from '@supaglue/types';
 import type { PersonEnrichmentData } from '@supaglue/types/enrichment/person_enrichment_data';
-import axios from 'axios';
 import { BadRequestError } from '../../../errors';
 import type { ConnectorAuthConfig } from '../../base';
 import { AbstractEnrichmentRemoteClient } from '../../categories/enrichment/base';

--- a/packages/core/remotes/impl/gong/index.ts
+++ b/packages/core/remotes/impl/gong/index.ts
@@ -1,6 +1,6 @@
+import axios from '@supaglue/core/remotes/sg_axios';
 import type { ConnectionUnsafe, EngagementOauthProvider, ListedObjectRecord, Provider } from '@supaglue/types';
 import type { FieldsToFetch } from '@supaglue/types/fields_to_fetch';
-import axios from 'axios';
 import { Readable } from 'stream';
 import { REFRESH_TOKEN_THRESHOLD_MS, retryWhenAxiosRateLimited } from '../../../lib';
 import type { ConnectorAuthConfig } from '../../base';

--- a/packages/core/remotes/impl/hubspot/index.ts
+++ b/packages/core/remotes/impl/hubspot/index.ts
@@ -4,6 +4,7 @@ import type {
   CollectionResponsePublicOwnerForwardPaging,
   CollectionResponsePublicOwnerForwardPaging as HubspotPaginatedOwners,
 } from '@hubspot/api-client/lib/codegen/crm/owners';
+import axios, { isAxiosError } from '@supaglue/core/remotes/sg_axios';
 import type {
   ConnectionUnsafe,
   CreatePropertyParams,
@@ -63,7 +64,6 @@ import type { SubmitFormData, SubmitFormResult } from '@supaglue/types/marketing
 import type { StandardOrCustomObject } from '@supaglue/types/standard_or_custom_object';
 import { HUBSPOT_STANDARD_OBJECT_TYPES } from '@supaglue/utils';
 import retry from 'async-retry';
-import axios, { isAxiosError } from 'axios';
 import { Readable } from 'stream';
 import {
   BadRequestError,

--- a/packages/core/remotes/impl/intercom/index.ts
+++ b/packages/core/remotes/impl/intercom/index.ts
@@ -1,3 +1,4 @@
+import axios from '@supaglue/core/remotes/sg_axios';
 import type {
   ConnectionUnsafe,
   ListedObjectRecord,
@@ -8,7 +9,6 @@ import type {
   StandardOrCustomObjectDef,
 } from '@supaglue/types';
 import type { FieldsToFetch } from '@supaglue/types/fields_to_fetch';
-import axios from 'axios';
 import { Readable } from 'stream';
 import { BadRequestError } from '../../../errors';
 import { retryWhenAxiosRateLimited } from '../../../lib';

--- a/packages/core/remotes/impl/marketo/index.ts
+++ b/packages/core/remotes/impl/marketo/index.ts
@@ -1,3 +1,4 @@
+import axios, { AxiosError } from '@supaglue/core/remotes/sg_axios';
 import type {
   ConnectionUnsafe,
   MarketoOauthConnectionCredentialsDecrypted,
@@ -8,7 +9,6 @@ import type {
 import type { FormField } from '@supaglue/types/marketing_automation/form_field';
 import type { FormMetadata } from '@supaglue/types/marketing_automation/form_metadata';
 import type { SubmitFormData, SubmitFormResult } from '@supaglue/types/marketing_automation/submit_form';
-import axios, { AxiosError } from 'axios';
 import simpleOauth2 from 'simple-oauth2';
 import {
   BadGatewayError,

--- a/packages/core/remotes/impl/outreach/index.ts
+++ b/packages/core/remotes/impl/outreach/index.ts
@@ -1,3 +1,4 @@
+import axios, { AxiosError } from '@supaglue/core/remotes/sg_axios';
 import type {
   ConnectionUnsafe,
   EngagementOauthProvider,
@@ -20,7 +21,6 @@ import type {
   SequenceTemplateCreateParams,
   SequenceTemplateId,
 } from '@supaglue/types/engagement';
-import axios, { AxiosError } from 'axios';
 import { Readable } from 'stream';
 import z from 'zod';
 import {

--- a/packages/core/remotes/impl/pipedrive/index.ts
+++ b/packages/core/remotes/impl/pipedrive/index.ts
@@ -1,3 +1,4 @@
+import axios, { AxiosError } from '@supaglue/core/remotes/sg_axios';
 import type {
   ConnectionUnsafe,
   CRMProvider,
@@ -26,7 +27,6 @@ import type {
   User,
 } from '@supaglue/types/crm';
 import type { FieldMappingConfig } from '@supaglue/types/field_mapping_config';
-import axios, { AxiosError } from 'axios';
 import { Readable } from 'stream';
 import {
   BadRequestError,

--- a/packages/core/remotes/impl/salesforce_marketing_cloud_account_engagement/index.ts
+++ b/packages/core/remotes/impl/salesforce_marketing_cloud_account_engagement/index.ts
@@ -2,6 +2,7 @@
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60924
 /// <reference lib="dom" />
 
+import axios, { AxiosError } from '@supaglue/core/remotes/sg_axios';
 import type {
   ConnectionUnsafe,
   MarketingAutomationProvider,
@@ -10,7 +11,6 @@ import type {
   SendPassthroughRequestResponse,
 } from '@supaglue/types';
 import type { SubmitFormData, SubmitFormResult } from '@supaglue/types/marketing_automation/submit_form';
-import axios, { AxiosError } from 'axios';
 import simpleOauth2 from 'simple-oauth2';
 import type { ConnectorAuthConfig } from '../../base';
 import { AbstractMarketingAutomationRemoteClient } from '../../categories/marketing_automation/base';

--- a/packages/core/remotes/impl/salesloft/index.ts
+++ b/packages/core/remotes/impl/salesloft/index.ts
@@ -1,3 +1,4 @@
+import axios, { AxiosError } from '@supaglue/core/remotes/sg_axios';
 import type {
   ConnectionUnsafe,
   EngagementOauthProvider,
@@ -19,7 +20,6 @@ import type {
   SequenceStepCreateParams,
   User,
 } from '@supaglue/types/engagement';
-import axios, { AxiosError } from 'axios';
 import { Readable } from 'stream';
 import { BadRequestError, InternalServerError, RemoteProviderError } from '../../../errors';
 import { REFRESH_TOKEN_THRESHOLD_MS, retryWhenAxiosRateLimited } from '../../../lib';

--- a/packages/core/remotes/impl/slack/index.ts
+++ b/packages/core/remotes/impl/slack/index.ts
@@ -1,5 +1,5 @@
+import axios from '@supaglue/core/remotes/sg_axios';
 import type { ConnectionUnsafe, EngagementOauthProvider, Provider } from '@supaglue/types';
-import axios from 'axios';
 import { REFRESH_TOKEN_THRESHOLD_MS } from '../../../lib';
 import type { ConnectorAuthConfig } from '../../base';
 import { AbstractNoCategoryRemoteClient } from '../../categories/no_category/base';

--- a/packages/core/remotes/sg_axios.ts
+++ b/packages/core/remotes/sg_axios.ts
@@ -1,0 +1,10 @@
+import { logger } from '@supaglue/core/lib';
+import axios, { AxiosError, isAxiosError } from 'axios';
+
+axios.interceptors.response.use(undefined, (err) => {
+  logger.warn({ err }, 'axios request failed');
+  return Promise.reject(err);
+});
+
+export default axios;
+export { AxiosError, isAxiosError };


### PR DESCRIPTION
log axios error responses for remote providers:
```
supaglue-api-1          | [22:42:15.316] WARN: axios request failed
supaglue-api-1          |     context: {
supaglue-api-1          |       "applicationEnv": "development",
supaglue-api-1          |       "applicationName": "My Application",
supaglue-api-1          |       "applicationId": "a5398e5c-3f64-4b41-9cc1-cffeee9dfb0a",
supaglue-api-1          |       "orgId": "org_2OO0cz8xFHmux421XdlbnWQ9OrS"
supaglue-api-1          |     }
supaglue-api-1          |     err: {
supaglue-api-1          |       "message": "Request failed with status code 400",
supaglue-api-1          |       "name": "AxiosError",
supaglue-api-1          |       "stack":
supaglue-api-1          |           AxiosError: Request failed with status code 400
supaglue-api-1          |               at settle (/app/node_modules/axios/lib/core/settle.js:19:12)
supaglue-api-1          |               at IncomingMessage.handleStreamEnd (/app/node_modules/axios/lib/adapters/http.js:556:11)
supaglue-api-1          |               at IncomingMessage.emit (node:events:529:35)
supaglue-api-1          |               at IncomingMessage.emit (node:domain:489:12)
supaglue-api-1          |               at endReadableNT (node:internal/streams/readable:1368:12)
supaglue-api-1          |               at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
supaglue-api-1          |       "config": {
supaglue-api-1          |         "transitional": {
supaglue-api-1          |           "silentJSONParsing": true,
supaglue-api-1          |           "forcedJSONParsing": true,
supaglue-api-1          |           "clarifyTimeoutError": false
supaglue-api-1          |         },
supaglue-api-1          |         "adapter": [
supaglue-api-1          |           "xhr",
supaglue-api-1          |           "http"
supaglue-api-1          |         ],
supaglue-api-1          |         "transformRequest": [
supaglue-api-1          |           null
supaglue-api-1          |         ],
supaglue-api-1          |         "transformResponse": [
supaglue-api-1          |           null
supaglue-api-1          |         ],
supaglue-api-1          |         "timeout": 0,
supaglue-api-1          |         "xsrfCookieName": "XSRF-TOKEN",
supaglue-api-1          |         "xsrfHeaderName": "X-XSRF-TOKEN",
supaglue-api-1          |         "maxContentLength": -1,
supaglue-api-1          |         "maxBodyLength": -1,
supaglue-api-1          |         "env": {},
supaglue-api-1          |         "headers": {
supaglue-api-1          |           "Accept": "application/json, text/plain, */*",
supaglue-api-1          |           "Content-Type": "application/json",
supaglue-api-1          |           "Authorization": "[Redacted]",
supaglue-api-1          |           "User-Agent": "axios/1.3.4",
supaglue-api-1          |           "Content-Length": "24",
supaglue-api-1          |           "Accept-Encoding": "gzip, compress, deflate, br"
supaglue-api-1          |         },
supaglue-api-1          |         "params": {
supaglue-api-1          |           "count": 100
supaglue-api-1          |         },
supaglue-api-1          |         "method": "post",
supaglue-api-1          |         "url": "https://api.hubapi.com/contacts/v1/lists",
supaglue-api-1          |         "data": "{\"data\":{\"asdf\":\"asdf\"}}"
supaglue-api-1          |       },
supaglue-api-1          |       "code": "ERR_BAD_REQUEST",
supaglue-api-1          |       "status": 400
supaglue-api-1          |     }
```

log customer body for passthrough for non-2xx:
```
supaglue-api-1          | [23:22:52.660] WARN: non-2xx passthrough axios response
supaglue-api-1          |     context: {
supaglue-api-1          |       "applicationEnv": "development",
supaglue-api-1          |       "applicationName": "My Application",
supaglue-api-1          |       "applicationId": "a5398e5c-3f64-4b41-9cc1-cffeee9dfb0a",
supaglue-api-1          |       "orgId": "org_2OO0cz8xFHmux421XdlbnWQ9OrS",
supaglue-api-1          |       "passthrough": {
supaglue-api-1          |         "method": "POST",
supaglue-api-1          |         "path": "/crm/v3/objects/companiess?limit=1&archived=true",
supaglue-api-1          |         "headers": {
supaglue-api-1          |           "Content-Type": "application/json"
supaglue-api-1          |         }
supaglue-api-1          |       }
supaglue-api-1          |     }
supaglue-api-1          |     passthroughBody: {
supaglue-api-1          |       "headers": {
supaglue-api-1          |         "Content-Type": "application/json"
supaglue-api-1          |       },
supaglue-api-1          |       "path": "/crm/v3/objects/companiess?limit=1&archived=true",
supaglue-api-1          |       "method": "POST",
supaglue-api-1          |       "body": {
supaglue-api-1          |         "asdf": "asdf"
supaglue-api-1          |       }
supaglue-api-1          |     }
supaglue-api-1          |     passthroughResponse: {
supaglue-api-1          |       "url": "https://api.hubapi.com/crm/v3/objects/companiess?limit=1&archived=true",
supaglue-api-1          |       "status": 400,
supaglue-api-1          |       "headers": {
supaglue-api-1          |         "date": "Mon, 06 Nov 2023 23:22:52 GMT",
supaglue-api-1          |         "content-type": "application/json;charset=utf-8",
supaglue-api-1          |         "content-length": "130",
supaglue-api-1          |         "connection": "close",
supaglue-api-1          |         "cf-ray": "822114be58869453-SJC",
supaglue-api-1          |         "cf-cache-status": "DYNAMIC",
supaglue-api-1          |         "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
supaglue-api-1          |         "vary": "origin, Accept-Encoding",
supaglue-api-1          |         "access-control-allow-credentials": "false",
supaglue-api-1          |         "x-content-type-options": "nosniff",
supaglue-api-1          |         "x-envoy-upstream-service-time": "16",
supaglue-api-1          |         "x-evy-trace-listener": "listener_https",
supaglue-api-1          |         "x-evy-trace-route-configuration": "listener_https/all",
supaglue-api-1          |         "x-evy-trace-route-service-name": "envoyset-translator",
supaglue-api-1          |         "x-evy-trace-served-by-pod": "iad02/hubapi-td/envoy-proxy-5b5c96c966-llhrc",
supaglue-api-1          |         "x-evy-trace-virtual-host": "all",
supaglue-api-1          |         "x-hubspot-correlation-id": "8bb02a03-0e0a-4cf7-a18c-a4927955cfe2",
supaglue-api-1          |         "x-hubspot-ratelimit-interval-milliseconds": "10000",
supaglue-api-1          |         "x-hubspot-ratelimit-max": "100",
supaglue-api-1          |         "x-hubspot-ratelimit-remaining": "99",
supaglue-api-1          |         "x-hubspot-ratelimit-secondly": "10",
supaglue-api-1          |         "x-hubspot-ratelimit-secondly-remaining": "9",
supaglue-api-1          |         "x-request-id": "8bb02a03-0e0a-4cf7-a18c-a4927955cfe2",
supaglue-api-1          |         "x-trace": "2B76F846A355167B29014691A0F879902DE755F195000000000000000000",
supaglue-api-1          |         "report-to": "{\"endpoints\":[{\"url\":\"https:\/\/a.nel.cloudflare.com\/report\/v3?s=qdg0xxdeNdBuO9Qh73eHlFpvp2BviIG1Y2JW5ta%2BuptAXnVn73%2B3oVRfmv%2BKHSnAjRa8CQoNn5%2FGJnnxGM7mjU7SKk3QJKLSxxrGKH3ZOAV3aO%2F%2BGhFVtwYSxmG9lqFL\"}],\"group\":\"cf-nel\",\"max_age\":604800}",
supaglue-api-1          |         "nel": "{\"success_fraction\":0.01,\"report_to\":\"cf-nel\",\"max_age\":604800}",
supaglue-api-1          |         "server": "cloudflare"
supaglue-api-1          |       },
supaglue-api-1          |       "body": {
supaglue-api-1          |         "status": "error",
supaglue-api-1          |         "message": "Unable to infer object type from: companiess",
supaglue-api-1          |         "correlationId": "8bb02a03-0e0a-4cf7-a18c-a4927955cfe2"
supaglue-api-1          |       }
supaglue-api-1          |     }
```
## Test Plan

[Describe test plan here]

## Deployment instructions

[Add any special deployment instructions here]
