### PR TITLE
fix: stream error handling

### DIFF
--- a/packages/core/remotes/utils/paginator.ts
+++ b/packages/core/remotes/utils/paginator.ts
@@ -62,7 +62,7 @@ export async function paginator<T>(
           response = await pageFetcher(cursor);
         } catch (e: any) {
           if (e.problemType === 'SG_TERMINAL_TOO_MANY_REQUESTS_ERROR') {
-            passThrough.emit('error', e);
+            passThrough.destroy(e);
             return;
           }
           throw e;
@@ -72,13 +72,13 @@ export async function paginator<T>(
         cursor = getNextCursorFromPage(response);
 
         readable.pipe(passThrough, { end: index === lastIndex && !cursor });
-        readable.on('error', (err) => passThrough.emit('error', err));
+        readable.on('error', (err) => passThrough.destroy(err));
 
         await new Promise((resolve) => readable.on('end', resolve));
       } while (cursor);
     }
   })().catch((err) => {
-    passThrough.emit('error', err);
+    passThrough.destroy(err);
   });
 
   return passThrough;


### PR DESCRIPTION
Node documentation indicates that this is the correct way to indicate errors in a stream and not to use `.emit('error', ...)` as that is internal to streams.

I'm hoping this will fix some cases were we aren't getting errors handled by the `handleErr` function in the provider.