### PR TITLE
feat: support custom field updating for apollo

### DIFF
--- a/apps/api/routes/engagement/v2/account.ts
+++ b/apps/api/routes/engagement/v2/account.ts
@@ -33,12 +33,13 @@ export default function init(app: Router): void {
       req: Request<GetAccountPathParams, GetAccountResponse, GetAccountRequest, GetAccountQueryParams>,
       res: Response<GetAccountResponse>
     ) => {
+      const includeRawData = req.query?.include_raw_data?.toString() === 'true';
       const { id: connectionId } = req.customerConnection;
       const account = await engagementCommonObjectService.get('account', connectionId, req.params.account_id);
       const snakecasedKeysAccount = toSnakecasedKeysEngagementAccount(account);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { raw_data, ...rest } = snakecasedKeysAccount;
-      return res.status(200).send(req.query?.include_raw_data ? snakecasedKeysAccount : rest);
+      return res.status(200).send(includeRawData ? snakecasedKeysAccount : rest);
     }
   );
 
@@ -48,6 +49,7 @@ export default function init(app: Router): void {
       req: Request<ListAccountsPathParams, ListAccountsResponse, ListAccountsRequest, ListAccountsQueryParams>,
       res: Response<ListAccountsResponse>
     ) => {
+      const includeRawData = req.query?.include_raw_data?.toString() === 'true';
       if (req.query?.read_from_cache?.toString() !== 'true') {
         throw new BadRequestError('Uncached reads not yet implemented for accounts.');
       }
@@ -63,7 +65,7 @@ export default function init(app: Router): void {
         pagination,
         records: records.map((record) => ({
           ...record,
-          raw_data: req.query?.include_raw_data ? record.raw_data : undefined,
+          raw_data: includeRawData ? record.raw_data : undefined,
           _supaglue_application_id: undefined,
           _supaglue_customer_id: undefined,
           _supaglue_provider_name: undefined,

--- a/apps/api/routes/engagement/v2/contact.ts
+++ b/apps/api/routes/engagement/v2/contact.ts
@@ -38,11 +38,12 @@ export default function init(app: Router): void {
       res: Response<GetContactResponse>
     ) => {
       const { id: connectionId } = req.customerConnection;
+      const includeRawData = req.query?.include_raw_data?.toString() === 'true';
       const contact = await engagementCommonObjectService.get('contact', connectionId, req.params.contact_id);
       const snakecasedKeysContact = toSnakecasedKeysEngagementContact(contact);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { raw_data, ...rest } = snakecasedKeysContact;
-      return res.status(200).send(req.query?.include_raw_data ? snakecasedKeysContact : rest);
+      return res.status(200).send(includeRawData ? snakecasedKeysContact : rest);
     }
   );
 

--- a/apps/api/routes/engagement/v2/mailbox.ts
+++ b/apps/api/routes/engagement/v2/mailbox.ts
@@ -25,12 +25,13 @@ export default function init(app: Router): void {
       req: Request<GetMailboxPathParams, GetMailboxResponse, GetMailboxRequest, GetMailboxQueryParams>,
       res: Response<GetMailboxResponse>
     ) => {
+      const includeRawData = req.query?.include_raw_data?.toString() === 'true';
       const { id: connectionId } = req.customerConnection;
       const mailbox = await engagementCommonObjectService.get('mailbox', connectionId, req.params.mailbox_id);
       const snakecasedKeysMailbox = toSnakecasedKeysMailbox(mailbox);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { raw_data, ...rest } = snakecasedKeysMailbox;
-      return res.status(200).send(req.query?.include_raw_data ? snakecasedKeysMailbox : rest);
+      return res.status(200).send(includeRawData ? snakecasedKeysMailbox : rest);
     }
   );
 
@@ -43,6 +44,7 @@ export default function init(app: Router): void {
       if (req.query?.read_from_cache?.toString() !== 'true') {
         throw new BadRequestError('Uncached reads not yet implemented for mailboxes.');
       }
+      const includeRawData = req.query?.include_raw_data?.toString() === 'true';
       const { pagination, records } = await managedDataService.getEngagementMailboxRecords(
         req.supaglueApplication.id,
         req.customerConnection.providerName,
@@ -55,7 +57,7 @@ export default function init(app: Router): void {
         pagination,
         records: records.map((record) => ({
           ...record,
-          raw_data: req.query?.include_raw_data ? record.raw_data : undefined,
+          raw_data: includeRawData ? record.raw_data : undefined,
           _supaglue_application_id: undefined,
           _supaglue_customer_id: undefined,
           _supaglue_provider_name: undefined,

--- a/apps/api/routes/engagement/v2/sequence.ts
+++ b/apps/api/routes/engagement/v2/sequence.ts
@@ -32,12 +32,13 @@ export default function init(app: Router): void {
       req: Request<GetSequencePathParams, GetSequenceResponse, GetSequenceRequest>,
       res: Response<GetSequenceResponse>
     ) => {
+      const includeRawData = req.query?.include_raw_data?.toString() === 'true';
       const { id: connectionId } = req.customerConnection;
       const sequence = await engagementCommonObjectService.get('sequence', connectionId, req.params.sequence_id);
       const snakecasedKeysSequence = toSnakecasedKeysSequence(sequence);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { raw_data, ...rest } = snakecasedKeysSequence;
-      return res.status(200).send(req.query?.include_raw_data ? snakecasedKeysSequence : rest);
+      return res.status(200).send(includeRawData ? snakecasedKeysSequence : rest);
     }
   );
 
@@ -50,6 +51,7 @@ export default function init(app: Router): void {
       if (req.query?.read_from_cache?.toString() !== 'true') {
         throw new BadRequestError('Uncached reads not yet implemented for sequences.');
       }
+      const includeRawData = req.query?.include_raw_data?.toString() === 'true';
       const { pagination, records } = await managedDataService.getEngagementSequenceRecords(
         req.supaglueApplication.id,
         req.customerConnection.providerName,
@@ -62,7 +64,7 @@ export default function init(app: Router): void {
         pagination,
         records: records.map((record) => ({
           ...record,
-          raw_data: req.query?.include_raw_data ? record.raw_data : undefined,
+          raw_data: includeRawData ? record.raw_data : undefined,
           _supaglue_application_id: undefined,
           _supaglue_customer_id: undefined,
           _supaglue_provider_name: undefined,

--- a/apps/api/routes/engagement/v2/sequence_state.ts
+++ b/apps/api/routes/engagement/v2/sequence_state.ts
@@ -41,6 +41,7 @@ export default function init(app: Router): void {
       >,
       res: Response<GetSequenceStateResponse>
     ) => {
+      const includeRawData = req.query?.include_raw_data?.toString() === 'true';
       const { id: connectionId } = req.customerConnection;
       const mailbox = await engagementCommonObjectService.get(
         'sequence_state',
@@ -50,7 +51,7 @@ export default function init(app: Router): void {
       const snakecasedKeysMailbox = toSnakecasedKeysSequenceState(mailbox);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { raw_data, ...rest } = snakecasedKeysMailbox;
-      return res.status(200).send(req.query?.include_raw_data ? snakecasedKeysMailbox : rest);
+      return res.status(200).send(includeRawData ? snakecasedKeysMailbox : rest);
     }
   );
 
@@ -68,6 +69,7 @@ export default function init(app: Router): void {
       if (req.query?.read_from_cache?.toString() !== 'true') {
         throw new BadRequestError('Uncached reads not yet implemented for sequence states.');
       }
+      const includeRawData = req.query?.include_raw_data?.toString() === 'true';
       const { pagination, records } = await managedDataService.getEngagementSequenceStateRecords(
         req.supaglueApplication.id,
         req.customerConnection.providerName,
@@ -80,7 +82,7 @@ export default function init(app: Router): void {
         pagination,
         records: records.map((record) => ({
           ...record,
-          raw_data: req.query?.include_raw_data ? record.raw_data : undefined,
+          raw_data: includeRawData ? record.raw_data : undefined,
           _supaglue_application_id: undefined,
           _supaglue_customer_id: undefined,
           _supaglue_provider_name: undefined,

--- a/apps/api/services/managed_data_service.ts
+++ b/apps/api/services/managed_data_service.ts
@@ -47,57 +47,6 @@ export class ManagedDataService {
     return await this.#pgPool.connect();
   }
 
-  async #getRecord<T extends Record<string, unknown>>(
-    applicationId: string,
-    category: ProviderCategory,
-    providerName: ProviderName,
-    customerId: string,
-    /**
-     * @param `objectName` is the provider-specific name and is case-sensitive.
-     */
-    objectName: string,
-    objectType: ObjectType,
-    id: string
-  ): Promise<T | null> {
-    const sync = await this.#syncService.findByAppCustomerProviderNameObjectTypeAndObject(
-      applicationId,
-      customerId,
-      providerName,
-      objectType,
-      objectName
-    );
-    if (!sync) {
-      throw new BadRequestError(
-        `No sync found for ${objectName} for customer ${customerId}. Please ensure you're syncing the right object type (standard or common) from your provider.`
-      );
-    }
-    const destination = await this.#destinationService.getDestinationSafeBySyncConfigId(sync.syncConfigId);
-    if (destination?.type !== 'supaglue') {
-      throw new BadRequestError(`You must set up a Supaglue Managed Destination before you can use this feature.`);
-    }
-    const schema = getSchemaName(applicationId);
-    const table =
-      objectType === 'common'
-        ? getCommonObjectTableName(category, objectName as CommonObjectType)
-        : getObjectTableName(providerName, objectName);
-    const qualifiedTable = `${schema}.${table}`;
-    const client = await this.#getClient();
-    try {
-      const result = await client.query<T>(
-        getByIdSql(qualifiedTable, applicationId, customerId, providerName, objectType, id)
-      );
-      if (!result.rows.length) {
-        return null;
-      }
-      return {
-        ...result.rows[0],
-        // Hoist the unified data up to top level
-        ...((result.rows[0] as Record<string, unknown>)['_supaglue_unified_data'] ?? {}),
-      };
-    } finally {
-      client.release();
-    }
-  }
   async #getRecords<T extends Record<string, unknown>>(
     applicationId: string,
     category: ProviderCategory,
@@ -153,16 +102,7 @@ export class ManagedDataService {
       const { total } = rows[0];
       // We fetch `pageSize + 1` records so we know if we need to return a `next` pagination.
       const result = await client.query<T>(
-        getListSql(
-          qualifiedTable,
-          applicationId,
-          customerId,
-          providerName,
-          objectType,
-          pageSize + 1,
-          cursor,
-          modifiedAfter
-        )
+        getSql(qualifiedTable, applicationId, customerId, providerName, objectType, pageSize + 1, cursor, modifiedAfter)
       );
       const records = result.rows.map(({ _supaglue_unified_data, ...row }) => ({
         ...row,
@@ -493,24 +433,7 @@ const getCountSql = (
   return sql;
 };
 
-const getByIdSql = (
-  qualifiedTable: string,
-  applicationId: string,
-  customerId: string,
-  providerName: string,
-  objectType: ObjectType,
-  id: string
-) => {
-  const idCol = objectType === 'common' ? 'id' : '_supaglue_id';
-  const sql = `SELECT * FROM ${qualifiedTable}
-    WHERE _supaglue_application_id = '${applicationId}'
-    AND _supaglue_customer_id = '${customerId}'
-    AND _supaglue_provider_name = '${providerName}'
-    AND ${idCol} = '${id}'`;
-  return sql;
-};
-
-const getListSql = (
+const getSql = (
   qualifiedTable: string,
   applicationId: string,
   customerId: string,

--- a/packages/core/remotes/impl/apollo/mappers.test.ts
+++ b/packages/core/remotes/impl/apollo/mappers.test.ts
@@ -242,7 +242,9 @@ describe('Conversion functions', () => {
       email: 'john.doe@example.com',
       present_raw_address: '123 Main St, Sample City, Sample State, 12345, Sample Country',
       account_id: '123',
-      field1: 'value1',
+      typed_custom_fields: {
+        field1: 'value1',
+      },
     };
 
     expect(toApolloContactCreateParams(params)).toEqual(expected);
@@ -284,7 +286,9 @@ describe('Conversion functions', () => {
       home_phone: '987654321',
       mobile_phone: '1112223333',
       account_id: '123',
-      field1: 'value1',
+      typed_custom_fields: {
+        field1: 'value1',
+      },
     };
 
     expect(toApolloContactUpdateParams(params)).toEqual(expected);

--- a/packages/core/remotes/impl/apollo/mappers.ts
+++ b/packages/core/remotes/impl/apollo/mappers.ts
@@ -151,6 +151,7 @@ export const toApolloAccountCreateParams = (params: AccountCreateParams): Record
   return {
     name: params.name,
     domain: params.domain,
+    typed_custom_fields: params.customFields,
   };
 };
 
@@ -175,7 +176,7 @@ export const toApolloContactCreateParams = (params: ContactCreateParams): Record
     corporate_phone: params.phoneNumbers?.find((p) => p.phoneNumberType === 'work')?.phoneNumber,
     home_phone: params.phoneNumbers?.find((p) => p.phoneNumberType === 'home')?.phoneNumber,
     other_phone: params.phoneNumbers?.find((p) => p.phoneNumberType === 'other')?.phoneNumber,
-    ...params.customFields,
+    typed_custom_fields: params.customFields,
   };
 };
 export const toApolloContactUpdateParams = (params: ContactUpdateParams): Record<string, any> => {
@@ -192,7 +193,7 @@ export const toApolloContactUpdateParams = (params: ContactUpdateParams): Record
     home_phone: params.phoneNumbers?.find((p) => p.phoneNumberType === 'home')?.phoneNumber,
     other_phone: params.phoneNumbers?.find((p) => p.phoneNumberType === 'other')?.phoneNumber,
     account_id: params.accountId,
-    ...params.customFields,
+    typed_custom_fields: params.customFields,
   };
 };
 


### PR DESCRIPTION
You still need to use passthrough to look up the custom field IDs, but this is better than not supporting it at all.

Also noticed that we weren't respecting the `include_raw_data` flag for engagement, so this also fixes this.