### PR TITLE
chore: more autopauses

### DIFF
--- a/packages/core/remotes/base.ts
+++ b/packages/core/remotes/base.ts
@@ -100,7 +100,7 @@ export abstract class AbstractRemoteClient extends EventEmitter implements Remot
     return super.emit(event, ...args);
   }
 
-  public handleErr(err: unknown): unknown {
+  public async handleErr(err: unknown): Promise<unknown> {
     return err;
   }
 

--- a/packages/core/remotes/categories/crm/index.ts
+++ b/packages/core/remotes/categories/crm/index.ts
@@ -45,18 +45,18 @@ export function getCrmRemoteClient<T extends CRMProviderName>(
       }
 
       return new Proxy(v, {
-        apply(_target, thisArg, argArray) {
+        async apply(_target, thisArg, argArray) {
           try {
             const res = v.apply(target, argArray);
             if (Promise.resolve(res) === res) {
               // if it's a promise
-              return (res as Promise<unknown>).catch((err) => {
-                throw target.handleErr(err);
+              return (res as Promise<unknown>).catch(async (err) => {
+                throw await target.handleErr(err);
               });
             }
             return res;
           } catch (err: unknown) {
-            throw target.handleErr(err);
+            throw await target.handleErr(err);
           }
         },
       });

--- a/packages/core/remotes/categories/engagement/base.ts
+++ b/packages/core/remotes/categories/engagement/base.ts
@@ -48,7 +48,7 @@ export abstract class AbstractEngagementRemoteClient extends AbstractRemoteClien
     super(...args);
   }
 
-  public handleErr(err: unknown): unknown {
+  public async handleErr(err: unknown): Promise<unknown> {
     return err;
   }
 

--- a/packages/core/remotes/categories/engagement/index.ts
+++ b/packages/core/remotes/categories/engagement/index.ts
@@ -37,17 +37,17 @@ export function getEngagementRemoteClient<T extends EngagementProviderName>(
       }
 
       return new Proxy(v, {
-        apply(_target, thisArg, argArray) {
+        async apply(_target, thisArg, argArray) {
           try {
             const res = v.apply(target, argArray);
             if (Promise.resolve(res) === res) {
               // if it's a promise
-              return (res as Promise<unknown>).catch((err) => {
-                throw target.handleErr(err);
+              return (res as Promise<unknown>).catch(async (err) => {
+                throw await target.handleErr(err);
               });
             }
           } catch (err: unknown) {
-            throw target.handleErr(err);
+            throw await target.handleErr(err);
           }
         },
       });

--- a/packages/core/remotes/categories/enrichment/base.ts
+++ b/packages/core/remotes/categories/enrichment/base.ts
@@ -11,7 +11,7 @@ export abstract class AbstractEnrichmentRemoteClient extends AbstractRemoteClien
     super(...args);
   }
 
-  public handleErr(err: unknown): unknown {
+  public async handleErr(err: unknown): Promise<unknown> {
     return err;
   }
 

--- a/packages/core/remotes/categories/enrichment/index.ts
+++ b/packages/core/remotes/categories/enrichment/index.ts
@@ -35,17 +35,17 @@ export function getEnrichmentRemoteClient<T extends EnrichmentProviderName>(
       }
 
       return new Proxy(v, {
-        apply(_target, thisArg, argArray) {
+        async apply(_target, thisArg, argArray) {
           try {
             const res = v.apply(target, argArray);
             if (Promise.resolve(res) === res) {
               // if it's a promise
-              return (res as Promise<unknown>).catch((err) => {
-                throw target.handleErr(err);
+              return (res as Promise<unknown>).catch(async (err) => {
+                throw await target.handleErr(err);
               });
             }
           } catch (err: unknown) {
-            throw target.handleErr(err);
+            throw await target.handleErr(err);
           }
         },
       });

--- a/packages/core/remotes/categories/marketing_automation/index.ts
+++ b/packages/core/remotes/categories/marketing_automation/index.ts
@@ -40,18 +40,18 @@ export function getMarketingAutmationRemoteClient<T extends MarketingAutomationP
       }
 
       return new Proxy(v, {
-        apply(_target, thisArg, argArray) {
+        async apply(_target, thisArg, argArray) {
           try {
             const res = v.apply(target, argArray);
             if (Promise.resolve(res) === res) {
               // if it's a promise
-              return (res as Promise<unknown>).catch((err) => {
-                throw target.handleErr(err);
+              return (res as Promise<unknown>).catch(async (err) => {
+                throw await target.handleErr(err);
               });
             }
             return res;
           } catch (err: unknown) {
-            throw target.handleErr(err);
+            throw await target.handleErr(err);
           }
         },
       });

--- a/packages/core/remotes/categories/no_category/base.ts
+++ b/packages/core/remotes/categories/no_category/base.ts
@@ -6,7 +6,7 @@ export abstract class AbstractNoCategoryRemoteClient extends AbstractRemoteClien
     super(...args);
   }
 
-  public handleErr(err: unknown): unknown {
+  public async handleErr(err: unknown): Promise<unknown> {
     return err;
   }
 }

--- a/packages/core/remotes/categories/no_category/index.ts
+++ b/packages/core/remotes/categories/no_category/index.ts
@@ -39,17 +39,17 @@ export function getNoCategoryRemoteClient<T extends NoCategoryProviderName>(
       }
 
       return new Proxy(v, {
-        apply(_target, thisArg, argArray) {
+        async apply(_target, thisArg, argArray) {
           try {
             const res = v.apply(target, argArray);
             if (Promise.resolve(res) === res) {
               // if it's a promise
-              return (res as Promise<unknown>).catch((err) => {
-                throw target.handleErr(err);
+              return (res as Promise<unknown>).catch(async (err) => {
+                throw await target.handleErr(err);
               });
             }
           } catch (err: unknown) {
-            throw target.handleErr(err);
+            throw await target.handleErr(err);
           }
         },
       });

--- a/packages/core/remotes/impl/apollo/index.ts
+++ b/packages/core/remotes/impl/apollo/index.ts
@@ -712,7 +712,7 @@ class ApolloClient extends AbstractEngagementRemoteClient {
     };
   }
 
-  public override handleErr(err: unknown): unknown {
+  public override async handleErr(err: unknown): Promise<unknown> {
     const error = err as any;
     if (error.message === 'Request failed with status code 401') {
       return new SGConnectionNoLongerAuthenticatedError(error.message, error);

--- a/packages/core/remotes/impl/hubspot/index.ts
+++ b/packages/core/remotes/impl/hubspot/index.ts
@@ -2377,7 +2377,7 @@ class HubSpotClient extends AbstractCrmRemoteClient implements MarketingAutomati
     };
   }
 
-  public override handleErr(err: unknown): unknown {
+  public override async handleErr(err: unknown): Promise<unknown> {
     // for errors we throw ourselves, they aren't native hubspot client errors, so don't continue
     // to unroll the error body message
     if (err instanceof SGError) {

--- a/packages/core/remotes/impl/marketo/index.ts
+++ b/packages/core/remotes/impl/marketo/index.ts
@@ -177,7 +177,7 @@ class MarketoClient extends AbstractMarketingAutomationRemoteClient {
     };
   }
 
-  public override handleErr(err: unknown): unknown {
+  public override async handleErr(err: unknown): Promise<unknown> {
     if (!(err instanceof AxiosError)) {
       return err;
     }

--- a/packages/core/remotes/impl/ms_dynamics_365_sales/index.ts
+++ b/packages/core/remotes/impl/ms_dynamics_365_sales/index.ts
@@ -362,7 +362,7 @@ class MsDynamics365Sales extends AbstractCrmRemoteClient {
         heartbeat();
       }
       if (!response.ok) {
-        throw this.handleErr(response);
+        throw await this.handleErr(response);
       }
       return await response.json();
     };
@@ -483,21 +483,21 @@ class MsDynamics365Sales extends AbstractCrmRemoteClient {
     ]);
   }
 
-  public override handleErr(err: unknown): unknown {
+  public override async handleErr(err: unknown): Promise<unknown> {
     if (err instanceof Response) {
-      // TODO: pass "cause" into the error constructor. to do this, `handleErr` needs to be async.
+      const { cause } = await err.json();
 
       switch (err.status) {
         case 400:
-          return new InternalServerError(err.statusText);
+          return new InternalServerError(err.statusText, cause);
         case 401:
-          return new UnauthorizedError(err.statusText);
+          return new UnauthorizedError(err.statusText, cause);
         case 403:
-          return new ForbiddenError(err.statusText);
+          return new ForbiddenError(err.statusText, cause);
         case 404:
-          return new NotFoundError(err.statusText);
+          return new NotFoundError(err.statusText, cause);
         case 304:
-          return new NotModifiedError(err.statusText);
+          return new NotModifiedError(err.statusText, cause);
         // The following are unmapped to Supaglue errors, but we want to pass
         // them back as 4xx so they aren't 500 and developers can view error messages
         // NOTE: `429` is omitted below since we process it differently for syncs
@@ -548,9 +548,9 @@ class MsDynamics365Sales extends AbstractCrmRemoteClient {
         case 449:
         case 450:
         case 451:
-          return new RemoteProviderError(err.statusText);
+          return new RemoteProviderError(err.statusText, cause);
         default:
-          return new InternalServerError(err.statusText);
+          return new InternalServerError(err.statusText, cause);
       }
     }
 

--- a/packages/core/remotes/impl/outreach/index.ts
+++ b/packages/core/remotes/impl/outreach/index.ts
@@ -1730,7 +1730,7 @@ class OutreachClient extends AbstractEngagementRemoteClient {
     return await super.sendPassthroughRequest(request);
   }
 
-  public override handleErr(err: unknown): unknown {
+  public override async handleErr(err: unknown): Promise<unknown> {
     if (!(err instanceof AxiosError)) {
       return err;
     }

--- a/packages/core/remotes/impl/pipedrive/index.ts
+++ b/packages/core/remotes/impl/pipedrive/index.ts
@@ -712,7 +712,7 @@ class PipedriveClient extends AbstractCrmRemoteClient {
     return await super.sendPassthroughRequest(request);
   }
 
-  public override handleErr(err: unknown): unknown {
+  public override async handleErr(err: unknown): Promise<unknown> {
     if (!(err instanceof AxiosError)) {
       return err;
     }

--- a/packages/core/remotes/impl/salesforce/index.ts
+++ b/packages/core/remotes/impl/salesforce/index.ts
@@ -1553,7 +1553,7 @@ ${modifiedAfter ? `WHERE SystemModstamp > ${modifiedAfter.toISOString()} ORDER B
     };
   }
 
-  public override handleErr(err: unknown): unknown {
+  public override async handleErr(err: unknown): Promise<unknown> {
     const error = err as any;
 
     // map certain provider errors to sg sync worker errors

--- a/packages/core/remotes/impl/salesforce_marketing_cloud_account_engagement/index.ts
+++ b/packages/core/remotes/impl/salesforce_marketing_cloud_account_engagement/index.ts
@@ -208,7 +208,7 @@ class SalesforceMarketingCloudAccountEngagmentClient extends AbstractMarketingAu
     };
   }
 
-  public override handleErr(err: unknown): unknown {
+  public override async handleErr(err: unknown): Promise<unknown> {
     // TODO implement error handling from
     // https://developer.salesforce.com/docs/marketing/pardot/guide/error-codes.html#error-responses-in-api-version-5
 

--- a/packages/core/remotes/impl/salesloft/index.ts
+++ b/packages/core/remotes/impl/salesloft/index.ts
@@ -466,7 +466,7 @@ class SalesloftClient extends AbstractEngagementRemoteClient {
     });
   }
 
-  public override handleErr(err: unknown): unknown {
+  public override async handleErr(err: unknown): Promise<unknown> {
     if (!(err instanceof AxiosError)) {
       return err;
     }

--- a/packages/core/remotes/index.ts
+++ b/packages/core/remotes/index.ts
@@ -72,18 +72,18 @@ export function getRemoteClient<T extends ProviderName>(
       }
 
       return new Proxy(v, {
-        apply(_target, thisArg, argArray) {
+        async apply(_target, thisArg, argArray) {
           try {
             const res = v.apply(target, argArray);
             if (Promise.resolve(res) === res) {
               // if it's a promise
-              return (res as Promise<unknown>).catch((err) => {
-                throw target.handleErr(err);
+              return (res as Promise<unknown>).catch(async (err) => {
+                throw await target.handleErr(err);
               });
             }
             return res;
           } catch (err: unknown) {
-            throw target.handleErr(err);
+            throw await target.handleErr(err);
           }
         },
       });

--- a/packages/sync-workflows/workflows/run_object_sync.ts
+++ b/packages/sync-workflows/workflows/run_object_sync.ts
@@ -63,6 +63,9 @@ function getPauseReasonIfShouldPause(err: any): string | undefined {
   if (err.cause?.failure?.message.startsWith('Additional field mappings are not allowed')) {
     return `Customer attempted to add additional field mappings for entity where additional field mappings are not allowed`;
   }
+  if (err.cause?.failure?.message === 'The requested resource does not exist') {
+    return `The requested resource does not exist.`;
+  }
 }
 
 export async function runObjectSync({ syncId, connectionId, category }: RunObjectSyncArgs): Promise<void> {


### PR DESCRIPTION
Add autopauses for:
- revoked Apollo API Keys
- getaddrinfo ENOTFOUND for Microsoft
- resource not found for Salesforce (indicates permission issue)

This also fixes error handling for Microsoft in general