### PR TITLE
chore: include sourcemaps in images and configure node to use them

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -45,4 +45,4 @@ COPY --from=installer /app/packages/db/prisma ./prisma
 COPY --from=installer /app/packages/sync-workflows/dist ./node_modules/@supaglue/sync-workflows
 COPY --from=installer /app/openapi ./openapi
 
-CMD node ./index.js
+CMD node --enable-source-maps ./index.js

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -9,7 +9,8 @@
       "@/*": ["./*"]
     },
     "plugins": [{ "transform": "typescript-transform-paths" }],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "sourceMap": true,
   },
   "ts-node": {
     "swc": true

--- a/apps/sync-worker/Dockerfile
+++ b/apps/sync-worker/Dockerfile
@@ -43,4 +43,4 @@ COPY --from=installer /app/packages/db/node_modules ./node_modules/@supaglue/db/
 COPY --from=installer /app/packages/db/prisma ./prisma
 COPY --from=installer /app/packages/sync-workflows/dist ./node_modules/@supaglue/sync-workflows
 
-CMD node ./index.js
+CMD node --enable-source-maps ./index.js

--- a/apps/sync-worker/tsconfig.build.json
+++ b/apps/sync-worker/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "sourceMap": true,
-    "inlineSources": true,
     "sourceRoot": "/"
   }
 }


### PR DESCRIPTION
This should allow stack traces to have the correct typescript line numbers in logs.