### PR TITLE
chore: cascade delete sync configs

### DIFF
--- a/packages/db/prisma/migrations/20231201002644_cascade_delete_sync_configs/migration.sql
+++ b/packages/db/prisma/migrations/20231201002644_cascade_delete_sync_configs/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "sync_configs" DROP CONSTRAINT "sync_configs_destination_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "sync_configs" DROP CONSTRAINT "sync_configs_provider_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "sync_configs" ADD CONSTRAINT "sync_configs_provider_id_fkey" FOREIGN KEY ("provider_id") REFERENCES "providers"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sync_configs" ADD CONSTRAINT "sync_configs_destination_id_fkey" FOREIGN KEY ("destination_id") REFERENCES "destinations"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -97,9 +97,9 @@ model SyncConfig {
   id            String      @id @default(uuid())
   applicationId String      @map("application_id")
   providerId    String      @map("provider_id")
-  provider      Provider    @relation(fields: [providerId], references: [id])
+  provider      Provider    @relation(fields: [providerId], references: [id], onDelete: Cascade)
   destinationId String      @map("destination_id")
-  destination   Destination @relation(fields: [destinationId], references: [id])
+  destination   Destination @relation(fields: [destinationId], references: [id], onDelete: Cascade)
   config        Json
   createdAt     DateTime    @default(now()) @map("created_at")
   updatedAt     DateTime    @updatedAt @map("updated_at")


### PR DESCRIPTION
This will make it so that the only thing blocking deleting applications (or anything) will be existing connections and/or syncs.