### PR TITLE
chore: optional docker compose config override for use with docker compose watch

### DIFF
--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -1,0 +1,19 @@
+FROM node:18-bullseye-slim AS base
+
+FROM base AS builder
+WORKDIR /workspace
+RUN yarn global add turbo
+COPY . .
+RUN --mount=type=cache,mode=0777,target=/workspace/.yarn/cache,id=api-yarn-cache turbo prune --scope=api --docker
+
+# Add lockfile and package.json's of isolated subworkspace
+FROM base AS dev
+WORKDIR /workspace
+
+# First install dependencies (as they change less often)
+COPY . .
+COPY .yarnrc.build.yml .yarnrc.yml
+COPY .yarn .yarn
+COPY --from=builder /workspace/out/json/ .
+COPY --from=builder /workspace/out/yarn.lock ./yarn.lock
+RUN --mount=type=cache,mode=0777,target=/workspace/.yarn/cache,id=api-yarn-cache yarn install

--- a/apps/sync-worker/Dockerfile.dev
+++ b/apps/sync-worker/Dockerfile.dev
@@ -1,0 +1,19 @@
+FROM node:18-bullseye-slim AS base
+
+FROM base AS builder
+WORKDIR /workspace
+RUN yarn global add turbo
+COPY . .
+RUN --mount=type=cache,mode=0777,target=/workspace/.yarn/cache,id=sync-worker-yarn-cache turbo prune --scope=sync-worker --docker
+
+# Add lockfile and package.json's of isolated subworkspace
+FROM base AS dev
+WORKDIR /workspace
+
+# First install dependencies (as they change less often)
+COPY . .
+COPY .yarnrc.build.yml .yarnrc.yml
+COPY .yarn .yarn
+COPY --from=builder /workspace/out/json/ .
+COPY --from=builder /workspace/out/yarn.lock ./yarn.lock
+RUN --mount=type=cache,mode=0777,target=/workspace/.yarn/cache,id=sync-worker-yarn-cache yarn install

--- a/docker-compose.override.watch.yml
+++ b/docker-compose.override.watch.yml
@@ -1,0 +1,48 @@
+services:
+  api:
+    image: !reset
+    volumes: !reset []
+    build:
+      context: .
+      dockerfile: ./apps/api/Dockerfile.dev
+    working_dir: /workspace
+    develop:
+      watch:
+        - action: sync
+          path: ./apps/api
+          target: /workspace/apps/api
+          ignore:
+            - node_modules/
+        - action: sync
+          path: ./packages
+          target: /workspace/packages
+        - action: sync
+          path: ./openapi
+          target: /workspace/openapi
+        - action: rebuild
+          path: package.json
+        - action: rebuild
+          path: ./apps/api/package.json
+    command: /bin/sh -c "yarn workspace api start"
+
+  sync-worker:
+    image: !reset
+    volumes: !reset []
+    build:
+      context: .
+      dockerfile: ./apps/sync-worker/Dockerfile.dev
+    working_dir: /workspace
+    develop:
+      watch:
+        - action: sync
+          path: ./apps/sync-worker
+          target: /workspace/apps/sync-worker
+          ignore:
+            - node_modules/
+        - action: sync
+          path: ./packages
+          target: /workspace/packages
+        - action: rebuild
+          path: package.json
+        - action: rebuild
+          path: ./apps/api/package.json


### PR DESCRIPTION
To use, `cp docker-compose.override.watch.yml docker-compose.override.yml` and run `docker compose watch`

Make sure you are on Docker Desktop version >= 4.25.0