### PR TITLE
feat: allow sync config deletions even when there are existing syncs

### DIFF
--- a/apps/mgmt-ui/src/components/syncs/syncConfig/SyncConfigDetailsPanel.tsx
+++ b/apps/mgmt-ui/src/components/syncs/syncConfig/SyncConfigDetailsPanel.tsx
@@ -160,6 +160,7 @@ function SyncConfigDetailsPanelImpl({ syncConfigId }: SyncConfigDetailsPanelImpl
         },
         commonObjects: commonObjects.map((object) => ({ object } as CommonObjectConfig)),
         standardObjects: standardObjects.map((object) => ({ object })),
+        customObjects: customObjects.map((object) => ({ object })),
         entities: entityIds.map((entityId) => ({ entityId })),
       },
     };

--- a/packages/core/services/sync_config_service.ts
+++ b/packages/core/services/sync_config_service.ts
@@ -237,6 +237,16 @@ export class SyncConfigService {
       },
     });
     await this.#prisma.$transaction([
+      this.#prisma.syncChange.createMany({
+        data: syncs.map((sync) => ({
+          syncId: sync.id,
+        })),
+      }),
+      this.#prisma.sync.deleteMany({
+        where: {
+          syncConfigId: id,
+        },
+      }),
       this.#prisma.syncConfig.deleteMany({
         where: { id, applicationId },
       }),
@@ -244,16 +254,6 @@ export class SyncConfigService {
         data: {
           syncConfigId: id,
         },
-      }),
-      this.#prisma.sync.deleteMany({
-        where: {
-          syncConfigId: id,
-        },
-      }),
-      this.#prisma.syncChange.createMany({
-        data: syncs.map((sync) => ({
-          syncId: sync.id,
-        })),
       }),
     ]);
   }

--- a/packages/core/services/sync_config_service.ts
+++ b/packages/core/services/sync_config_service.ts
@@ -236,9 +236,6 @@ export class SyncConfigService {
         syncConfigId: id,
       },
     });
-    if (syncs.length) {
-      throw new BadRequestError('Cannot delete sync config with active connections');
-    }
     await this.#prisma.$transaction([
       this.#prisma.syncConfig.deleteMany({
         where: { id, applicationId },
@@ -247,6 +244,16 @@ export class SyncConfigService {
         data: {
           syncConfigId: id,
         },
+      }),
+      this.#prisma.sync.deleteMany({
+        where: {
+          syncConfigId: id,
+        },
+      }),
+      this.#prisma.syncChange.createMany({
+        data: syncs.map((sync) => ({
+          syncId: sync.id,
+        })),
       }),
     ]);
   }


### PR DESCRIPTION
Also fix a UI bug where you weren't able to create new SyncConfigs in the UI with custom objects (but you could update them after the fact).

Currently, the API will not allow you to delete Sync Configs for which there are existing syncs (you have to delete the connections, or all the objects). 