### PR TITLE
fix: revert "feat!: URL-encode cursors"

### DIFF
--- a/packages/core/lib/pagination.test.ts
+++ b/packages/core/lib/pagination.test.ts
@@ -31,11 +31,11 @@ describe('getPaginatedSupaglueRecords', () => {
 
     expect(result.pagination.next).toBeTruthy();
     if (result.pagination.next) {
-      expect(decodeCursor(decodeURIComponent(result.pagination.next))).toEqual({ id: '10', reverse: false });
+      expect(decodeCursor(result.pagination.next)).toEqual({ id: '10', reverse: false });
     }
     expect(result.pagination.previous).toBeTruthy();
     if (result.pagination.previous) {
-      expect(decodeCursor(decodeURIComponent(result.pagination.previous))).toEqual({ id: '1', reverse: true });
+      expect(decodeCursor(result.pagination.previous)).toEqual({ id: '1', reverse: true });
     }
     expect(result.records.length).toBe(10);
   });
@@ -48,7 +48,7 @@ describe('getPaginatedSupaglueRecords', () => {
     expect(result.pagination.next).toBeNull();
     expect(result.pagination.previous).toBeTruthy();
     if (result.pagination.previous) {
-      expect(decodeCursor(decodeURIComponent(result.pagination.previous))).toEqual({ id: '1', reverse: true });
+      expect(decodeCursor(result.pagination.previous)).toEqual({ id: '1', reverse: true });
     }
     expect(result.records.length).toBe(10);
   });
@@ -59,7 +59,7 @@ describe('getPaginatedSupaglueRecords', () => {
 
     expect(result.pagination.next).toBeTruthy();
     if (result.pagination.next) {
-      expect(decodeCursor(decodeURIComponent(result.pagination.next))).toEqual({ id: '10', reverse: false });
+      expect(decodeCursor(result.pagination.next)).toEqual({ id: '10', reverse: false });
     }
     expect(result.pagination.previous).toBeNull();
     expect(result.records.length).toBe(10);
@@ -81,11 +81,11 @@ describe('getPaginatedSupaglueRecords', () => {
 
     expect(result.pagination.next).toBeTruthy();
     if (result.pagination.next) {
-      expect(decodeCursor(decodeURIComponent(result.pagination.next))).toEqual({ id: '11', reverse: false });
+      expect(decodeCursor(result.pagination.next)).toEqual({ id: '11', reverse: false });
     }
     expect(result.pagination.previous).toBeTruthy();
     if (result.pagination.previous) {
-      expect(decodeCursor(decodeURIComponent(result.pagination.previous))).toEqual({ id: '2', reverse: true });
+      expect(decodeCursor(result.pagination.previous)).toEqual({ id: '2', reverse: true });
     }
     expect(result.records.length).toBe(10);
   });
@@ -97,7 +97,7 @@ describe('getPaginatedSupaglueRecords', () => {
 
     expect(result.pagination.next).toBeTruthy();
     if (result.pagination.next) {
-      expect(decodeCursor(decodeURIComponent(result.pagination.next))).toEqual({ id: '9', reverse: false });
+      expect(decodeCursor(result.pagination.next)).toEqual({ id: '9', reverse: false });
     }
     expect(result.pagination.previous).toBeNull();
     expect(result.records.length).toBe(9);

--- a/packages/core/lib/pagination.ts
+++ b/packages/core/lib/pagination.ts
@@ -48,7 +48,7 @@ export type Cursor = {
 };
 
 export const encodeCursor = (cursorParams: Cursor): string => {
-  return encodeURIComponent(Buffer.from(JSON.stringify(cursorParams), 'binary').toString('base64'));
+  return Buffer.from(JSON.stringify(cursorParams), 'binary').toString('base64');
 };
 
 export const decodeCursor = (encoded?: string): Cursor | undefined => {

--- a/packages/core/lib/pagination.ts
+++ b/packages/core/lib/pagination.ts
@@ -1,4 +1,5 @@
 import type { PaginationInternalParams, PaginationParams, ProviderName } from '@supaglue/types';
+import base64url from 'base64url';
 import { BadRequestError } from '../errors';
 
 export const DEFAULT_PAGE_SIZE = 10;
@@ -48,14 +49,14 @@ export type Cursor = {
 };
 
 export const encodeCursor = (cursorParams: Cursor): string => {
-  return Buffer.from(JSON.stringify(cursorParams), 'binary').toString('base64');
+  return base64url(JSON.stringify(cursorParams));
 };
 
 export const decodeCursor = (encoded?: string): Cursor | undefined => {
   if (!encoded) {
     return;
   }
-  return JSON.parse(Buffer.from(encoded, 'base64').toString('binary'));
+  return JSON.parse(base64url.decode(encoded));
 };
 
 export const toPaginationInternalParams = (paginationParams: PaginationParams): PaginationInternalParams => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "@temporalio/proto": "^1.8.6",
     "async-retry": "^1.3.3",
     "axios": "^1.6.0",
+    "base64url": "^3.0.1",
     "csv-parse": "^5.3.5",
     "csv-stringify": "^6.3.0",
     "jsforce": "^2.0.0-beta.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6338,6 +6338,7 @@ __metadata:
     "@types/uuid": ^9.0.1
     async-retry: ^1.3.3
     axios: ^1.6.0
+    base64url: ^3.0.1
     concurrently: ^8.2.2
     csv-parse: ^5.3.5
     csv-stringify: ^6.3.0


### PR DESCRIPTION
Reason: for developers using http clients (like axios) this may result in double-url-encoding which will lead to 500s.