### PR TITLE
feat!: surface default and override sync strategies

### DIFF
--- a/apps/api/routes/mgmt/v2/sync/index.ts
+++ b/apps/api/routes/mgmt/v2/sync/index.ts
@@ -21,6 +21,7 @@ import type {
   TriggerSyncResponse,
 } from '@supaglue/schemas/v2/mgmt';
 import type { ObjectSyncDTO } from '@supaglue/types/sync';
+import { snakecaseKeys } from '@supaglue/utils/snakecase';
 import type { Request, Response } from 'express';
 import { Router } from 'express';
 
@@ -68,7 +69,7 @@ export default function init(app: Router) {
 
       const objectSyncs = results.filter((result) => result.type === 'object') as ObjectSyncDTO[];
 
-      const snakeCaseResults = results.map((result) => {
+      const snakecaseResults = results.map((result) => {
         const base = {
           id: result.id,
           connection_id: result.connectionId,
@@ -83,7 +84,9 @@ export default function init(app: Router) {
             type: 'object' as const,
             object_type: result.objectType,
             object: result.object,
-            related_sync_states: req.query?.customer_id ? generateRelatedObjectSyncStates(objectSyncs) : {},
+            related_sync_states: req.query?.customer_id
+              ? snakecaseKeys(generateRelatedObjectSyncStates(objectSyncs))
+              : {},
           };
         }
 
@@ -94,7 +97,7 @@ export default function init(app: Router) {
           related_sync_states: {}, // NOTE: not implementing for entity
         };
       });
-      return res.status(200).send({ next, previous, results: snakeCaseResults, total_count: totalCount });
+      return res.status(200).send({ next, previous, results: snakecaseResults, total_count: totalCount });
     }
   );
 

--- a/apps/mgmt-ui/src/components/syncs/SyncsListPanel.tsx
+++ b/apps/mgmt-ui/src/components/syncs/SyncsListPanel.tsx
@@ -1,6 +1,8 @@
 import { TabPanel } from '@/components/TabPanel';
+import { useSyncConfigs } from '@/hooks/useSyncConfigs';
 import { useSyncs } from '@/hooks/useSyncs';
 import type { SyncFilterParams } from '@/utils/filter';
+import type { SyncAndSyncConfigDTO } from '@supaglue/types/sync';
 import { useState } from 'react';
 import SyncsTable from '../logs/SyncsTable';
 
@@ -8,6 +10,16 @@ export default function SyncsListPanel() {
   const [currentCursor, setCurrentCursor] = useState<string | undefined>(undefined);
   const [filterParams, setFilterParams] = useState<SyncFilterParams[] | undefined>();
   const { syncs, isLoading, mutate } = useSyncs(currentCursor, filterParams);
+  const { syncConfigs, isLoading: isSyncConfigLoading } = useSyncConfigs();
+
+  // join syncs and syncConfigs
+  const syncsWithSyncConfig = (syncs?.results ?? []).map<SyncAndSyncConfigDTO>((sync: any) => {
+    const syncConfig = (syncConfigs ?? []).find((syncConfig) => syncConfig.id === sync.syncConfigId);
+    if (syncConfig) {
+      sync.syncConfig = syncConfig;
+    }
+    return sync;
+  });
 
   const handleNextPage = () => {
     if (syncs?.next) {
@@ -33,8 +45,8 @@ export default function SyncsListPanel() {
         handlePreviousPage={handlePreviousPage}
         handleFilters={handleFilters}
         rowCount={syncs?.totalCount ?? 0}
-        data={syncs?.results ?? []}
-        isLoading={isLoading}
+        data={syncsWithSyncConfig ?? []}
+        isLoading={isLoading || isSyncConfigLoading}
         mutate={mutate}
       />
     </TabPanel>

--- a/apps/mgmt-ui/src/components/syncs/syncConfig/SyncConfigListPanel.tsx
+++ b/apps/mgmt-ui/src/components/syncs/syncConfig/SyncConfigListPanel.tsx
@@ -9,6 +9,7 @@ import { useProviders } from '@/hooks/useProviders';
 import { toGetSyncConfigsResponse, useSyncConfigs } from '@/hooks/useSyncConfigs';
 import type { SupaglueProps } from '@/pages/applications/[applicationId]';
 import getIcon from '@/utils/companyToIcon';
+import { millisToHumanReadable } from '@/utils/datetime';
 import { getDestinationName } from '@/utils/destination';
 import providerToIcon from '@/utils/providerToIcon';
 import { PeopleAltOutlined } from '@mui/icons-material';
@@ -106,7 +107,11 @@ export default function SyncConfigListPanel(props: SupaglueProps) {
       headerName: 'Frequency',
       width: 100,
       renderCell: (params) => {
-        return <span className="whitespace-normal">{params.row.frequency}</span>;
+        return (
+          <span className="whitespace-normal" title={params.row.objects}>
+            {params.row.frequency}
+          </span>
+        );
       },
     },
     {
@@ -114,7 +119,11 @@ export default function SyncConfigListPanel(props: SupaglueProps) {
       headerName: 'Objects',
       width: 150,
       renderCell: (params) => {
-        return <span className="whitespace-normal">{params.row.objects}</span>;
+        return (
+          <span className="whitespace-normal" title={params.row.objects}>
+            {params.row.objects}
+          </span>
+        );
       },
     },
     {
@@ -210,41 +219,6 @@ export default function SyncConfigListPanel(props: SupaglueProps) {
       />
     </div>
   );
-}
-
-function millisToHumanReadable(millis: number): string {
-  const seconds = Math.floor((millis / 1000) % 60);
-  const minutes = Math.floor((millis / (1000 * 60)) % 60);
-  const hours = Math.floor((millis / (1000 * 60 * 60)) % 24);
-  const days = Math.floor(millis / (1000 * 60 * 60 * 24));
-
-  let humanReadable = '';
-
-  // Add days if any
-  if (days > 0) {
-    humanReadable += `${days} day${days > 1 ? 's' : ''}, `;
-  }
-
-  // Add hours if any
-  if (hours > 0) {
-    humanReadable += `${hours} hour${hours > 1 ? 's' : ''}, `;
-  }
-
-  // Add minutes if any
-  if (minutes > 0) {
-    humanReadable += `${minutes} minute${minutes > 1 ? 's' : ''}, `;
-  }
-
-  // Add seconds
-  if (seconds > 0) {
-    humanReadable += `${seconds} second${seconds > 1 || seconds === 0 ? 's' : ''}`;
-  }
-
-  if (humanReadable.endsWith(', ')) {
-    humanReadable = humanReadable.slice(0, -2);
-  }
-
-  return humanReadable;
 }
 
 function getObjectsString(syncConfig: SyncConfigDTO): string {

--- a/apps/mgmt-ui/src/utils/datetime.ts
+++ b/apps/mgmt-ui/src/utils/datetime.ts
@@ -23,3 +23,38 @@ export const relativeDateFromISOString = (timestamp?: string | null): string => 
   }
   return description || '-';
 };
+
+export function millisToHumanReadable(millis: number): string {
+  const seconds = Math.floor((millis / 1000) % 60);
+  const minutes = Math.floor((millis / (1000 * 60)) % 60);
+  const hours = Math.floor((millis / (1000 * 60 * 60)) % 24);
+  const days = Math.floor(millis / (1000 * 60 * 60 * 24));
+
+  let humanReadable = '';
+
+  // Add days if any
+  if (days > 0) {
+    humanReadable += `${days} day${days > 1 ? 's' : ''}, `;
+  }
+
+  // Add hours if any
+  if (hours > 0) {
+    humanReadable += `${hours} hour${hours > 1 ? 's' : ''}, `;
+  }
+
+  // Add minutes if any
+  if (minutes > 0) {
+    humanReadable += `${minutes} minute${minutes > 1 ? 's' : ''}, `;
+  }
+
+  // Add seconds
+  if (seconds > 0) {
+    humanReadable += `${seconds} second${seconds > 1 || seconds === 0 ? 's' : ''}`;
+  }
+
+  if (humanReadable.endsWith(', ')) {
+    humanReadable = humanReadable.slice(0, -2);
+  }
+
+  return humanReadable;
+}

--- a/apps/mgmt-ui/src/utils/syncConfig.ts
+++ b/apps/mgmt-ui/src/utils/syncConfig.ts
@@ -1,0 +1,46 @@
+import type { SyncConfig, SyncStrategyConfigWithHubspotAssociationsToFetch } from '@supaglue/types';
+import type { Sync } from '@supaglue/types/sync';
+
+export function getFriendlySyncStrategyType(syncStrategyType: string) {
+  if (syncStrategyType === 'full then incremental') {
+    return 'incremental';
+  } else if (syncStrategyType === 'full only') {
+    return 'full';
+  }
+
+  return 'incremental';
+}
+
+// @todo: move this to a shared package. encapsulate supaglue concepts into classes
+export function getSyncStrategyConfigAndHubspotAssociationsToFetch(
+  syncConfig: SyncConfig,
+  sync: Sync
+): SyncStrategyConfigWithHubspotAssociationsToFetch {
+  // @deprecated
+  if (sync.type === 'entity') {
+    return syncConfig.config.defaultConfig;
+  }
+
+  if (sync.objectType === 'common') {
+    const commonObjectConfig = syncConfig.config.commonObjects?.find((object) => object.object === sync.object);
+    return {
+      ...(commonObjectConfig?.syncStrategyOverride ?? syncConfig.config.defaultConfig),
+      associationsToFetch: commonObjectConfig?.associationsToFetch,
+    };
+  }
+  if (sync.objectType === 'standard') {
+    const standardObjectConfig = syncConfig.config.standardObjects?.find((object) => object.object === sync.object);
+    return {
+      ...(standardObjectConfig?.syncStrategyOverride ?? syncConfig.config.defaultConfig),
+      associationsToFetch: standardObjectConfig?.associationsToFetch,
+    };
+  }
+  if (sync.objectType === 'custom') {
+    const customObjectConfig = syncConfig.config.customObjects?.find((object) => object.object === sync.object);
+    return {
+      ...(customObjectConfig?.syncStrategyOverride ?? syncConfig.config.defaultConfig),
+      associationsToFetch: customObjectConfig?.associationsToFetch,
+    };
+  }
+  return syncConfig.config.defaultConfig;
+}

--- a/packages/core/mappers/sync.ts
+++ b/packages/core/mappers/sync.ts
@@ -1,4 +1,4 @@
-import type { Connection as ConnectionModel, Sync as SyncModel } from '@supaglue/db';
+import type { Connection as ConnectionModel, Sync as SyncModel, SyncConfig as SyncConfigModel } from '@supaglue/db';
 import type { ObjectType, Sync, SyncDTO, SyncState, SyncStrategyType } from '@supaglue/types/sync';
 import { parseCustomerIdPk } from '../lib';
 
@@ -48,7 +48,9 @@ export const fromSyncModel = (model: SyncModel): Sync => {
   throw new Error('incorrectly configured sync');
 };
 
-export const fromSyncModelWithConnection = (model: SyncModel & { connection: ConnectionModel }): SyncDTO => {
+export const fromSyncModelWithConnectionAndSyncConfig = (
+  model: SyncModel & { connection: ConnectionModel; syncConfig: SyncConfigModel }
+): SyncDTO => {
   const sync = fromSyncModel(model);
 
   const { connection } = model;

--- a/packages/core/services/sync_service.ts
+++ b/packages/core/services/sync_service.ts
@@ -5,7 +5,7 @@ import type { ConnectionService } from '.';
 import { NotFoundError } from '../errors';
 import { getCustomerIdPk } from '../lib';
 import { getPaginationParams, getPaginationResult } from '../lib/pagination';
-import { fromSyncModel, fromSyncModelWithConnection } from '../mappers/sync';
+import { fromSyncModel, fromSyncModelWithConnectionAndSyncConfig } from '../mappers/sync';
 
 export class SyncService {
   #prisma: PrismaClient;
@@ -34,6 +34,7 @@ export class SyncService {
       where: whereClause,
       include: {
         connection: true,
+        syncConfig: true,
       },
       orderBy: [
         {
@@ -57,7 +58,7 @@ export class SyncService {
 
     const [models, count] = await Promise.all([modelsPromise, countPromise]);
 
-    const results = models.map(fromSyncModelWithConnection);
+    const results = models.map(fromSyncModelWithConnectionAndSyncConfig);
 
     return {
       ...getPaginationResult<string>(page_size, cursor, results),

--- a/packages/sync-workflows/services/sync_service.ts
+++ b/packages/sync-workflows/services/sync_service.ts
@@ -498,6 +498,7 @@ WHERE s.connection_id = '${connection.id}'`);
     });
   }
 
+  // @todo: move this to a shared package. encapsulate supaglue concepts into classes
   #getSyncStrategyConfig(syncConfig: SyncConfig, sync: Sync): SyncStrategyConfig {
     if (sync.type === 'entity') {
       return syncConfig.config.defaultConfig;

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -34,12 +34,12 @@ export type ProviderName =
 export type CategoryOfProviderName<T extends ProviderName> = T extends CRMProviderName
   ? CRMProviderCategory
   : T extends EngagementProviderName
-  ? EngagementProviderCategory
-  : T extends EnrichmentProviderName
-  ? EnrichmentProviderCategory
-  : T extends MarketingAutomationProviderName
-  ? MarketingAutomationProviderCategory
-  : 'no_category';
+    ? EngagementProviderCategory
+    : T extends EnrichmentProviderName
+      ? EnrichmentProviderCategory
+      : T extends MarketingAutomationProviderName
+        ? MarketingAutomationProviderCategory
+        : 'no_category';
 
 export type CommonObjectForCategory<T extends ProviderCategory> = {
   crm: CRMCommonObjectType;

--- a/packages/types/snakecased_keys.ts
+++ b/packages/types/snakecased_keys.ts
@@ -6,6 +6,6 @@ export type SnakecasedKeys<T> = {
   [K in keyof T as CamelToSnake<K & string>]: T[K] extends Record<string, unknown> | null | undefined
     ? SnakecasedKeys<T[K]>
     : T[K] extends Array<infer U>
-    ? Array<U extends Record<string, unknown> ? SnakecasedKeys<U> : U>
-    : T[K];
+      ? Array<U extends Record<string, unknown> ? SnakecasedKeys<U> : U>
+      : T[K];
 };

--- a/packages/types/sync.ts
+++ b/packages/types/sync.ts
@@ -1,4 +1,6 @@
 import type { PaginationInternalParams } from './common';
+import type { SnakecasedKeys } from './snakecased_keys';
+import type { SyncConfig } from './sync_config';
 
 export type ObjectType = 'common' | 'standard' | 'custom';
 
@@ -47,6 +49,7 @@ export type EntitySync = FullThenIncrementalEntitySync | FullOnlyEntitySync;
 export type FullThenIncrementalSync = FullThenIncrementalObjectSync | FullThenIncrementalEntitySync;
 export type FullOnlySync = FullOnlyObjectSync | FullOnlyEntitySync;
 export type Sync = ObjectSync | EntitySync;
+export type SnakecasedSync = SnakecasedKeys<Sync>;
 
 export type ObjectSyncDTO = Sync & {
   type: 'object';
@@ -59,6 +62,14 @@ export type SyncDTO = Sync & {
   // External Id
   customerId: string;
   providerName: string;
+};
+
+export type SyncAndSyncConfigDTO = Sync & {
+  // External Id
+  customerId: string;
+  providerName: string;
+
+  syncConfig: SyncConfig; // Note: using SyncConfig b/c it's not easy to pass around the resolved providerName and destinationName. @todo: encapsulate Supaglue concepts into classes
 };
 
 export type FullOnlySyncStateCreatedPhase = {

--- a/packages/types/sync_config.ts
+++ b/packages/types/sync_config.ts
@@ -1,4 +1,5 @@
 import type { ProviderName } from './';
+import type { SnakecasedKeys } from './snakecased_keys';
 import type { SyncStrategyType } from './sync';
 import type { CommonObjectConfig, CustomObjectConfig, StandardObjectConfig } from './sync_object_config';
 
@@ -43,3 +44,19 @@ export type SyncStrategyConfig = {
   // default: true
   autoStartOnConnection?: boolean;
 };
+
+export type SyncStrategyConfigWithHubspotAssociationsToFetch = {
+  periodMs: number;
+  strategy: SyncStrategyType;
+  // Only applicable if strategy is set to incremental. If set, it will perform a full sync after N consecutive incremental syncs.
+  fullSyncEveryNIncrementals?: number;
+  // default: true
+  autoStartOnConnection?: boolean;
+
+  // If empty or unspecified, no additional associations will be fetched other than ones required for the common model or none for standard/custom objects
+  // Only relevant for Hubspot.
+  associationsToFetch?: string[];
+};
+
+export type SnakecasedSyncStrategyConfigWithHubspotAssociationsToFetch =
+  SnakecasedKeys<SyncStrategyConfigWithHubspotAssociationsToFetch>;


### PR DESCRIPTION

- surface frequency, period full, and strategy on sync page (respecting inheritance), associations to sync
- breaking change: snakecased `related_sync_states`
- removed entity names from syncs so there's more room

![Screenshot 2023-12-06 at 5 00 03 PM](https://github.com/supaglue-labs/supaglue/assets/471516/69f6573c-5ca8-4d6a-a19c-baa7de7042ff)


note: we should move to using classes for Supaglue's core concepts for better encapsulation (we have a lot of loose functions in different places)

## Test Plan

- tested locally

## Deployment instructions

[Add any special deployment instructions here]
