### PR TITLE
fix: don't swallow errors in outreach

### DIFF
--- a/packages/core/remotes/impl/outreach/index.ts
+++ b/packages/core/remotes/impl/outreach/index.ts
@@ -1434,6 +1434,7 @@ class OutreachClient extends AbstractEngagementRemoteClient {
         if (e.response?.status === 400) {
           throw new SGConnectionNoLongerAuthenticatedError('Unable to refresh access token. Refresh token invalid.');
         }
+        throw e;
       }
     }
   }


### PR DESCRIPTION
Just something I noticed while looking at code